### PR TITLE
CIAPP-530 Support crash reporting in apps under UITesting

### DIFF
--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -5,24 +5,46 @@
  */
 
 import DatadogExporter
+#if canImport(Cocoa)
+import Cocoa
+let launchNotificationName = NSApplication.didFinishLaunchingNotification
+#elseif canImport(UIKit)
+import UIKit
+let launchNotificationName = UIApplication.didFinishLaunchingNotification
+#endif
 
 internal class DDTestMonitor {
     static var instance: DDTestMonitor?
 
     let tracer: DDTracer
-    var testObserver: DDTestObserver
+    var testObserver: DDTestObserver?
     var networkInstrumentation: NetworkAutoInstrumentation?
     var stderrCapturer: StderrCapture
     var injectHeaders: Bool = false
+    var notificationObserver: NSObjectProtocol?
 
     init() {
         tracer = DDTracer()
-        testObserver = DDTestObserver(tracer: tracer)
         stderrCapturer = StderrCapture()
+        ///If the library is being loaded in a binary launched from a UITest, dont start test observing
+        if !tracer.isBinaryUnderUITesting {
+            testObserver = DDTestObserver(tracer: tracer)
+        }  else {
+            notificationObserver = NotificationCenter.default.addObserver(
+                forName: launchNotificationName,
+                object: nil, queue: nil) { _ in
+                /// As crash reporter is initialized in testBundleWillStart() method, we initialize it here
+                /// because dont have test observer
+                DDCrashes.install()
+                let launchedSpan = self.tracer.createSpanFromContext(spanContext: self.tracer.launchSpanContext!)
+                let simpleSpan = SimpleSpanData(spanData: launchedSpan.toSpanData())
+                DDCrashes.setCustomData(customData: SimpleSpanSerializer.serializeSpan(simpleSpan: simpleSpan))
+            }
+        }
     }
 
     func startInstrumenting() {
-        testObserver.startObserving()
+        testObserver?.startObserving()
         if !tracer.env.disableNetworkInstrumentation {
             startNetworkAutoInstrumentation()
             if !tracer.env.disableHeadersInjection {

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -17,10 +17,10 @@ internal class DDTestObserver: NSObject, XCTestObservation {
     let testNameRegex = try? NSRegularExpression(pattern: "([\\w]+) ([\\w]+)", options: .caseInsensitive)
     let supportsSkipping = NSClassFromString("XCTSkippedTestContext") != nil
     var currentBundleName = ""
-    let isUIApplication = Bundle.main.bundleIdentifier?.hasSuffix("xctrunner") ?? false
+    let isUITestRunner = Bundle.main.bundleIdentifier?.hasSuffix("xctrunner") ?? false
 
     init(tracer: DDTracer) {
-        if isUIApplication {
+        if isUITestRunner {
             XCUIApplication.swizzleMethods
         }
         self.tracer = tracer

--- a/Sources/DatadogSDKTesting/OutputCapture/StderrCapture.swift
+++ b/Sources/DatadogSDKTesting/OutputCapture/StderrCapture.swift
@@ -51,7 +51,7 @@ class StderrCapture {
     func stderrMessage(tracer: DDTracer, string: String) {
         guard tracer.activeTestSpan != nil ||
                 tracer.tracerSdk.currentSpan != nil ||
-                tracer.launchSpanContext != nil else {
+                tracer.isBinaryUnderUITesting else {
             return
         }
 


### PR DESCRIPTION
When the framework is loaded in the tested applicatio, install crash handler in didFinishLaunchingNotification, and create the crashed span as a child of the test span. We create it as a child span because the test span has already been created and sent to the backend by the testRunner, and we should not send the same span twice