### PR TITLE
Fix header injection in network calls of UI tests.

### DIFF
--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -44,7 +44,7 @@ internal class DDTestMonitor {
                     }
                     if !self.tracer.env.disableCrashHandler {
                         DDCrashes.install()
-                        let launchedSpan = self.tracer.createSpanFromContext(spanContext: self.tracer.launchSpanContext!)
+                        let launchedSpan = self.tracer.createSpanFromLaunchContext()
                         let simpleSpan = SimpleSpanData(spanData: launchedSpan.toSpanData())
                         DDCrashes.setCustomData(customData: SimpleSpanSerializer.serializeSpan(simpleSpan: simpleSpan))
                     }

--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/DDNetworkInstrumentation.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/DDNetworkInstrumentation.swift
@@ -13,7 +13,7 @@ class DDNetworkInstrumentation {
     var urlSessionInstrumentation: URLSessionInstrumentation!
 
     internal static let acceptableHeaders: Set<String> = {
-        let headers: Set = ["CONTENT-TYPE", "CONTENT-LENGTH", "CONTENT-ENCODING", "CONTENT-LANGUAGE", "USER-AGENT", "REFERER", "ACCEPT", "ORIGIN", "ACCESS-CONTROL-ALLOW-ORIGIN", "ACCESS-CONTROL-ALLOW-CREDENTIALS", "ACCESS-CONTROL-ALLOW-HEADERS", "ACCESS-CONTROL-ALLOW-METHODS", "ACCESS-CONTROL-EXPOSE-HEADERS", "ACCESS-CONTROL-MAX-AGE", "ACCESS-CONTROL-REQUEST-HEADERS", "ACCESS-CONTROL-REQUEST-METHOD", "DATE", "EXPIRES", "CACHE-CONTROL", "ALLOW", "SERVER", "CONNECTION"]
+        let headers: Set = ["CONTENT-TYPE", "CONTENT-LENGTH", "CONTENT-ENCODING", "CONTENT-LANGUAGE", "USER-AGENT", "REFERER", "ACCEPT", "ORIGIN", "ACCESS-CONTROL-ALLOW-ORIGIN", "ACCESS-CONTROL-ALLOW-CREDENTIALS", "ACCESS-CONTROL-ALLOW-HEADERS", "ACCESS-CONTROL-ALLOW-METHODS", "ACCESS-CONTROL-EXPOSE-HEADERS", "ACCESS-CONTROL-MAX-AGE", "ACCESS-CONTROL-REQUEST-HEADERS", "ACCESS-CONTROL-REQUEST-METHOD", "DATE", "EXPIRES", "CACHE-CONTROL", "ALLOW", "SERVER", "CONNECTION", "TRACEPARENT", "X-DATADOG-TRACE-ID", "X-DATADOG-PARENT-ID"]
         if let extraHeaders = DDTestMonitor.instance?.tracer.env.extraHTTPHeaders {
             return headers.union(extraHeaders)
         }
@@ -51,7 +51,7 @@ class DDNetworkInstrumentation {
 
     func shouldInstrumentRequest(request: URLRequest) -> Bool {
         guard let tracer = DDTestMonitor.instance?.tracer,
-              tracer.activeSpan != nil || tracer.launchSpanContext != nil,
+              tracer.propagationContext != nil,
               !self.excludes(request.url)
         else {
             return false
@@ -63,7 +63,7 @@ class DDNetworkInstrumentation {
     func shouldInjectTracingHeaders(request: inout URLRequest) -> Bool {
         guard injectHeaders == true,
               let tracer = DDTestMonitor.instance?.tracer,
-              tracer.activeSpan != nil,
+              tracer.propagationContext != nil,
               !excludes(request.url)
         else {
             return false


### PR DESCRIPTION
Also add Opentelemetry and datadog trace headers to the acceptable headers env variable so they are never redacted