### PR TITLE
CIAPP-1869 Add support for US3

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2781,8 +2781,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.1;
+				kind = revision;
+				revision = 0bcf4da0bad436e7cd7782ce8e1214ec4e8fbb03;
 			};
 		};
 		E157A719256E9D1D00CBCA52 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/open-telemetry/opentelemetry-swift",
         "state": {
           "branch": null,
-          "revision": "3a731edb3180bb63c9ff2435911234d6b3545c39",
-          "version": "1.0.1"
+          "revision": "0bcf4da0bad436e7cd7782ce8e1214ec4e8fbb03",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift", from: "1.0.1"),
+        .package(name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift", ._revisionItem("0bcf4da0bad436e7cd7782ce8e1214ec4e8fbb03")),
         .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.8.1"),
         .package(name: "SigmaSwiftStatistics", url: "https://github.com/evgenyneu/SigmaSwiftStatistics.git", from: "9.0.2"),
     ],

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -61,6 +61,8 @@ internal class DDTracer {
         switch env.tracesEndpoint {
             case "us", "US":
                 endpoint = Endpoint.us
+            case "us3", "US3":
+                endpoint = Endpoint.us3
             case "eu", "EU":
                 endpoint = Endpoint.eu
             case "gov", "GOV":

--- a/Tests/DatadogSDKTesting/DDTracerTests.swift
+++ b/Tests/DatadogSDKTesting/DDTracerTests.swift
@@ -121,6 +121,13 @@ class DDTracerTests: XCTestCase {
         DDEnvironmentValues.environment["DD_ENDPOINT"] = nil
     }
 
+    func testEndpointChangeToUS3() {
+        DDEnvironmentValues.environment["DD_ENDPOINT"] = "us3"
+        let tracer = DDTracer()
+        XCTAssertTrue(tracer.endpointURLs().contains("https://trace.browser-intake-us3-datadoghq.com/v1/input/"))
+        DDEnvironmentValues.environment["DD_ENDPOINT"] = nil
+    }
+
     func testEndpointChangeToEU() {
         DDEnvironmentValues.environment["DD_ENDPOINT"] = "eu"
         let tracer = DDTracer()


### PR DESCRIPTION
### What and why?

Adds support to US3 Datadog endpoint

### How?

It links with the latest opentelemetry-swift version that includes the support for it
`DD_ENDPOINT` accepts now `us3` or `US3` as possible values

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
- [X] Make sure each commit and the PR mention the Issue number or JIRA reference
