### PR TITLE
CIAPP-2724 Add testing framework version

### DIFF
--- a/Sources/DatadogSDKTesting/DDTags.swift
+++ b/Sources/DatadogSDKTesting/DDTags.swift
@@ -30,7 +30,6 @@ internal enum DDTags {
 }
 
 internal enum DDGenericTags {
-    static let language = "language"
     static let type = "type"
     static let resourceName = "resource.name"
     static let origin = "_dd.origin"
@@ -66,6 +65,11 @@ internal enum DDDeviceTags {
 internal enum DDRuntimeTags {
     static let runtimeName = "runtime.name"
     static let runtimeVersion = "runtime.version"
+}
+
+internal enum DDTracerTags {
+    static let tracerLanguage = "tracer.language"
+    static let tracerVersion = "tracer.version"
 }
 
 internal enum DDGitTags {

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -15,6 +15,7 @@ internal class DDTestObserver: NSObject, XCTestObservation {
 
     static let testNameRegex = try! NSRegularExpression(pattern: "([\\w]+) ([\\w]+)", options: .caseInsensitive)
     static let supportsSkipping = NSClassFromString("XCTSkippedTestContext") != nil
+    static let tracerVersion = (Bundle(for: DDTestObserver.self).infoDictionary?["CFBundleShortVersionString"] as? String) ?? "unknown"
     var currentBundleName = ""
     var currentBundleFunctionInfo = FunctionMap()
     var currentTestExecutionOrder = 0
@@ -80,7 +81,6 @@ internal class DDTestObserver: NSObject, XCTestObservation {
         currentTestExecutionOrder = currentTestExecutionOrder + 1
 
         let attributes: [String: String] = [
-            DDGenericTags.language: "swift",
             DDGenericTags.type: DDTagValues.typeTest,
             DDGenericTags.resourceName: "\(currentBundleName).\(testSuite).\(testName)",
             DDTestTags.testName: testName,
@@ -96,7 +96,9 @@ internal class DDTestObserver: NSObject, XCTestObservation {
             DDDeviceTags.deviceName: tracer.env.deviceName,
             DDDeviceTags.deviceModel: tracer.env.deviceModel,
             DDRuntimeTags.runtimeName: "Xcode",
-            DDRuntimeTags.runtimeVersion: tracer.env.runtimeVersion
+            DDRuntimeTags.runtimeVersion: tracer.env.runtimeVersion,
+            DDTracerTags.tracerLanguage: "swift",
+            DDTracerTags.tracerVersion: DDTestObserver.tracerVersion
         ]
 
         let testSpan = tracer.startSpan(name: testCase.name, attributes: attributes)

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -53,7 +53,7 @@ internal class DDTracer {
         let tracerProvider = OpenTelemetrySDK.instance.tracerProvider
         tracerProvider.updateActiveSampler(Samplers.alwaysOn)
 
-        let bundle = Bundle(for: type(of: self))
+        let bundle = Bundle.main
         let identifier = bundle.bundleIdentifier ?? "com.datadoghq.DatadogSDKTesting"
         let version = (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "unknown"
 


### PR DESCRIPTION
### What and why?

Report tracer language and version as the specification now implies under the tracer tag, it allows reporting the version of the application under testing

### How?

`tracer.language` and `tracer.version` now have the information that will be used in the future for all tracers

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
