### PR TITLE
CIAPP-2670 - Support-active-context-with-structured-concurrency

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2808,7 +2808,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = revision;
-				revision = 426742cc6f473a90e64e27f1820a033869660d8d;
+				revision = 73951896dfe02bccaf55907bbc56796d1968c2f9;
 			};
 		};
 		E157A719256E9D1D00CBCA52 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {


### PR DESCRIPTION
### What and why?
Add support for async/await methods and tests

With the current implementation of Async/Await and structured concurrency, otel version used for automatic context handling was not working, and some changes were needed. async/await methods and network calling were not inheriting the parent span, so were not associated to the test span.

### How?

Update to otel-swift version supporting async/await

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
