### PR TITLE
Update code to be synchronized with newer opentelemetry-swift version

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -1589,8 +1589,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
+				kind = revision;
+				revision = 8f55c3d534eb83b9352ed7bf64f88e34d1cabc49;
 			};
 		};
 		E1FB4839253891650083B263 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/Sources/DatadogSDKTesting/Crashes/SimpleSpanData.swift
+++ b/Sources/DatadogSDKTesting/Crashes/SimpleSpanData.swift
@@ -15,7 +15,7 @@ internal struct SimpleSpanData: Codable, Equatable {
     var traceIdLo: UInt64
     var spanId: UInt64
     var name: String
-    var startEpochNanos: UInt64
+    var startTime: Date
     var stringAttributes = [String: String]()
 
     init(spanData: SpanData) {
@@ -23,16 +23,16 @@ internal struct SimpleSpanData: Codable, Equatable {
         self.traceIdLo = spanData.traceId.rawLowerLong
         self.spanId = spanData.spanId.rawValue
         self.name = spanData.name
-        self.startEpochNanos = spanData.startEpochNanos
+        self.startTime = spanData.startTime
         self.stringAttributes = spanData.attributes.mapValues { $0.description }
     }
 
-    internal init(traceIdHi: UInt64, traceIdLo: UInt64, spanId: UInt64, name: String, startEpochNanos: UInt64, stringAttributes: [String: String] = [String: String]()) {
+    internal init(traceIdHi: UInt64, traceIdLo: UInt64, spanId: UInt64, name: String, startTime: Date, stringAttributes: [String: String] = [String: String]()) {
         self.traceIdHi = traceIdHi
         self.traceIdLo = traceIdLo
         self.spanId = spanId
         self.name = name
-        self.startEpochNanos = startEpochNanos
+        self.startTime = startTime
         self.stringAttributes = stringAttributes
     }
 }

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -84,11 +84,13 @@ internal class DDTestObserver: NSObject, XCTestObservation {
         var status: String
         if supportsSkipping, testCase.testRun?.hasBeenSkipped == true {
             status = DDTestTags.statusSkip
+            activeTest.status = .ok
         } else if testCase.testRun?.hasSucceeded ?? false {
             status = DDTestTags.statusPass
+            activeTest.status = .ok
         } else {
             status = DDTestTags.statusFail
-            activeTest.status = .internalError
+            activeTest.status = .error
         }
 
         activeTest.setAttribute(key: DDTestTags.testStatus, value: status)

--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/DDNetworkActivityLogger.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/DDNetworkActivityLogger.swift
@@ -156,24 +156,8 @@ class DDNetworkActivityLogger {
         switch code {
             case 200...399:
                 return Status.ok
-            case 400:
-                return Status.invalidArgument
-            case 504:
-                return Status.deadlineExceeded
-            case 404:
-                return Status.notFound
-            case 403:
-                return Status.permissionDenied
-            case 401:
-                return Status.unauthenticated
-            case 429:
-                return Status.resourceExhausted
-            case 501:
-                return Status.unimplemented
-            case 503:
-                return Status.unavailable
             default:
-                return Status.unknown
+                return Status.error
         }
     }
 

--- a/Tests/DatadogSDKTesting/Crashes/SimpleSpanSerializerTests.swift
+++ b/Tests/DatadogSDKTesting/Crashes/SimpleSpanSerializerTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 internal class SimpleSpanSerializerTests: XCTestCase {
     func testGivenASimpleSpan_ItSerializesAndDeserializesWithoutChanges() throws {
-        let original = SimpleSpanData(traceIdHi: 1, traceIdLo: 2, spanId: 3, name: "name", startEpochNanos: 33, stringAttributes: [:])
+        let original = SimpleSpanData(traceIdHi: 1, traceIdLo: 2, spanId: 3, name: "name", startTime: Date(timeIntervalSinceReferenceDate: 33), stringAttributes: [:])
 
         let serialized = SimpleSpanSerializer.serializeSpan(simpleSpan: original)
         let deserialized = SimpleSpanSerializer.deserializeSpan(data: serialized)
@@ -20,7 +20,7 @@ internal class SimpleSpanSerializerTests: XCTestCase {
     }
 
     func testGivenASpanWithAttributes_ItSerializesAndDeserializes() throws {
-        let original = SimpleSpanData(traceIdHi: 1, traceIdLo: 2, spanId: 3, name: "name", startEpochNanos: 33, stringAttributes: ["key1": "value1", "key2": "value2"])
+        let original = SimpleSpanData(traceIdHi: 1, traceIdLo: 2, spanId: 3, name: "name", startTime: Date(timeIntervalSinceReferenceDate: 33), stringAttributes: ["key1": "value1", "key2": "value2"])
 
         let serialized = SimpleSpanSerializer.serializeSpan(simpleSpan: original)
         let deserialized = SimpleSpanSerializer.deserializeSpan(data: serialized)

--- a/Tests/DatadogSDKTesting/DDEnvironmentValuesTests.swift
+++ b/Tests/DatadogSDKTesting/DDEnvironmentValuesTests.swift
@@ -159,7 +159,7 @@ class DDEnvironmentValuesTests: XCTestCase {
                 spec[1].forEach {
                     XCTAssertEqual(spanData.attributes[$0.key]?.description, $0.value)
                     if spanData.attributes[$0.key]?.description != $0.value {
-                        print("\(spanData.attributes[$0.key]?.description) != \($0.value)")
+                        print("\(spanData.attributes[$0.key]!.description) != \($0.value)")
                     }
                 }
             }

--- a/Tests/DatadogSDKTesting/DDTestObserverTests.swift
+++ b/Tests/DatadogSDKTesting/DDTestObserverTests.swift
@@ -41,7 +41,7 @@ internal class DDTestObserverTests: XCTestCase {
 
         //let fingerprint = String((testBundle + testSuite + testName + deviceModel + deviceVersion).hash)
 
-        let span = testObserver.tracer.tracerSdk.currentSpan as! RecordEventsReadableSpan
+        let span = testObserver.tracer.tracerSdk.activeSpan as! RecordEventsReadableSpan
         let spanData = span.toSpanData()
 
         XCTAssertEqual(spanData.name, "-[DDTestObserverTests testWhenTestCaseWillStartIsCalled_testSpanIsCreated]")
@@ -64,7 +64,7 @@ internal class DDTestObserverTests: XCTestCase {
 
     func testWhenTestCaseDidFinishIsCalled_testStatusIsSet() {
         testObserver.testCaseWillStart(self)
-        let testSpan = testObserver.tracer.tracerSdk.currentSpan as! RecordEventsReadableSpan
+        let testSpan = testObserver.tracer.tracerSdk.activeSpan as! RecordEventsReadableSpan
         var spanData = testSpan.toSpanData()
         XCTAssertNil(spanData.attributes[DDTestTags.testStatus])
 
@@ -78,7 +78,7 @@ internal class DDTestObserverTests: XCTestCase {
         testObserver.testCaseWillStart(self)
         testObserver.testCase(self, didFailWithDescription: "descrip", inFile: "samplefile", atLine: 239)
 
-        let testSpan = testObserver.tracer.tracerSdk.currentSpan as! RecordEventsReadableSpan
+        let testSpan = testObserver.tracer.tracerSdk.activeSpan as! RecordEventsReadableSpan
         let spanData = testSpan.toSpanData()
 
         XCTAssertNotNil(spanData.attributes[DDTags.errorType])
@@ -90,7 +90,7 @@ internal class DDTestObserverTests: XCTestCase {
 
     func testWhenTestCaseDidFinishIsCalledAndTheTestIsABenchmark_benchmarkTagsAreAdded() {
         testObserver.testCaseWillStart(self)
-        let testSpan = testObserver.tracer.tracerSdk.currentSpan as! RecordEventsReadableSpan
+        let testSpan = testObserver.tracer.tracerSdk.activeSpan as! RecordEventsReadableSpan
         let perfMetric = XCTPerformanceMetric.wallClockTime
         self.setValue([perfMetric], forKey: "_activePerformanceMetricIDs")
         self.setValue([perfMetric: ["measurements" : [1,2,3,4,5]]], forKey: "_perfMetricsForID")

--- a/Tests/DatadogSDKTesting/DDTracerTests.swift
+++ b/Tests/DatadogSDKTesting/DDTracerTests.swift
@@ -68,7 +68,7 @@ class DDTracerTests: XCTestCase {
     }
 
     func testCreateSpanFromCrash() {
-        let simpleSpan = SimpleSpanData(traceIdHi: 1, traceIdLo: 2, spanId: 3, name: "name", startEpochNanos: 33, stringAttributes: [:])
+        let simpleSpan = SimpleSpanData(traceIdHi: 1, traceIdLo: 2, spanId: 3, name: "name", startTime: Date(timeIntervalSinceReferenceDate: 33), stringAttributes: [:])
         let crashDate: Date? = nil
         let errorType = "errorType"
         let errorMessage = "errorMessage"
@@ -86,11 +86,11 @@ class DDTracerTests: XCTestCase {
         XCTAssertEqual(spanData.traceId, TraceId(idHi: 1, idLo: 2))
         XCTAssertEqual(spanData.spanId, SpanId(id:3))
         XCTAssertEqual(spanData.attributes[DDTestTags.testStatus],  AttributeValue.string( DDTestTags.statusFail))
-        XCTAssertEqual(spanData.status, Status.internalError)
+        XCTAssertEqual(spanData.status, Status.error)
         XCTAssertEqual(spanData.attributes[DDTags.errorType], AttributeValue.string(errorType))
         XCTAssertEqual(spanData.attributes[DDTags.errorMessage], AttributeValue.string(errorMessage))
         XCTAssertEqual(spanData.attributes[DDTags.errorStack], AttributeValue.string(errorStack))
-        XCTAssertEqual(spanData.endEpochNanos, spanData.startEpochNanos + 100)
+        XCTAssertEqual(spanData.endTime, spanData.startTime.addingTimeInterval(TimeInterval.fromMicroseconds(1)))
     }
     
 }

--- a/Tests/DatadogSDKTesting/OutputCapture/StderrCaptureTests.swift
+++ b/Tests/DatadogSDKTesting/OutputCapture/StderrCaptureTests.swift
@@ -25,14 +25,15 @@ class StderrCaptureTests: XCTestCase {
         DDTestMonitor.instance?.testObserver?.currentTestSpan = span
         capturer.stderrMessage(tracer: tracer, string: stringToCapture)
         Thread.sleep(forTimeInterval: 0.5)
+        span.status = .ok
         span.end()
         let spanData = span.toSpanData()
 
-        XCTAssertEqual(spanData.timedEvents.count, 1)
-        XCTAssertEqual(spanData.timedEvents.first?.attributes["message"]?.description, "This should be captured" )
+        XCTAssertEqual(spanData.events.count, 1)
+        XCTAssertEqual(spanData.events.first?.attributes["message"]?.description, "This should be captured" )
 
-        let timeToCheck = StderrCapture.logDateFormatter.date(from: "2020-10-22 12:01:33.161546+0200")!.timeIntervalSince1970
-        XCTAssertEqual(spanData.timedEvents.first?.epochNanos, UInt64(timeToCheck * 1_000_000_000))
+        let timeToCheck = StderrCapture.logDateFormatter.date(from: "2020-10-22 12:01:33.161546+0200")!
+        XCTAssertEqual(spanData.events.first?.timestamp, timeToCheck)
     }
 
     func testWhenWhenUIStepHappens_messageIsCapturedAndConvertedToEvents() {
@@ -46,13 +47,14 @@ class StderrCaptureTests: XCTestCase {
         DDTestMonitor.instance?.testObserver?.currentTestSpan = span
         capturer.stderrMessage(tracer: tracer, string: stringToCapture)
         Thread.sleep(forTimeInterval: 0.6)
+        span.status = .ok
         span.end()
         let spanData = span.toSpanData()
 
-        XCTAssertEqual(spanData.timedEvents.count, 1)
-        XCTAssertEqual(spanData.timedEvents.first?.attributes["message"]?.description, "Open com.datadoghq.DemoSwift" )
+        XCTAssertEqual(spanData.events.count, 1)
+        XCTAssertEqual(spanData.events.first?.attributes["message"]?.description, "Open com.datadoghq.DemoSwift" )
 
-        let timeToCheck = date.addingTimeInterval(0.5).timeIntervalSince1970
-        XCTAssertEqual(spanData.timedEvents.first?.epochNanos,  UInt64(timeToCheck * 1_000_000_000))
+        let timeToCheck = date.addingTimeInterval(0.5)
+        XCTAssertEqual(spanData.events.first?.timestamp,  timeToCheck)
     }
 }

--- a/Tests/DatadogSDKTesting/OutputCapture/StdoutCaptureTests.swift
+++ b/Tests/DatadogSDKTesting/OutputCapture/StdoutCaptureTests.swift
@@ -22,13 +22,14 @@ class StdoutCaptureTests: XCTestCase {
         StdoutCapture.startCapturing(tracer: tracer)
         let span = tracer.startSpan(name: "Unnamed", attributes: [:])
         print(stringToCapture)
+        span.status = .ok
         span.end()
         let spanData = span.toSpanData()
         DDInstrumentationControl.stopStdoutCapture()
 
         XCTAssertTrue(StdoutCapture.stdoutBuffer.isEmpty)
-        XCTAssertEqual(spanData.timedEvents.count, 1)
-        XCTAssertEqual(spanData.timedEvents.first?.attributes["message"]?.description, stringToCapture + "\n" )
+        XCTAssertEqual(spanData.events.count, 1)
+        XCTAssertEqual(spanData.events.first?.attributes["message"]?.description, stringToCapture + "\n" )
     }
 
     func testWhenPrintIsCalledAndIsNotCapturing_stringIsNotCaptured() {
@@ -39,11 +40,12 @@ class StdoutCaptureTests: XCTestCase {
         DDInstrumentationControl.stopStdoutCapture()
         let span = tracer.startSpan(name: "Unnamed", attributes: [:])
         print(stringToCapture)
+        span.status = .ok
         span.end()
         let spanData = span.toSpanData()
 
         XCTAssertTrue(StdoutCapture.stdoutBuffer.isEmpty)
-        XCTAssertEqual(spanData.timedEvents.count, 0)
+        XCTAssertEqual(spanData.events.count, 0)
     }
 
     func testWhenSomeCharactersAreWrittenToStdoutWithoutNewLines_charactersAreCapturedButNotConvertedToEvents () {
@@ -54,11 +56,12 @@ class StdoutCaptureTests: XCTestCase {
         let span = tracer.startSpan(name: "Unnamed", attributes: [:])
         fputs(stringToCapture, stdout)
         let spanData = span.toSpanData()
+        span.status = .ok
         span.end()
         DDInstrumentationControl.stopStdoutCapture()
 
         XCTAssertFalse(StdoutCapture.stdoutBuffer.isEmpty)
         XCTAssertEqual(StdoutCapture.stdoutBuffer, stringToCapture)
-        XCTAssertEqual(spanData.timedEvents.count, 0)
+        XCTAssertEqual(spanData.events.count, 0)
     }
 }


### PR DESCRIPTION
* Changes in possible values of Span status
* Span status must be explicitly set to Ok
* It uses now Date values by default for timing
* Some classes renames