### PR TITLE
CIAPP-2617 - Identify UITests from standard unit tests

### DIFF
--- a/Sources/DatadogSDKTesting/DDTags.swift
+++ b/Sources/DatadogSDKTesting/DDTags.swift
@@ -49,6 +49,7 @@ internal enum DDTestTags {
     static let testExecutionOrder = "test.execution.order"
     static let testExecutionProcessId = "test.execution.processId"
     static let testCodeowners = "test.codeowners"
+    static let testIsUITest = "test.is_ui_test"
 }
 
 internal enum DDOSTags {

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -54,7 +54,7 @@ internal class DDTestObserver: NSObject, XCTestObservation {
         currentBundleFunctionInfo = FileLocator.testFunctionsInModule(currentBundleName)
         #endif
         if let workspacePath = tracer.env.workspacePath {
-            codeOwners = CodeOwners.init(workspacePath: URL(fileURLWithPath:workspacePath))
+            codeOwners = CodeOwners(workspacePath: URL(fileURLWithPath: workspacePath))
         }
 
         if !tracer.env.disableCrashHandler {
@@ -100,6 +100,10 @@ internal class DDTestObserver: NSObject, XCTestObservation {
         ]
 
         let testSpan = tracer.startSpan(name: testCase.name, attributes: attributes)
+
+        // Is not a UITest until a XCUIApplication is launched
+        testSpan.setAttribute(key: DDTestTags.testIsUITest, value: false)
+
         if !tracer.env.disableDDSDKIOSIntegration {
             tracer.addPropagationsHeadersToEnvironment()
         }

--- a/Sources/DatadogSDKTesting/Utils/XCUIApplicationSwizzler.swift
+++ b/Sources/DatadogSDKTesting/Utils/XCUIApplicationSwizzler.swift
@@ -27,6 +27,7 @@ extension XCUIApplication {
 
     @objc
     func swizzled_launch() {
+        DDTestMonitor.instance?.testObserver?.currentTestSpan?.setAttribute(key: DDTestTags.testIsUITest, value: true)
         if let testSpanContext = DDTracer.activeSpan?.context {
             self.launchEnvironment["ENVIRONMENT_TRACER_SPANID"] = testSpanContext.spanId.hexString
             self.launchEnvironment["ENVIRONMENT_TRACER_TRACEID"] = testSpanContext.traceId.hexString


### PR DESCRIPTION
### What and why?
Identify UITests from standard unit tests
@iGranDav told me that it would be useful for them to have an easy way to identify UI tests form the rest.

### How?

Add a special tag for identifying UITests that is automatically set when XCUIApplication is launched

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
