### PR TITLE
Use repository name as default test service name

### DIFF
--- a/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
+++ b/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
@@ -595,4 +595,13 @@ internal struct DDEnvironmentValues {
         let returnVariable = variable.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
         return returnVariable.isEmpty ? nil : returnVariable
     }
+
+    func getRepositoryName() -> String? {
+        guard let repository = repository,
+              let repoURL = URL(string: repository)
+        else {
+            return nil
+        }
+        return repoURL.deletingPathExtension().lastPathComponent
+    }
 }

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -72,7 +72,7 @@ internal class DDTracer {
         }
 
         let exporterConfiguration = ExporterConfiguration(
-            serviceName: env.ddService ?? ProcessInfo.processInfo.processName,
+            serviceName: env.ddService ?? env.getRepositoryName() ?? ProcessInfo.processInfo.processName,
             resource: "Resource",
             applicationName: identifier,
             applicationVersion: version,

--- a/Tests/DatadogSDKTesting/DDEnvironmentValuesTests.swift
+++ b/Tests/DatadogSDKTesting/DDEnvironmentValuesTests.swift
@@ -162,6 +162,17 @@ class DDEnvironmentValuesTests: XCTestCase {
         return tracerSdk.spanBuilder(spanName: "spanName").startSpan() as! RecordEventsReadableSpan
     }
 
+    private func testRepositoryName() {
+        testEnvironment["GITHUB_WORKSPACE"] = "/tmp/folder"
+        testEnvironment["GITHUB_REPOSITORY"] = "therepo"
+
+        setEnvVariables()
+        let env = DDEnvironmentValues()
+
+        XCTAssertEqual(env.repository, "https://github.com/therepo.git")
+        XCTAssertEqual(env.getRepositoryName(), "therepo")
+    }
+
     func testSpecs() throws {
         let bundle = Bundle(for: type(of: self))
         let fixturesURL = bundle.resourceURL!.appendingPathComponent("ci")


### PR DESCRIPTION
### What and why?

Use repository name as default test service name

### How?

If the user has not set `DD_SERVICE`, use first the repository name recovered from git and only process name as last resource

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
- [X] Make sure each commit and the PR mention the Issue number or JIRA reference
