### PR TITLE
CIAPP-570 - Adjust network instrumentation for dd-sdk usage

### DIFF
--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/DDNetworkInstrumentation.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/DDNetworkInstrumentation.swift
@@ -103,7 +103,8 @@ class DDNetworkInstrumentation {
             let sessionTaskId = UUID().uuidString
             
             let block: @convention(block) (URLSession, AnyObject) -> URLSessionTask = { session, argument in
-                if let url = argument as? URL {
+                if let url = argument as? URL,
+                   self.injectHeaders == true {
                     let request = URLRequest(url: url)
                     if selector == #selector(URLSession.dataTask(with:) as (URLSession) -> (URL) -> URLSessionDataTask) {
                         return session.dataTask(with: request)
@@ -179,7 +180,8 @@ class DDNetworkInstrumentation {
             let sessionTaskId = UUID().uuidString
             
             let block: @convention(block) (URLSession, AnyObject, @escaping (Any?, URLResponse?, Error?) -> Void) -> URLSessionTask = { session, argument, completion in
-                if let url = argument as? URL {
+                if let url = argument as? URL,
+                   self.injectHeaders == true {
                     let request = URLRequest(url: url)
                     
                     if selector == #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask) {


### PR DESCRIPTION
We don't need to convert requests made with `URL` internally to requests using `URLRequest` if we are not injecting headers.
`dd-sdk-ios` injects automatically headers in requests made with URLRequests, and as we were modifying them it was breaking one of their tests that didn't expect the headers. This PR fixes that.
We cannot avoid converting the calls if we need to inject headers though