### PR TITLE
CIAPP-509 Capture RUM SDK instrumentation

### DIFF
--- a/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
+++ b/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
@@ -21,6 +21,7 @@ internal struct DDEnvironmentValues {
     let disableStderrInstrumentation: Bool
     let extraHTTPHeaders: Set<String>?
     let excludedURLS: Set<String>?
+    let disableDDSDKIOSIntegration: Bool
 
     /// Device Information
     let platformName: String
@@ -84,6 +85,10 @@ internal struct DDEnvironmentValues {
 
         let envStderr = DDEnvironmentValues.getEnvVariable("DD_DISABLE_STDERR_INSTRUMENTATION") as NSString?
         disableStderrInstrumentation = envStderr?.boolValue ?? false
+
+        /// Instrumentation configuration values
+        let envDisableDDSDKIOSIntegration = DDEnvironmentValues.getEnvVariable("DD_DISABLE_SDKIOS_INTEGRATION") as NSString?
+        disableDDSDKIOSIntegration = envDisableDDSDKIOSIntegration?.boolValue ?? false
 
         /// Device Information
         platformName = PlatformUtils.getRunningPlatform()

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -67,6 +67,9 @@ internal class DDTestObserver: NSObject, XCTestObservation {
         ]
 
         let testSpan = tracer.startSpan(name: testCase.name, attributes: attributes)
+        if !tracer.env.disableDDSDKIOSIntegration {
+            tracer.addPropagationsHeadersToEnvironment()
+        }
         tracer.env.addTagsToSpan(span: testSpan)
 
         let simpleSpan = SimpleSpanData(spanData: testSpan.toSpanData())

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -206,6 +206,13 @@ internal class DDTracer {
         spanProcessor.forceFlush()
     }
 
+    func addPropagationsHeadersToEnvironment() {
+        let headers = tracePropagationHTTPHeaders()
+        headers.forEach {
+            setenv($0.key, $0.value, 1)
+        }
+    }
+
     func tracePropagationHTTPHeaders() -> [String: String] {
         var headers = [String: String]()
 
@@ -220,8 +227,8 @@ internal class DDTracer {
         }
         tracerSdk.textFormat.inject(spanContext: currentSpan.context, carrier: &headers, setter: HeaderSetter())
 
-        headers[DDHeaders.traceIDField.rawValue] = String(format: "%016llx", currentSpan.context.traceId.rawLowerLong)
-        headers[DDHeaders.parentSpanIDField.rawValue] = currentSpan.context.spanId.hexString
+        headers[DDHeaders.traceIDField.rawValue] = String(currentSpan.context.traceId.rawLowerLong)
+        headers[DDHeaders.parentSpanIDField.rawValue] = String(currentSpan.context.spanId.rawValue)
 
         return headers
     }

--- a/Tests/DatadogSDKTesting/DDTracerTests.swift
+++ b/Tests/DatadogSDKTesting/DDTracerTests.swift
@@ -53,8 +53,8 @@ class DDTracerTests: XCTestCase {
         let spanData = span.toSpanData()
         let headers = tracer.tracePropagationHTTPHeaders()
 
-        XCTAssertEqual(headers[DDHeaders.traceIDField.rawValue], String(format: "%016llx", spanData.traceId.rawLowerLong))
-        XCTAssertEqual(headers[DDHeaders.parentSpanIDField.rawValue], spanData.spanId.hexString)
+        XCTAssertEqual(headers[DDHeaders.traceIDField.rawValue], String(spanData.traceId.rawLowerLong))
+        XCTAssertEqual(headers[DDHeaders.parentSpanIDField.rawValue], String(spanData.spanId.rawValue))
 
         span.end()
     }


### PR DESCRIPTION
This PR works in concordance with [this PR in dd-sdk-ios](https://github.com/DataDog/dd-sdk-ios/pull/329). 
With both PR ready, is now possible to add all logs and traces from `dd-sdk-ios` to each test when Datadog tracer is running.

These changes basically Inject dd context to environment variables for every test and application launch, so they can be read from the `dd-sdk-ios` tracer and use them as the parent context of logs and spans.
Added also an environment variable to disable the functionality