### PR TITLE
CIAPP-2526 Manual test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ BITRISE_BUILD_NUMBER=$(BITRISE_BUILD_NUMBER)
 BITRISE_BUILD_URL=$(BITRISE_BUILD_URL)
 ```
 
+A more comprehensive and updated documentation can be found at [CI Visibility - Swift Tests](https://docs.datadoghq.com/continuous_integration/setup_tests/swift) 
 
 
 ## UITests

--- a/Sources/DatadogSDKTesting/FrameworkLoadHandler.swift
+++ b/Sources/DatadogSDKTesting/FrameworkLoadHandler.swift
@@ -16,7 +16,7 @@ public class FrameworkLoadHandler: NSObject {
 
     internal static func installTestObserver() {
         /// Only initialize test observer if user configured so and is running tests
-        guard let enabled = environment["DD_TEST_RUNNER"] as NSString? else {
+         guard let enabled = DDEnvironmentValues.getEnvVariable("DD_TEST_RUNNER") as NSString? else {
             print("[DatadogSDKTesting] Library loaded but not active, DD_TEST_RUNNER is missing")
             return
         }
@@ -27,13 +27,15 @@ public class FrameworkLoadHandler: NSObject {
         }
 
         let isInTestMode = environment["XCInjectBundleInto"] != nil ||
-            environment["XCTestConfigurationFilePath"] != nil || environment["SDKROOT"] != nil
+            environment["XCTestConfigurationFilePath"] != nil ||
+            environment["XCTestBundlePath"] != nil ||
+            environment["SDKROOT"] != nil
         if isInTestMode {
-            guard environment["DATADOG_CLIENT_TOKEN"] != nil else {
+            guard DDEnvironmentValues.getEnvVariable("DATADOG_CLIENT_TOKEN") != nil else {
                 print("[DatadogSDKTesting] DATADOG_CLIENT_TOKEN missing.")
                 return
             }
-            if environment["SRCROOT"] == nil {
+            if DDEnvironmentValues.getEnvVariable("SRCROOT") == nil {
                 print("[DatadogSDKTesting] SRCROOT is not properly set")
             }
             print("[DatadogSDKTesting] Library loaded and active. Instrumenting tests.")

--- a/Sources/DatadogSDKTesting/Utils/XCUIApplicationSwizzler.swift
+++ b/Sources/DatadogSDKTesting/Utils/XCUIApplicationSwizzler.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension XCUIApplication {
     fileprivate func addProcessEnvironmentToLaunch(_ environment: String) {
-        self.launchEnvironment[environment] = ProcessInfo.processInfo.environment[environment]
+        self.launchEnvironment[environment] = DDEnvironmentValues.getEnvVariable(environment)
     }
 
     fileprivate func addPropagationsHeadersToEnvironment(tracer: DDTracer?) {
@@ -38,6 +38,7 @@ extension XCUIApplication {
                 "DATADOG_CLIENT_TOKEN",
                 "XCTestConfigurationFilePath",
                 "XCInjectBundleInto",
+                "XCTestBundlePath",
                 "SDKROOT",
                 "DD_ENV",
                 "DD_SERVICE",
@@ -53,6 +54,7 @@ extension XCUIApplication {
                 "DD_DISABLE_STDERR_INSTRUMENTATION",
                 "DD_DISABLE_SDKIOS_INTEGRATION",
                 "DD_DISABLE_CRASH_HANDLER",
+                "DD_SITE",
                 "DD_ENDPOINT",
                 "DD_DONT_EXPORT"
             ].forEach(addProcessEnvironmentToLaunch)

--- a/Tests/DatadogSDKTesting/CISpec.swift
+++ b/Tests/DatadogSDKTesting/CISpec.swift
@@ -33,6 +33,7 @@ class CISpec: XCTestCase {
 
     func testGenerateSpecJson() throws {
         testEnvironment["DYLD_LIBRARY_PATH"] = ProcessInfo.processInfo.environment["DYLD_LIBRARY_PATH"]
+        testEnvironment["SRCROOT"] = ProcessInfo.processInfo.environment["SRCROOT"]
         testEnvironment["DATADOG_CLIENT_TOKEN"] = "fakeToken"
         testEnvironment["CI_PIPELINE_URL"] = "https://foo/repo/-/pipelines/1234"
         testEnvironment["HOME"] = "/not-my-home"

--- a/Tests/DatadogSDKTesting/DDEnvironmentValuesTests.swift
+++ b/Tests/DatadogSDKTesting/DDEnvironmentValuesTests.swift
@@ -37,6 +37,7 @@ class DDEnvironmentValuesTests: XCTestCase {
 
     override func tearDown() {
         DDEnvironmentValues.environment = previousEnvironment
+        DDEnvironmentValues.infoDictionary = previousInfoDictionary
     }
 
     private func setEnvVariables() {
@@ -219,6 +220,7 @@ class DDEnvironmentValuesTests: XCTestCase {
     }
 
     func testWhenNotRunningInCI_CITagsAreNotAdded() {
+        testEnvironment["SRCROOT"] = ProcessInfo.processInfo.environment["SRCROOT"]
         setEnvVariables()
 
         let span = createSimpleSpan()
@@ -237,6 +239,7 @@ class DDEnvironmentValuesTests: XCTestCase {
     func testAddCustomTagsWithDDTags() {
         testEnvironment["DD_TAGS"] = "key1:value1 key2:value2 key3:value3 keyFoo:$FOO keyFooFoo:$FOOFOO keyMix:$FOO-v1"
         testEnvironment["FOO"] = "BAR"
+        testEnvironment["SRCROOT"] = ProcessInfo.processInfo.environment["SRCROOT"]
         setEnvVariables()
 
         let span = createSimpleSpan()
@@ -275,6 +278,8 @@ class DDEnvironmentValuesTests: XCTestCase {
     func testIfCommitHashFromEnvironmentIsNotSetGitFolderIsEvaluated() {
         testEnvironment["GITHUB_WORKSPACE"] = "/tmp/folder"
         testEnvironment["GITHUB_SHA"] = nil
+        testEnvironment["SRCROOT"] = ProcessInfo.processInfo.environment["SRCROOT"]
+
 
         setEnvVariables()
         let env = DDEnvironmentValues()
@@ -298,6 +303,7 @@ class DDEnvironmentValuesTests: XCTestCase {
 
         testEnvironment["GITHUB_WORKSPACE"] = "/tmp/folder"
         testEnvironment["GITHUB_SHA"] = gitInfo?.commit
+        testEnvironment["SRCROOT"] = ProcessInfo.processInfo.environment["SRCROOT"]
 
         setEnvVariables()
         let env = DDEnvironmentValues()

--- a/Tests/DatadogSDKTesting/FrameworkLoadHandlerTests.swift
+++ b/Tests/DatadogSDKTesting/FrameworkLoadHandlerTests.swift
@@ -31,7 +31,6 @@ class FrameworkLoadHandlerTests: XCTestCase {
         FrameworkLoadHandler.environment = testEnvironment
         DDEnvironmentValues.environment = testEnvironment
         DDEnvironmentValues.environment["DD_DONT_EXPORT"] = "true"
-        DDEnvironmentValues.environment["DATADOG_CLIENT_TOKEN"] = "fakeToken"
     }
 
     func testWhenTestRunnerIsConfiguredAndIsInTestingMode_ItIsInitialised() {


### PR DESCRIPTION
### What and why?

Allow configuration values to be provided in the Info.plist files of the test bundles apart from the environment variables of the test action. If values appear both in environment variables and plist file, environment value takes precedence.
Relates to #40

### How?

When recovering the environment values we use the infoDictionary of the test bundle as a fallback if the environment variable doesn't exist. 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
