### PR TITLE
CIAPP-427 Add user control to enable and disable instrumentation in code

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		E13D0BE82546FAE100C37D56 /* DatadogExporter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = E13D0BE62546FAE100C37D56 /* DatadogExporter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		E13D0BEA2546FAEE00C37D56 /* DatadogExporter in Frameworks */ = {isa = PBXBuildFile; productRef = E13D0BE92546FAEE00C37D56 /* DatadogExporter */; };
 		E13D0BEB2546FAEE00C37D56 /* DatadogExporter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = E13D0BE92546FAEE00C37D56 /* DatadogExporter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		E158E2DC25471DA000DBCD6C /* DDInstrumentationControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E158E2DB25471DA000DBCD6C /* DDInstrumentationControl.swift */; };
 		E1798CC62524B9BD008DEBB9 /* DDTracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1798CC52524B9BD008DEBB9 /* DDTracer.swift */; };
 		E1798CCC2524C21C008DEBB9 /* NetworkAutoInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1798CCB2524C21C008DEBB9 /* NetworkAutoInstrumentation.swift */; };
 		E1798CD22524C256008DEBB9 /* MethodSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1798CD02524C255008DEBB9 /* MethodSwizzler.swift */; };
@@ -91,6 +92,7 @@
 		E126DD2C253F366200700A40 /* StdoutCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StdoutCapture.swift; sourceTree = "<group>"; };
 		E126DD2E253F367600700A40 /* StderrCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StderrCapture.swift; sourceTree = "<group>"; };
 		E13D0BC92546E29C00C37D56 /* SignalUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalUtils.swift; sourceTree = "<group>"; };
+		E158E2DB25471DA000DBCD6C /* DDInstrumentationControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDInstrumentationControl.swift; sourceTree = "<group>"; };
 		E160A11125275CC1003121A5 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		E160A114252B3A6B003121A5 /* ObjcLoadHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjcLoadHandler.h; sourceTree = "<group>"; };
 		E1798CC52524B9BD008DEBB9 /* DDTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracer.swift; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 				E126DD27253F355F00700A40 /* OutputCapture */,
 				E116D7D925248C280022779D /* Utils */,
 				E1ABA07325231F4700ED8AEF /* DDEnvironmentValues.swift */,
+				E158E2DB25471DA000DBCD6C /* DDInstrumentationControl.swift */,
 				E1ABA07125231F4700ED8AEF /* DDTags.swift */,
 				E1ABA08A252341EA00ED8AEF /* DDTestMonitor.swift */,
 				E1ABA07025231F4700ED8AEF /* DDTestObserver.swift */,
@@ -473,6 +476,7 @@
 				E1ABA07725231F4700ED8AEF /* DDEnvironmentValues.swift in Sources */,
 				E1ABA06D25231F3200ED8AEF /* ObjcLoadHandler.m in Sources */,
 				E1798CD32524C256008DEBB9 /* URLSessionSwizzler.swift in Sources */,
+				E158E2DC25471DA000DBCD6C /* DDInstrumentationControl.swift in Sources */,
 				E1FB4842253891CE0083B263 /* SimpleSpanData.swift in Sources */,
 				E1ABA07625231F4700ED8AEF /* FrameworkLoadHandler.swift in Sources */,
 				E1ABA07525231F4700ED8AEF /* DDTags.swift in Sources */,

