### PR TITLE
CIAPP-2480  Update to Event Platform Intake API v2

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2808,7 +2808,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = revision;
-				revision = fb9f9c63f61520780cc3065606749a61f268c247;
+				revision = b89615ee9af80720d48764f753134d7d9b52864f;
 			};
 		};
 		E157A719256E9D1D00CBCA52 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2506,7 +2506,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2534,7 +2533,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2810,7 +2808,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = revision;
-				revision = ec3f32ebd716df6fb549424c7190675a6c8932a8;
+				revision = 577c45abc4603def73aa334beb02489f9de08ae5;
 			};
 		};
 		E157A719256E9D1D00CBCA52 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2190,7 +2190,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.5-beta.1;
+				MARKETING_VERSION = "0.9.5-beta.1";
 				OTHER_LDFLAGS = "-weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSDKTesting;
 				PRODUCT_NAME = DatadogSDKTesting;
@@ -2218,7 +2218,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.5-beta.1;
+				MARKETING_VERSION = "0.9.5-beta.1";
 				OTHER_LDFLAGS = "-weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSDKTesting;
 				PRODUCT_NAME = DatadogSDKTesting;
@@ -2245,7 +2245,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.5-beta.1;
+				MARKETING_VERSION = "0.9.5-beta.1";
 				OTHER_LDFLAGS = "-weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSDKTesting;
 				PRODUCT_NAME = DatadogSDKTesting;
@@ -2274,7 +2274,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.5-beta.1;
+				MARKETING_VERSION = "0.9.5-beta.1";
 				OTHER_LDFLAGS = "-weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSDKTesting;
 				PRODUCT_NAME = DatadogSDKTesting;
@@ -2425,7 +2425,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.9.5-beta.1;
+				MARKETING_VERSION = "0.9.5-beta.1";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2488,7 +2488,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.9.5-beta.1;
+				MARKETING_VERSION = "0.9.5-beta.1";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -2519,7 +2519,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.5-beta.1;
+				MARKETING_VERSION = "0.9.5-beta.1";
 				OTHER_LDFLAGS = " -weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSDKTesting;
 				PRODUCT_NAME = DatadogSDKTesting;
@@ -2547,7 +2547,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.5-beta.1;
+				MARKETING_VERSION = "0.9.5-beta.1";
 				OTHER_LDFLAGS = " -weak-lXCTestSwiftSupport";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.DatadogSDKTesting;
 				PRODUCT_NAME = DatadogSDKTesting;
@@ -2809,8 +2809,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.4;
+				kind = revision;
+				revision = ec3f32ebd716df6fb549424c7190675a6c8932a8;
 			};
 		};
 		E157A719256E9D1D00CBCA52 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2808,7 +2808,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = revision;
-				revision = 577c45abc4603def73aa334beb02489f9de08ae5;
+				revision = fb9f9c63f61520780cc3065606749a61f268c247;
 			};
 		};
 		E157A719256E9D1D00CBCA52 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2808,7 +2808,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = revision;
