### PR TITLE
CIAPP-1608  Fix network requests in UI tests

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2134,7 +2134,7 @@
 			repositoryURL = "https://github.com/nachoBonafonte/opentelemetry-swift.git";
 			requirement = {
 				kind = revision;
-				revision = fb106e36b0e84e4814f706964df85c439adff355;
+				revision = d8bbe0f877077925ee5c40fca0fc83cfb64ade89;
 			};
 		};
 		E1FB4839253891650083B263 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/Sources/DatadogSDKTesting/Utils/XCUIApplicationSwizzler.swift
+++ b/Sources/DatadogSDKTesting/Utils/XCUIApplicationSwizzler.swift
@@ -13,7 +13,7 @@ extension XCUIApplication {
     }
 
     fileprivate func addPropagationsHeadersToEnvironment(tracer: DDTracer?) {
-        if let headers = tracer?.tracePropagationHTTPHeaders() {
+        if let headers = tracer?.environmentPropagationHTTPHeaders() {
             self.launchEnvironment.merge(headers) { _, new in new }
         }
     }


### PR DESCRIPTION
After changing to Opentelemetry network instrumentation, trace context was not correctly propagated. Use environment Opentelemetry EnvironmentContextPropagator to propagate the trace to the child process.