### PR TITLE
Add support for reporting test source location.

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E11295BB25F2483D002719E7 /* FileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11295BA25F2483D002719E7 /* FileLocator.swift */; };
+		E11295BC25F2483D002719E7 /* FileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11295BA25F2483D002719E7 /* FileLocator.swift */; };
+		E11295BD25F2483D002719E7 /* FileLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11295BA25F2483D002719E7 /* FileLocator.swift */; };
+		E11295C825F63BA8002719E7 /* DDSymbolAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = E11295C725F63BA8002719E7 /* DDSymbolAddress.c */; };
+		E11295C925F63BA8002719E7 /* DDSymbolAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = E11295C725F63BA8002719E7 /* DDSymbolAddress.c */; };
+		E11295CA25F63BA8002719E7 /* DDSymbolAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = E11295C725F63BA8002719E7 /* DDSymbolAddress.c */; };
 		E12515E5254892C600670D23 /* XCUIApplicationSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12515E4254892C500670D23 /* XCUIApplicationSwizzler.swift */; };
 		E126DD2D253F366200700A40 /* StdoutCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = E126DD2C253F366200700A40 /* StdoutCapture.swift */; };
 		E126DD2F253F367600700A40 /* StderrCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = E126DD2E253F367600700A40 /* StderrCapture.swift */; };
@@ -119,7 +125,6 @@
 		E19F86A025E7FCB7003202F5 /* CISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19F869E25E7FA73003202F5 /* CISpec.swift */; };
 		E19F86A125E7FCB8003202F5 /* CISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19F869E25E7FA73003202F5 /* CISpec.swift */; };
 		E1ABA05B25231E2500ED8AEF /* DatadogSDKTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = E1ABA04D25231E2500ED8AEF /* DatadogSDKTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E1ABA06D25231F3200ED8AEF /* ObjcLoadHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA06C25231F3200ED8AEF /* ObjcLoadHandler.m */; };
 		E1ABA07425231F4700ED8AEF /* DDTestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA07025231F4700ED8AEF /* DDTestObserver.swift */; };
 		E1ABA07525231F4700ED8AEF /* DDTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA07125231F4700ED8AEF /* DDTags.swift */; };
 		E1ABA07625231F4700ED8AEF /* FrameworkLoadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA07225231F4700ED8AEF /* FrameworkLoadHandler.swift */; };
@@ -140,6 +145,10 @@
 		E1D476A625DD369F00832592 /* BinaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D476A525DD369F00832592 /* BinaryParser.swift */; };
 		E1D476A725DD369F00832592 /* BinaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D476A525DD369F00832592 /* BinaryParser.swift */; };
 		E1D476A825DD369F00832592 /* BinaryParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D476A525DD369F00832592 /* BinaryParser.swift */; };