-				revision = b89615ee9af80720d48764f753134d7d9b52864f;
+				revision = 426742cc6f473a90e64e27f1820a033869660d8d;
 			};
 		};
 		E157A719256E9D1D00CBCA52 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -13,7 +13,9 @@ import Foundation
 enum DDHeaders: String, CaseIterable {
     case traceIDField = "x-datadog-trace-id"
     case parentSpanIDField = "x-datadog-parent-id"
-    case originField = "X-Datadog-Origin"
+    case originField = "x-datadog-origin"
+    case ddSamplingPriority = "x-datadog-sampling-priority"
+    case ddSampled = "x-datadog-sampled"
 }
 
 internal class DDTracer {
@@ -59,13 +61,13 @@ internal class DDTracer {
 
         var endpoint: Endpoint
         switch env.tracesEndpoint {
-            case "us", "US", "https://app.datadoghq.com", "app.datadoghq.com", "datadoghq.com":
+            case "us", "US", "us1", "US1", "https://app.datadoghq.com", "app.datadoghq.com", "datadoghq.com":
                 endpoint = Endpoint.us1
             case "us3", "US3", "https://us3.datadoghq.com", "us3.datadoghq.com":
                 endpoint = Endpoint.us3
-            case "eu", "EU", "https://app.datadoghq.eu", "app.datadoghq.eu", "datadoghq.eu":
+            case "eu", "EU", "eu1", "EU1","https://app.datadoghq.eu", "app.datadoghq.eu", "datadoghq.eu":
                 endpoint = Endpoint.eu1
-            case "gov", "GOV", "https://app.ddog-gov.com", "app.ddog-gov.com", "ddog-gov.com":
+            case "gov", "GOV", "us1_fed", "US1_FED","https://app.ddog-gov.com", "app.ddog-gov.com", "ddog-gov.com":
                 endpoint = Endpoint.us1_fed
             default:
                 endpoint = Endpoint.us1
@@ -278,7 +280,10 @@ internal class DDTracer {
         }
         return [DDHeaders.traceIDField.rawValue: String(context.traceId.rawLowerLong),
                 DDHeaders.parentSpanIDField.rawValue: String(context.spanId.rawValue),
-                DDHeaders.originField.rawValue: "ciapp-test"]
+                DDHeaders.originField.rawValue: DDTagValues.originCiApp,
+                DDHeaders.ddSamplingPriority.rawValue: "1",
+                DDHeaders.ddSampled.rawValue: "1"
+        ]
     }
 
     func tracePropagationHTTPHeaders() -> [String: String] {

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -60,15 +60,15 @@ internal class DDTracer {
         var endpoint: Endpoint
         switch env.tracesEndpoint {
             case "us", "US", "https://app.datadoghq.com", "app.datadoghq.com", "datadoghq.com":
-                endpoint = Endpoint.us
+                endpoint = Endpoint.us1
             case "us3", "US3", "https://us3.datadoghq.com", "us3.datadoghq.com":
                 endpoint = Endpoint.us3
             case "eu", "EU", "https://app.datadoghq.eu", "app.datadoghq.eu", "datadoghq.eu":
-                endpoint = Endpoint.eu
+                endpoint = Endpoint.eu1
             case "gov", "GOV", "https://app.ddog-gov.com", "app.ddog-gov.com", "ddog-gov.com":
-                endpoint = Endpoint.gov
+                endpoint = Endpoint.us1_fed
             default:
-                endpoint = Endpoint.us
+                endpoint = Endpoint.us1
         }
 
         // When reporting tests to local server
@@ -84,8 +84,7 @@ internal class DDTracer {
             applicationName: identifier,
             applicationVersion: version,
             environment: env.ddEnvironment ?? (env.isCi ? "ci" : "none"),
-            clientToken: env.ddClientToken ?? "",
-            apiKey: nil,
+            apiKey: env.ddClientToken ?? "",
             endpoint: endpoint,
             uploadCondition: { true },
             performancePreset: .instantDataDelivery,

--- a/Tests/DatadogSDKTesting/DDTracerTests.swift
+++ b/Tests/DatadogSDKTesting/DDTracerTests.swift
@@ -111,34 +111,39 @@ class DDTracerTests: XCTestCase {
 
     func testEndpointIsUSByDefault() {
         let tracer = DDTracer()
-        XCTAssertTrue(tracer.endpointURLs().contains("https://public-trace-http-intake.logs.datadoghq.com/v1/input/"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://trace.browser-intake-datadoghq.com/api/v2/spans"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://logs.browser-intake-datadoghq.com/api/v2/logs"))
     }
 
     func testEndpointChangeToUS() {
         DDEnvironmentValues.environment["DD_ENDPOINT"] = "US"
         let tracer = DDTracer()
-        XCTAssertTrue(tracer.endpointURLs().contains("https://public-trace-http-intake.logs.datadoghq.com/v1/input/"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://trace.browser-intake-datadoghq.com/api/v2/spans"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://logs.browser-intake-datadoghq.com/api/v2/logs"))
         DDEnvironmentValues.environment["DD_ENDPOINT"] = nil
     }
 
     func testEndpointChangeToUS3() {
         DDEnvironmentValues.environment["DD_ENDPOINT"] = "us3"
         let tracer = DDTracer()
-        XCTAssertTrue(tracer.endpointURLs().contains("https://trace.browser-intake-us3-datadoghq.com/v1/input/"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://trace.browser-intake-us3-datadoghq.com/api/v2/spans"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://logs.browser-intake-us3-datadoghq.com/api/v2/logs"))
         DDEnvironmentValues.environment["DD_ENDPOINT"] = nil
     }
 
     func testEndpointChangeToEU() {
         DDEnvironmentValues.environment["DD_ENDPOINT"] = "eu"
         let tracer = DDTracer()
-        XCTAssertTrue(tracer.endpointURLs().contains("https://public-trace-http-intake.logs.datadoghq.eu/v1/input/"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https:/public-trace-http-intake.logs.datadoghq.eu/api/v2/spans"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://mobile-http-intake.logs.datadoghq.eu/api/v2/logs"))
         DDEnvironmentValues.environment["DD_ENDPOINT"] = nil
     }
 
     func testEndpointChangeToGov() {
         DDEnvironmentValues.environment["DD_ENDPOINT"] = "GOV"
         let tracer = DDTracer()
-        XCTAssertTrue(tracer.endpointURLs().contains("https://trace.browser-intake-ddog-gov.com/v1/input/"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://trace.browser-intake-ddog-gov.com/api/v2/spans"))
+        XCTAssertTrue(tracer.endpointURLs().contains("https://logs.browser-intake-ddog-gov.com/api/v2/logs"))
         DDEnvironmentValues.environment["DD_ENDPOINT"] = nil
     }
 


### PR DESCRIPTION
### What and why?

 Update to Event Platform Intake API v2

### How?

Linking with latest opentelemetry-swift which supports V2 and changing the endpoints in the tests

### Review checklist

- [ X ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ X ] Make sure each commit and the PR mention the Issue number or JIRA reference