--- a/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
+++ b/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
@@ -15,6 +15,7 @@ internal struct DDEnvironmentValues {
 
     /// Instrumentation configuration values
     let disableNetworkInstrumentation: Bool
+    let disableHeadersInjection: Bool
     let disableStdoutInstrumentation: Bool
     let disableStderrInstrumentation: Bool
 
@@ -50,6 +51,9 @@ internal struct DDEnvironmentValues {
         /// Instrumentation configuration values
         let envNetwork = DDEnvironmentValues.getEnvVariable("DD_DISABLE_NETWORK_INSTRUMENTATION") as NSString?
         disableNetworkInstrumentation = envNetwork?.boolValue ?? false
+
+        let envHeaders = DDEnvironmentValues.getEnvVariable("DD_DISABLE_HEADERS_INJECTION") as NSString?
+        disableHeadersInjection = envHeaders?.boolValue ?? false
 
         let envStdout = DDEnvironmentValues.getEnvVariable("DD_DISABLE_STDOUT_INSTRUMENTATION") as NSString?
         disableStdoutInstrumentation = envStdout?.boolValue ?? false

--- a/Sources/DatadogSDKTesting/DDInstrumentationControl.swift
+++ b/Sources/DatadogSDKTesting/DDInstrumentationControl.swift
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+@objc public class DDInstrumentationControl: NSObject {
+    @objc public static func startInjectingHeaders() {
+        DDTestMonitor.instance?.injectHeaders = true
+    }
+
+    @objc public static func stopInjectingHeaders() {
+        DDTestMonitor.instance?.injectHeaders = false
+    }
+
+    @objc public static func startStdoutCapture() {
+        DDTestMonitor.instance?.startStdoutCapture()
+    }
+
+    @objc public static func stopStdoutCapture() {
+        DDTestMonitor.instance?.stopStdoutCapture()
+    }
+
+    @objc public static func startStderrCapture() {
+        DDTestMonitor.instance?.startStderrCapture()
+    }
+
+    @objc public static func stopStderrCapture() {
+        DDTestMonitor.instance?.stopStderrCapture()
+    }
+}

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -13,6 +13,7 @@ internal class DDTestMonitor {
     var testObserver: DDTestObserver
     var networkInstrumentation: NetworkAutoInstrumentation?
     var stderrCapturer: StderrCapture
+    var injectHeaders: Bool = false
 
     init() {
         tracer = DDTracer()
@@ -24,17 +25,42 @@ internal class DDTestMonitor {
         testObserver.startObserving()
         if !tracer.env.disableNetworkInstrumentation {
             startNetworkAutoInstrumentation()
+            if !tracer.env.disableHeadersInjection {
+                injectHeaders = true
+            }
         }
         if !tracer.env.disableStdoutInstrumentation {
-            StdoutCapture.startCapturing(tracer: tracer)
+            startStdoutCapture()
         }
         if !tracer.env.disableStderrInstrumentation {
-            stderrCapturer.startCapturing(tracer: tracer)
+            startStderrCapture()
         }
     }
 
     func startNetworkAutoInstrumentation() {
         let urlFilter = URLFilter(excludedURLs: tracer.endpointURLs())
         networkInstrumentation = NetworkAutoInstrumentation(urlFilter: urlFilter)
+    }
+
+    func startHeaderInjection() {
+        injectHeaders = true
+    }
+
+    func stopHeaderInjection() {
+        injectHeaders = false
+    }
+
+    func startStdoutCapture() {
+        StdoutCapture.startCapturing(tracer: tracer)
+    }
+    func stopStdoutCapture() {
+        StdoutCapture.stopCapturing()
+    }
+
+    func startStderrCapture() {
+        stderrCapturer.startCapturing(tracer: tracer)
+    }
+    func stopStderrCapture() {
+        stderrCapturer.stopCapturing()
     }
 }

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -21,7 +21,7 @@ internal class DDTracer {
     let datadogExporter: DatadogExporter
 
     init() {
-        tracerSdk = OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: "hq.datadog.testing", instrumentationVersion: "0.1.0") as! TracerSdk
+        tracerSdk = OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: "hq.datadog.testing", instrumentationVersion: "0.2.0") as! TracerSdk
 
         let exporterConfiguration = ExporterConfiguration(
             serviceName: env.ddService ?? ProcessInfo.processInfo.processName,

--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/NetworkAutoInstrumentation.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/NetworkAutoInstrumentation.swift
@@ -32,6 +32,9 @@ internal class NetworkAutoInstrumentation {
     }
 
     static func canInjectHeaders(to request: URLRequest) -> Bool {
+        guard DDTestMonitor.instance?.injectHeaders ?? false else {
+            return false
+        }
         let containsHeaders: Bool
         containsHeaders = DDHeaders.allCases.contains { headerKey -> Bool in
             request.value(forHTTPHeaderField: headerKey.rawValue) != nil

--- a/Tests/DatadogSDKTesting/OutputCapture/StderrCaptureTests.swift
+++ b/Tests/DatadogSDKTesting/OutputCapture/StderrCaptureTests.swift
@@ -55,20 +55,4 @@ class StderrCaptureTests: XCTestCase {
         let timeToCheck = date.addingTimeInterval(0.1).timeIntervalSince1970
         XCTAssertEqual(spanData.timedEvents.first?.epochNanos,  UInt64(timeToCheck * 1_000_000_000))
     }
-
-//    func testWhenSomeCharactersAreWittenToStdoutWithoutNewLines_charactersAreCapturedButNotConvertedToEvents () {
-//        let tracer = DDTracer()
-//        let stringToCapture = "This should  not be captured"
-//
-//        StdoutCapture.startCapturing(tracer: tracer)
-//        let span = tracer.startSpan(name: "Unnamed", attributes: [:])
-//        fputs(stringToCapture, stdout)
-//        let spanData = span.toSpanData()
-//        span.end()
-//        StdoutCapture.stopCapturing()
-//
-//        XCTAssertFalse(StdoutCapture.stdoutBuffer.isEmpty)
-//        XCTAssertEqual(StdoutCapture.stdoutBuffer, stringToCapture)
-//        XCTAssertEqual(spanData.timedEvents.count, 0)
-//    }
 }

--- a/Tests/DatadogSDKTesting/OutputCapture/StdoutCaptureTests.swift
+++ b/Tests/DatadogSDKTesting/OutputCapture/StdoutCaptureTests.swift
@@ -24,7 +24,7 @@ class StdoutCaptureTests: XCTestCase {
         print(stringToCapture)
         span.end()
         let spanData = span.toSpanData()
-        StdoutCapture.stopCapturing()
+        DDInstrumentationControl.stopStdoutCapture()
 
         XCTAssertTrue(StdoutCapture.stdoutBuffer.isEmpty)
         XCTAssertEqual(spanData.timedEvents.count, 1)
@@ -35,8 +35,8 @@ class StdoutCaptureTests: XCTestCase {
         let tracer = DDTracer()
         let stringToCapture = "This should be captured"
 
-        StdoutCapture.startCapturing(tracer: tracer)
-        StdoutCapture.stopCapturing()
+        DDInstrumentationControl.startStdoutCapture()
+        DDInstrumentationControl.stopStdoutCapture()
         let span = tracer.startSpan(name: "Unnamed", attributes: [:])
         print(stringToCapture)
         span.end()
@@ -55,7 +55,7 @@ class StdoutCaptureTests: XCTestCase {
         fputs(stringToCapture, stdout)
         let spanData = span.toSpanData()
         span.end()
-        StdoutCapture.stopCapturing()
+        DDInstrumentationControl.stopStdoutCapture()
 
         XCTAssertFalse(StdoutCapture.stdoutBuffer.isEmpty)
         XCTAssertEqual(StdoutCapture.stdoutBuffer, stringToCapture)


### PR DESCRIPTION
Added public class `DDInstrumentationControl` to enable and disable dinamically stdout and stderr capturing, and header injection.
It can be used to deactivate temporarily some instrumentation inside some of the tests when instrumentation can be a problem in a specific test. **User must be very careful to keep previous state after test ends.**
Added also environment variable to disable header injection gloablly: `DD_DISABLE_HEADERS_INJECTION`