+		E1D6EFA225F6631200E8C3AE /* DDSymbolAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = E1D6EFA125F6563000E8C3AE /* DDSymbolAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1D6EFA325F6631E00E8C3AE /* DDSymbolAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = E1D6EFA125F6563000E8C3AE /* DDSymbolAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1D6EFA425F6632B00E8C3AE /* DDSymbolAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = E1D6EFA125F6563000E8C3AE /* DDSymbolAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1D6EFA525F6647F00E8C3AE /* ObjcLoadHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA06C25231F3200ED8AEF /* ObjcLoadHandler.m */; };
 		E1DFF0EA257010E700344895 /* PlatformUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E141CF5F256FD513008B6B70 /* PlatformUtils.swift */; };
 		E1DFF0EB257010E800344895 /* PlatformUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E141CF5F256FD513008B6B70 /* PlatformUtils.swift */; };
 		E1FB48312538909D0083B263 /* DatadogSDKTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1ABA04A25231E2500ED8AEF /* DatadogSDKTesting.framework */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -244,6 +253,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		E11295BA25F2483D002719E7 /* FileLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLocator.swift; sourceTree = "<group>"; };
+		E11295C725F63BA8002719E7 /* DDSymbolAddress.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = DDSymbolAddress.c; sourceTree = "<group>"; };
 		E116D7DA25248C390022779D /* SwiftExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		E121DF07258CF652009EA71E /* azurepipelines.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = azurepipelines.json; sourceTree = "<group>"; };
 		E121DF08258CF652009EA71E /* buildkite.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = buildkite.json; sourceTree = "<group>"; };
@@ -321,6 +332,7 @@
 		E1D4768F25DC2B8E00832592 /* config */ = {isa = PBXFileReference; lastKnownFileType = text; path = config; sourceTree = "<group>"; };
 		E1D4769525DC2B8E00832592 /* master */ = {isa = PBXFileReference; lastKnownFileType = text; path = master; sourceTree = "<group>"; };
 		E1D476A525DD369F00832592 /* BinaryParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryParser.swift; sourceTree = "<group>"; };
+		E1D6EFA125F6563000E8C3AE /* DDSymbolAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DDSymbolAddress.h; sourceTree = "<group>"; };
 		E1FB483D253891CE0083B263 /* SimpleSpanSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleSpanSerializer.swift; sourceTree = "<group>"; };
 		E1FB483E253891CE0083B263 /* DDCrashes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDCrashes.swift; sourceTree = "<group>"; };
 		E1FB483F253891CE0083B263 /* SimpleSpanData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleSpanData.swift; sourceTree = "<group>"; };
@@ -402,6 +414,7 @@
 				E116D7DA25248C390022779D /* SwiftExtensions.swift */,
 				E1665A7225D12D7500BA53CD /* Spawn.swift */,
 				E12515E4254892C500670D23 /* XCUIApplicationSwizzler.swift */,
