### PR TITLE
Allow disabling crash handler for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ DD_MAX_PAYLOAD_SIZE # It sets the maximum size that will be reported from the pa
 
 You can also disable or enable specific autoinstrumentation in some of the tests from Swift or Objective-C by importing the module `DatadogSDKTesting` and using the class: `DDInstrumentationControl`.
 
+### Disable crash handling
+
+You should never need to do it, but in some ***very specific cases*** you may want to disable crash reporting for tests (e.g. you want to test your own crash handler, ... ):
+```shell
+DD_DISABLE_CRASH_HANDLER # Disables crash handling and reporting. (Boolean) WARNING, read note below
+```
+> You must know that if you disable crash reporting, crashing tests wont be reported to the backend and wont appear as a failure. If you really, really need to do this for any of your tests, run it as a totally separated target, so you dont disable it for the rest of the tests
+
 
 ## Adding custom tags
 

--- a/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
+++ b/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
@@ -24,6 +24,7 @@ internal struct DDEnvironmentValues {
     let extraHTTPHeaders: Set<String>?
     let excludedURLS: Set<String>?
     let disableDDSDKIOSIntegration: Bool
+    let disableCrashHandler: Bool
 
     /// OS Information
     let osName: String
@@ -119,9 +120,11 @@ internal struct DDEnvironmentValues {
         let envStderr = DDEnvironmentValues.getEnvVariable("DD_DISABLE_STDERR_INSTRUMENTATION") as NSString?
         disableStderrInstrumentation = envStderr?.boolValue ?? false
 
-        /// Instrumentation configuration values
         let envDisableDDSDKIOSIntegration = DDEnvironmentValues.getEnvVariable("DD_DISABLE_SDKIOS_INTEGRATION") as NSString?
         disableDDSDKIOSIntegration = envDisableDDSDKIOSIntegration?.boolValue ?? false
+
+        let envDisableCrashReporting = DDEnvironmentValues.getEnvVariable("DD_DISABLE_CRASH_HANDLER") as NSString?
+        disableCrashHandler = envDisableCrashReporting?.boolValue ?? false
 
         /// Device Information
         osName = PlatformUtils.getRunningPlatform()

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -36,13 +36,18 @@ internal class DDTestMonitor {
         } else {
             notificationObserver = NotificationCenter.default.addObserver(
                 forName: launchNotificationName,
-                object: nil, queue: nil) { _ in
+                object: nil, queue: nil) { [weak self] _ in
                     /// As crash reporter is initialized in testBundleWillStart() method, we initialize it here
                     /// because dont have test observer
-                    DDCrashes.install()
-                    let launchedSpan = self.tracer.createSpanFromContext(spanContext: self.tracer.launchSpanContext!)
-                    let simpleSpan = SimpleSpanData(spanData: launchedSpan.toSpanData())
-                    DDCrashes.setCustomData(customData: SimpleSpanSerializer.serializeSpan(simpleSpan: simpleSpan))
+                    guard let self = self else {
+                        return
+                    }
+                    if !self.tracer.env.disableCrashHandler {
+                        DDCrashes.install()
+                        let launchedSpan = self.tracer.createSpanFromContext(spanContext: self.tracer.launchSpanContext!)
+                        let simpleSpan = SimpleSpanData(spanData: launchedSpan.toSpanData())
+                        DDCrashes.setCustomData(customData: SimpleSpanSerializer.serializeSpan(simpleSpan: simpleSpan))
+                    }
             }
         }
     }

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -31,7 +31,9 @@ internal class DDTestObserver: NSObject, XCTestObservation {
 
     func testBundleWillStart(_ testBundle: Bundle) {
         currentBundleName = testBundle.bundleURL.deletingPathExtension().lastPathComponent
-        DDCrashes.install()
+        if !tracer.env.disableCrashHandler {
+            DDCrashes.install()
+        }
     }
 
     func testBundleDidFinish(_ testBundle: Bundle) {

--- a/Tests/DatadogSDKTesting/DDEnvironmentValuesTests.swift
+++ b/Tests/DatadogSDKTesting/DDEnvironmentValuesTests.swift
@@ -52,6 +52,7 @@ class DDEnvironmentValuesTests: XCTestCase {
         XCTAssertEqual(env.extraHTTPHeaders, nil)
         XCTAssertEqual(env.excludedURLS, nil)
         XCTAssertEqual(env.enableRecordPayload, false)
+        XCTAssertEqual(env.disableCrashHandler, false)
     }
 
     func testWhenConfigurationEnvironmentAreSet_TheyAreStoredCorrectly() {
@@ -62,6 +63,7 @@ class DDEnvironmentValuesTests: XCTestCase {
         testEnvironment["DD_INSTRUMENTATION_EXTRA_HEADERS"] = "header1,header2;header3 header4"
         testEnvironment["DD_EXCLUDED_URLS"] = "http://www.google"
         testEnvironment["DD_ENABLE_RECORD_PAYLOAD"] = "true"
+        testEnvironment["DD_DISABLE_CRASH_HANDLER"] = "true"
 
         setEnvVariables()
 
@@ -73,6 +75,7 @@ class DDEnvironmentValuesTests: XCTestCase {
         XCTAssertEqual(env.extraHTTPHeaders?.count, 4)
         XCTAssertEqual(env.excludedURLS?.count, 1)
         XCTAssertEqual(env.enableRecordPayload, true)
+        XCTAssertEqual(env.disableCrashHandler, true)
     }
 
     func testAddsTagsToSpan() {


### PR DESCRIPTION
Add an environment variable to disable crash handler, and warn about its usage.
Disabling it will make crashing tests to not be reported as failures, so use it with care.
It can only be enabled or disabled with an environment variable at startup because it cannot be disabled once that it has been enabled