+				E11295BA25F2483D002719E7 /* FileLocator.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -618,6 +631,7 @@
 		E160A113252B3A6B003121A5 /* include */ = {
 			isa = PBXGroup;
 			children = (
+				E1D6EFA125F6563000E8C3AE /* DDSymbolAddress.h */,
 				E160A114252B3A6B003121A5 /* ObjcLoadHandler.h */,
 			);
 			path = include;
@@ -701,6 +715,7 @@
 			children = (
 				E160A113252B3A6B003121A5 /* include */,
 				E1ABA06C25231F3200ED8AEF /* ObjcLoadHandler.m */,
+				E11295C725F63BA8002719E7 /* DDSymbolAddress.c */,
 			);
 			path = Objc;
 			sourceTree = "<group>";
@@ -838,6 +853,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E157A721256E9D1D00CBCA52 /* DatadogSDKTesting.h in Headers */,
+				E1D6EFA325F6631E00E8C3AE /* DDSymbolAddress.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -846,6 +862,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E157A759256E9D3300CBCA52 /* DatadogSDKTesting.h in Headers */,
+				E1D6EFA425F6632B00E8C3AE /* DDSymbolAddress.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -854,6 +871,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E1ABA05B25231E2500ED8AEF /* DatadogSDKTesting.h in Headers */,
+				E1D6EFA225F6631200E8C3AE /* DDSymbolAddress.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1152,6 +1170,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E11295BC25F2483D002719E7 /* FileLocator.swift in Sources */,
 				E157A723256E9D1D00CBCA52 /* SwiftExtensions.swift in Sources */,
 				E1665A8225D13BBB00BA53CD /* DDSymbolicator.swift in Sources */,
 				E157A724256E9D1D00CBCA52 /* DDTestMonitor.swift in Sources */,
@@ -1170,6 +1189,7 @@
 				E157A732256E9D1D00CBCA52 /* DDError.swift in Sources */,
 				E157A734256E9D1D00CBCA52 /* StdoutCapture.swift in Sources */,
 				E1D476A725DD369F00832592 /* BinaryParser.swift in Sources */,
+				E11295C825F63BA8002719E7 /* DDSymbolAddress.c in Sources */,
 				E157A735256E9D1D00CBCA52 /* SimpleSpanSerializer.swift in Sources */,
 				E1DFF0EA257010E700344895 /* PlatformUtils.swift in Sources */,
 				E157A736256E9D1D00CBCA52 /* DDCrashes.swift in Sources */,
@@ -1183,6 +1203,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E11295BD25F2483D002719E7 /* FileLocator.swift in Sources */,
 				E157A75B256E9D3300CBCA52 /* SwiftExtensions.swift in Sources */,
 				E1665A8125D13BBB00BA53CD /* DDSymbolicator.swift in Sources */,
 				E157A75C256E9D3300CBCA52 /* DDTestMonitor.swift in Sources */,
@@ -1201,6 +1222,7 @@
 				E157A76A256E9D3300CBCA52 /* DDError.swift in Sources */,
 				E157A76C256E9D3300CBCA52 /* StdoutCapture.swift in Sources */,
 				E1D476A825DD369F00832592 /* BinaryParser.swift in Sources */,
+				E11295C925F63BA8002719E7 /* DDSymbolAddress.c in Sources */,
 				E157A76D256E9D3300CBCA52 /* SimpleSpanSerializer.swift in Sources */,
 				E1DFF0EB257010E800344895 /* PlatformUtils.swift in Sources */,
 				E157A76E256E9D3300CBCA52 /* DDCrashes.swift in Sources */,
@@ -1256,12 +1278,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E11295BB25F2483D002719E7 /* FileLocator.swift in Sources */,
 				E1AD079F252F5B00003705C1 /* SwiftExtensions.swift in Sources */,
+				E1D6EFA525F6647F00E8C3AE /* ObjcLoadHandler.m in Sources */,
 				E1665A8525D1524100BA53CD /* DDSymbolicator.swift in Sources */,
 				E1ABA08B252341EA00ED8AEF /* DDTestMonitor.swift in Sources */,
 				E14405A625D6AA9500FE3D3C /* GitInfo.swift in Sources */,
 				E1ABA07725231F4700ED8AEF /* DDEnvironmentValues.swift in Sources */,
-				E1ABA06D25231F3200ED8AEF /* ObjcLoadHandler.m in Sources */,
 				E158E2DC25471DA000DBCD6C /* DDInstrumentationControl.swift in Sources */,
 				E1FB4842253891CE0083B263 /* SimpleSpanData.swift in Sources */,
 				E19E053C255177770032BAB9 /* DDNetworkInstrumentation.swift in Sources */,
@@ -1274,6 +1297,7 @@
 				E1AD07A9252F5CB8003705C1 /* DDError.swift in Sources */,
 				E126DD2D253F366200700A40 /* StdoutCapture.swift in Sources */,
 				E1D476A625DD369F00832592 /* BinaryParser.swift in Sources */,
+				E11295CA25F63BA8002719E7 /* DDSymbolAddress.c in Sources */,
 				E1FB4840253891CE0083B263 /* SimpleSpanSerializer.swift in Sources */,
 				E1FB4841253891CE0083B263 /* DDCrashes.swift in Sources */,
 				E1ABA07425231F4700ED8AEF /* DDTestObserver.swift in Sources */,

--- a/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
+++ b/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
@@ -63,6 +63,9 @@ internal struct DDEnvironmentValues {
     var committerEmail: String?
     var committerDate: String?
 
+    /// Source location
+    var sourceRoot: String?
+
     static var environment = ProcessInfo.processInfo.environment
     static let environmentCharset = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
@@ -77,6 +80,8 @@ internal struct DDEnvironmentValues {
 
         ddEnvironment = DDEnvironmentValues.getEnvVariable("DD_ENV")
         ddService = DDEnvironmentValues.getEnvVariable("DD_SERVICE")
+
+        sourceRoot = ProcessInfo.processInfo.environment["SRCROOT"]
 
         if let envDDTags = DDEnvironmentValues.getEnvVariable("DD_TAGS") {
             let ddtagsEntries = envDDTags.components(separatedBy: " ")
@@ -388,8 +393,8 @@ internal struct DDEnvironmentValues {
 
         // Read git folder information
         var gitInfo: GitInfo?
-        if let srcRoot = ProcessInfo.processInfo.environment["SRCROOT"] {
-            var rootFolder = NSString(string: URL(fileURLWithPath: srcRoot).path)
+        if let sourceRoot = sourceRoot {
+            var rootFolder = NSString(string: URL(fileURLWithPath: sourceRoot).path)
             while !FileManager.default.fileExists(atPath: rootFolder.appendingPathComponent(".git")) {
                 if rootFolder.isEqual(to: rootFolder.deletingLastPathComponent) {
                     // We reached to the top

--- a/Sources/DatadogSDKTesting/DDTags.swift
+++ b/Sources/DatadogSDKTesting/DDTags.swift
@@ -44,6 +44,10 @@ internal struct DDTestTags {
     static let testSuite        = "test.suite"
     static let testBundle       = "test.bundle"
     static let testFramework    = "test.framework"
+    static let testSourceFile   = "test.source.file"
+    static let testSourceStartLine  = "test.source.startLine"
+    static let testSourceEndLine    = "test.source.endLine"
+
 
     static let testStatus       = "test.status"
     static let statusPass       = "pass"

--- a/Sources/DatadogSDKTesting/DatadogSDKTesting.h
+++ b/Sources/DatadogSDKTesting/DatadogSDKTesting.h
@@ -14,4 +14,4 @@ FOUNDATION_EXPORT const unsigned char DatadogSDKTestingVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <DatadogSDKTesting/PublicHeader.h>
 
-
+#import <DatadogSDKTesting/DDSymbolAddress.h>

--- a/Sources/DatadogSDKTesting/Objc/DDSymbolAddress.c
+++ b/Sources/DatadogSDKTesting/Objc/DDSymbolAddress.c
@@ -1,0 +1,95 @@
+#import "DDSymbolAddress.h"
+
+#import <string.h>
+#import <mach-o/nlist.h>
+
+void * FindSymbolInImage(const char *symbol, const struct mach_header *image, intptr_t slide)
+{
+    if ((image == NULL) || (symbol == NULL)) {
+        return NULL;
+    }
+
+    struct symtab_command *symtab_cmd = NULL;
+
+    if (image->magic == MH_MAGIC_64) {
+        struct segment_command_64 *linkedit_segment = NULL;
+        struct segment_command_64 *text_segment = NULL;
+
+        struct segment_command_64 *cur_seg_cmd;
+        uintptr_t cur = (uintptr_t)image + sizeof(struct mach_header_64);
+        for (uint i = 0; i < image->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
+            cur_seg_cmd = (struct segment_command_64 *)cur;
+            if (cur_seg_cmd->cmd == LC_SEGMENT_64) {
+                if (!strcmp(cur_seg_cmd->segname, SEG_TEXT)) {
+                    text_segment = cur_seg_cmd;
+                } else if (strcmp(cur_seg_cmd->segname, SEG_LINKEDIT) == 0) {
+                    linkedit_segment = cur_seg_cmd;
+                }
+            } else if (cur_seg_cmd->cmd == LC_SYMTAB) {
+                symtab_cmd = (struct symtab_command *)cur_seg_cmd;
+            }
+        }
+
+        if (!symtab_cmd || !linkedit_segment || !text_segment) {
+            return NULL;
+        }
+
+        uintptr_t linkedit_base = (uintptr_t)slide + (uintptr_t)(linkedit_segment->vmaddr - linkedit_segment->fileoff);
+        struct nlist_64 *symtab = (struct nlist_64 *)(linkedit_base + symtab_cmd->symoff);
+        char *strtab = (char *)(linkedit_base + symtab_cmd->stroff);
+
+        struct nlist_64 *sym;
+        int index;
+        for (index = 0, sym = symtab; index < symtab_cmd->nsyms; index += 1, sym += 1) {
+            if (sym->n_un.n_strx != 0 && !strcmp(symbol, strtab + sym->n_un.n_strx)) {
+                uint64_t address = slide + sym->n_value;
+                if (sym->n_desc & N_ARM_THUMB_DEF) {
+                    return (void *)(address | 1);
+                } else {
+                    return (void *)(address);
+                }
+            }
+        }
+    } else {
+        struct segment_command *linkedit_segment = NULL;
+        struct segment_command *text_segment = NULL;
+
+        struct segment_command *cur_seg_cmd;
+        uintptr_t cur = (uintptr_t)image + sizeof(struct mach_header);
+        for (uint i = 0; i < image->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
+            cur_seg_cmd = (struct segment_command *)cur;
+            if (cur_seg_cmd->cmd == LC_SEGMENT) {
+                if (!strcmp(cur_seg_cmd->segname, SEG_TEXT)) {
+                    text_segment = cur_seg_cmd;
+                } else if (strcmp(cur_seg_cmd->segname, SEG_LINKEDIT) == 0) {
+                    linkedit_segment = cur_seg_cmd;
+                }
+            } else if (cur_seg_cmd->cmd == LC_SYMTAB) {
+                symtab_cmd = (struct symtab_command *)cur_seg_cmd;
+            }
+        }
+
+        if (!symtab_cmd || !linkedit_segment || !text_segment) {
+            return NULL;
+        }
+
+        uintptr_t linkedit_base = (uintptr_t)slide + (uintptr_t)(linkedit_segment->vmaddr - linkedit_segment->fileoff);
+        struct nlist *symtab = (struct nlist *)(linkedit_base + symtab_cmd->symoff);
+        char *strtab = (char *)(linkedit_base + symtab_cmd->stroff);
+
+        struct nlist *sym;
+        int index;
+        for (index = 0, sym = symtab; index < symtab_cmd->nsyms; index += 1, sym += 1) {
+            if (sym->n_un.n_strx != 0 && !strcmp(symbol, strtab + sym->n_un.n_strx)) {
+                uint64_t address = slide + sym->n_value;
+                if (sym->n_desc & N_ARM_THUMB_DEF) {
+                    return (void *)(address | 1);
+                } else {
+                    return (void *)(address);
+                }
+            }
+        }
+    }
+
+    return NULL;
+}

--- a/Sources/DatadogSDKTesting/Objc/include/DDSymbolAddress.h
+++ b/Sources/DatadogSDKTesting/Objc/include/DDSymbolAddress.h
@@ -1,0 +1,9 @@
+#ifndef CSCoverageUtils_h
+#define CSCoverageUtils_h
+
+#import <stdio.h>
+#import <mach-o/dyld.h>
+
+void *_Nullable FindSymbolInImage(const char *_Nonnull symbol, const struct mach_header *_Nonnull image, intptr_t slide);
+
+#endif /* CSCoverageUtils_h */

--- a/Sources/DatadogSDKTesting/Utils/FileLocator.swift
+++ b/Sources/DatadogSDKTesting/Utils/FileLocator.swift
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+struct FileLocator {
+    /// It returns the file path and line of a test given the test class and test name
+    static func filePath(forTestClass testClass: UnsafePointer<Int8>, testName: String, library: String) -> String {
+        guard let objcClass = objc_getClass(testClass) as? AnyClass else {
+            return ""
+        }
+
+        var testThrowsError = false
+        var method = class_getInstanceMethod(objcClass, Selector(testName))
+        if method == nil {
+            //Try if the test throws an error
+            method = class_getInstanceMethod(objcClass, Selector(testName + "AndReturnError:"))
+            if method == nil {
+                return ""
+            }
+            testThrowsError = true
+        }
+
+        let imp = method_getImplementation(method!)
+        guard let symbol = DDSymbolicator.symbol(forAddress: imp.debugDescription, library: library) else {
+            return ""
+        }
+
+        let symbolInfo: String
+        if symbol.contains("<compiler-generated>") {
+            // Test was written in Swift, and this is just the Obj-c wrapper,
+            // me must locate the original swift method address in the binary
+            let newName = DDSymbolicator.swiftTestMangledName(forClassName: String(cString: testClass), testName: testName, throwsError: testThrowsError)
+            if let address = DDSymbolicator.address(forSymbolName: newName, library: library),
+               let swiftSymbol = DDSymbolicator.symbol(forAddress: address.debugDescription, library: library)
+            {
+                symbolInfo = swiftSymbol
+            } else {
+                symbolInfo = ""
+            }
+        } else {
+            symbolInfo = symbol
+        }
+
+        let symbolInfoComponents = symbolInfo.components(separatedBy: CharacterSet(charactersIn: "() ")).filter { !$0.isEmpty }
+        return symbolInfoComponents.last ?? ""
+    }
+}


### PR DESCRIPTION
It locates the address where the test is defined and uses atos to get the source location.
It uses C source file for locating symbols in Mach-O images