### PR TITLE
CIAPP-2667 Add support for new benchmark values in XCTest

### DIFF
--- a/Sources/DatadogSDKTesting/DDTags.swift
+++ b/Sources/DatadogSDKTesting/DDTags.swift
@@ -99,22 +99,49 @@ internal enum DDCITags {
 }
 
 internal enum DDBenchmarkTags {
-    static let benchmarkRuns = "benchmark.runs"
-    static let durationMean = "benchmark.duration.mean"
-    static let memoryTotalBytes = "benchmark.memory.total_bytes_allocations"
-    static let memoryMeanBytes_allocations = "benchmark.memory.mean_bytes_allocations"
-    static let statisticsN = "benchmark.statistics.n"
-    static let statisticsMax = "benchmark.statistics.max"
-    static let statisticsMin = "benchmark.statistics.min"
-    static let statisticsMean = "benchmark.statistics.mean"
-    static let statisticsMedian = "benchmark.statistics.median"
-    static let statisticsStdDev = "benchmark.statistics.std_dev"
-    static let statisticsStdErr = "benchmark.statistics.std_err"
-    static let statisticsKurtosis = "benchmark.statistics.kurtosis"
-    static let statisticsSkewness = "benchmark.statistics.skewness"
-    static let statisticsP99 = "benchmark.statistics.p99"
-    static let statisticsP95 = "benchmark.statistics.p95"
-    static let statisticsP90 = "benchmark.statistics.p90"
+    static let benchmark = "benchmark"
+    static let benchmarkMean = "mean"
+    static let benchmarkRun = "run"
+    static let benchmarkInfo = "info"
+
+    static let statisticsN = "statistics.n"
+    static let statisticsMax = "statistics.max"
+    static let statisticsMin = "statistics.min"
+    static let statisticsMean = "statistics.mean"
+    static let statisticsMedian = "statistics.median"
+    static let statisticsStdDev = "statistics.std_dev"
+    static let statisticsStdErr = "statistics.std_err"
+    static let statisticsKurtosis = "statistics.kurtosis"
+    static let statisticsSkewness = "statistics.skewness"
+    static let statisticsP99 = "statistics.p99"
+    static let statisticsP95 = "statistics.p95"
+    static let statisticsP90 = "statistics.p90"
+}
+
+internal enum DDBenchmarkMeasuresTags: String {
+    case duration
+    case system_time
+    case user_time
+    case run_time
+    case transient_vm_allocations
+    case persistent_vm_allocations
+    case temporary_heap_allocations
+    case persistent_heap_allocations
+    case persistent_heap_allocations_nodes
+    case transient_heap_allocations
+    case transient_heap_allocations_nodes
+    case total_heap_allocations
+    case memory_physical_peak
+    case memory_physical
+    case high_water_mark_vm_allocations
+    case high_water_mark_heap_allocations
+    case application_launch
+    case clock_time_monotonic
+    case cpu_instructions_retired
+    case cpu_cycles
+    case cpu_time
+    case disk_logical_writes
+    case disk_logical_reads
 }
 
 internal enum DDTagValues {

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -181,58 +181,205 @@ internal class DDTestObserver: NSObject, XCTestObservation {
     #endif
 
     private func addBenchmarkTagsIfNeeded(testCase: XCTestCase, activeTest: Span) {
-        guard let metricsForId = testCase.value(forKey: "_perfMetricsForID") as? [XCTPerformanceMetric: AnyObject],
-              let metric = metricsForId.first(where: {
-                  let measurements = $0.value.value(forKey: "measurements") as? [Double]
-                  return (measurements?.count ?? 0) > 0
-              })
-        else {
+        guard let metrics = testCase.value(forKey: "_perfMetricsForID") as? [XCTPerformanceMetric: AnyObject] else {
             return
         }
-
-        guard let measurements = metric.value.value(forKey: "measurements") as? [Double] else {
-            return
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_TotalHeapAllocationsKilobytes")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .total_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
         }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_PersistentVMAllocations")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .persistent_vm_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_RunTime")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
+            addBenchmarkValue(activeTest: activeTest, benchmark: .run_time, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_PersistentHeapAllocations")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .persistent_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_Memory.physical")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .memory_physical, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_CPU.instructions_retired")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1000 } // Convert to instructions
+            addBenchmarkValue(activeTest: activeTest, benchmark: .cpu_instructions_retired, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_CPU.cycles")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            addBenchmarkValue(activeTest: activeTest, benchmark: .cpu_cycles, values: measurements, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_TemporaryHeapAllocationsKilobytes")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .temporary_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_HighWaterMarkForVMAllocations")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .high_water_mark_vm_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_TransientHeapAllocationsKilobytes")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .transient_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "XCTPerformanceMetric_TransientVMAllocationsKilobytes")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .transient_vm_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_Memory.physical_peak")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .memory_physical_peak, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_CPU.time")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
+            addBenchmarkValue(activeTest: activeTest, benchmark: .cpu_time, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_UserTime")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
+            addBenchmarkValue(activeTest: activeTest, benchmark: .user_time, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_HighWaterMarkForHeapAllocations")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 } // Convert to bytes
+            addBenchmarkValue(activeTest: activeTest, benchmark: .high_water_mark_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_SystemTime")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
+            addBenchmarkValue(activeTest: activeTest, benchmark: .system_time, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_Clock.time.monotonic")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
+            addBenchmarkValue(activeTest: activeTest, benchmark: .clock_time_monotonic, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_TransientHeapAllocationsNodes")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            addBenchmarkValue(activeTest: activeTest, benchmark: .transient_heap_allocations_nodes, values: measurements, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_PersistentHeapAllocationsNodes")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 }
+            addBenchmarkValue(activeTest: activeTest, benchmark: .persistent_heap_allocations_nodes, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_Disk.logical_writes")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1024 }
+            addBenchmarkValue(activeTest: activeTest, benchmark: .disk_logical_writes, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_WallClockTime")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
+            addBenchmarkValue(activeTest: activeTest, benchmark: .duration, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+        if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_ApplicationLaunch-AppLaunch.duration")],
+           let measurements = metric.value(forKey: "measurements") as? [Double],
+           measurements.count > 0
+        {
+            let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
+            addBenchmarkValue(activeTest: activeTest, benchmark: .application_launch, values: values, name: metric.value(forKey: "_name") as? String)
+        }
+    }
 
+    private func addBenchmarkValue(activeTest: Span, benchmark: DDBenchmarkMeasuresTags, values: [Double], name: String?) {
         activeTest.setAttribute(key: DDTestTags.testType, value: DDTagValues.typeBenchmark)
-        let values = measurements.map { $0 * 1_000_000_000 } // Convert to nanoseconds
-        activeTest.setAttribute(key: DDBenchmarkTags.benchmarkRuns, value: values.count)
-        activeTest.setAttribute(key: DDBenchmarkTags.statisticsN, value: values.count)
+
+        let tag = DDBenchmarkTags.benchmark + "." + benchmark.rawValue + "."
+
+        activeTest.setAttribute(key: tag + DDBenchmarkTags.benchmarkRun, value: values.count)
+        activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsN, value: values.count)
         if let average = Sigma.average(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.durationMean, value: average)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.benchmarkMean, value: average)
         }
         if let max = Sigma.max(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsMax, value: max)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsMax, value: max)
         }
         if let min = Sigma.min(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsMin, value: min)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsMin, value: min)
         }
         if let mean = Sigma.average(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsMean, value: mean)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsMean, value: mean)
         }
         if let median = Sigma.median(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsMedian, value: median)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsMedian, value: median)
         }
         if let stdDev = Sigma.standardDeviationSample(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsStdDev, value: stdDev)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsStdDev, value: stdDev)
         }
         if let stdErr = Sigma.standardErrorOfTheMean(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsStdErr, value: stdErr)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsStdErr, value: stdErr)
         }
-        if let kurtosis = Sigma.kurtosisA(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsKurtosis, value: kurtosis)
+        if let kurtosis = Sigma.kurtosisA(values), kurtosis.isFinite {
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsKurtosis, value: kurtosis)
         }
-        if let skewness = Sigma.skewnessA(values) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsSkewness, value: skewness)
+        if let skewness = Sigma.skewnessA(values), skewness.isFinite {
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsSkewness, value: skewness)
         }
         if let percentile99 = Sigma.percentile(values, percentile: 0.99) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsP99, value: percentile99)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsP99, value: percentile99)
         }
         if let percentile95 = Sigma.percentile(values, percentile: 0.95) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsP95, value: percentile95)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsP95, value: percentile95)
         }
         if let percentile90 = Sigma.percentile(values, percentile: 0.90) {
-            activeTest.setAttribute(key: DDBenchmarkTags.statisticsP90, value: percentile90)
+            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsP90, value: percentile90)
         }
     }
 }

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -189,197 +189,200 @@ internal class DDTestObserver: NSObject, XCTestObservation {
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .total_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .total_heap_allocations, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_PersistentVMAllocations")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .persistent_vm_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .persistent_vm_allocations, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_RunTime")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
-            addBenchmarkValue(activeTest: activeTest, benchmark: .run_time, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .run_time, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_PersistentHeapAllocations")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .persistent_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .persistent_heap_allocations, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_Memory.physical")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .memory_physical, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .memory_physical, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_CPU.instructions_retired")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1000 } // Convert to instructions
-            addBenchmarkValue(activeTest: activeTest, benchmark: .cpu_instructions_retired, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .cpu_instructions_retired, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_CPU.cycles")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
-            addBenchmarkValue(activeTest: activeTest, benchmark: .cpu_cycles, values: measurements, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .cpu_cycles, values: measurements, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_TemporaryHeapAllocationsKilobytes")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .temporary_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .temporary_heap_allocations, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_HighWaterMarkForVMAllocations")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .high_water_mark_vm_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .high_water_mark_vm_allocations, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_TransientHeapAllocationsKilobytes")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .transient_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .transient_heap_allocations, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "XCTPerformanceMetric_TransientVMAllocationsKilobytes")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .transient_vm_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .transient_vm_allocations, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_Memory.physical_peak")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .memory_physical_peak, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .memory_physical_peak, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_CPU.time")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
-            addBenchmarkValue(activeTest: activeTest, benchmark: .cpu_time, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .cpu_time, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_UserTime")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
-            addBenchmarkValue(activeTest: activeTest, benchmark: .user_time, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .user_time, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_HighWaterMarkForHeapAllocations")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 } // Convert to bytes
-            addBenchmarkValue(activeTest: activeTest, benchmark: .high_water_mark_heap_allocations, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .high_water_mark_heap_allocations, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_SystemTime")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
-            addBenchmarkValue(activeTest: activeTest, benchmark: .system_time, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .system_time, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_Clock.time.monotonic")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
-            addBenchmarkValue(activeTest: activeTest, benchmark: .clock_time_monotonic, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .clock_time_monotonic, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_TransientHeapAllocationsNodes")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
-            addBenchmarkValue(activeTest: activeTest, benchmark: .transient_heap_allocations_nodes, values: measurements, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .transient_heap_allocations_nodes, values: measurements, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_PersistentHeapAllocationsNodes")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 }
-            addBenchmarkValue(activeTest: activeTest, benchmark: .persistent_heap_allocations_nodes, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .persistent_heap_allocations_nodes, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_Disk.logical_writes")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1024 }
-            addBenchmarkValue(activeTest: activeTest, benchmark: .disk_logical_writes, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .disk_logical_writes, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.XCTPerformanceMetric_WallClockTime")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
-            addBenchmarkValue(activeTest: activeTest, benchmark: .duration, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .duration, values: values, info: metric.value(forKey: "_name") as? String)
         }
         if let metric = metrics[XCTPerformanceMetric(rawValue: "com.apple.dt.XCTMetric_ApplicationLaunch-AppLaunch.duration")],
            let measurements = metric.value(forKey: "measurements") as? [Double],
            measurements.count > 0
         {
             let values = measurements.map { $0 * 1000000000 } // Convert to nanoseconds
-            addBenchmarkValue(activeTest: activeTest, benchmark: .application_launch, values: values, name: metric.value(forKey: "_name") as? String)
+            addBenchmarkValue(testSpan: activeTest, benchmark: .application_launch, values: values, info: metric.value(forKey: "_name") as? String)
         }
     }
 
-    private func addBenchmarkValue(activeTest: Span, benchmark: DDBenchmarkMeasuresTags, values: [Double], name: String?) {
-        activeTest.setAttribute(key: DDTestTags.testType, value: DDTagValues.typeBenchmark)
+    private func addBenchmarkValue(testSpan: Span, benchmark: DDBenchmarkMeasuresTags, values: [Double], info: String?) {
+        testSpan.setAttribute(key: DDTestTags.testType, value: DDTagValues.typeBenchmark)
 
         let tag = DDBenchmarkTags.benchmark + "." + benchmark.rawValue + "."
 
-        activeTest.setAttribute(key: tag + DDBenchmarkTags.benchmarkRun, value: values.count)
-        activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsN, value: values.count)
+        if let benchmarkInfo = info {
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.benchmarkInfo, value: benchmarkInfo)
+        }
+        testSpan.setAttribute(key: tag + DDBenchmarkTags.benchmarkRun, value: values.count)
+        testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsN, value: values.count)
         if let average = Sigma.average(values) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.benchmarkMean, value: average)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.benchmarkMean, value: average)
         }
         if let max = Sigma.max(values) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsMax, value: max)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsMax, value: max)
         }
         if let min = Sigma.min(values) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsMin, value: min)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsMin, value: min)
         }
         if let mean = Sigma.average(values) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsMean, value: mean)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsMean, value: mean)
         }
         if let median = Sigma.median(values) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsMedian, value: median)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsMedian, value: median)
         }
         if let stdDev = Sigma.standardDeviationSample(values) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsStdDev, value: stdDev)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsStdDev, value: stdDev)
         }
         if let stdErr = Sigma.standardErrorOfTheMean(values) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsStdErr, value: stdErr)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsStdErr, value: stdErr)
         }
         if let kurtosis = Sigma.kurtosisA(values), kurtosis.isFinite {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsKurtosis, value: kurtosis)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsKurtosis, value: kurtosis)
         }
         if let skewness = Sigma.skewnessA(values), skewness.isFinite {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsSkewness, value: skewness)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsSkewness, value: skewness)
         }
         if let percentile99 = Sigma.percentile(values, percentile: 0.99) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsP99, value: percentile99)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsP99, value: percentile99)
         }
         if let percentile95 = Sigma.percentile(values, percentile: 0.95) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsP95, value: percentile95)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsP95, value: percentile95)
         }
         if let percentile90 = Sigma.percentile(values, percentile: 0.90) {
-            activeTest.setAttribute(key: tag + DDBenchmarkTags.statisticsP90, value: percentile90)
+            testSpan.setAttribute(key: tag + DDBenchmarkTags.statisticsP90, value: percentile90)
         }
     }
 }

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -52,6 +52,8 @@ internal class DDTracer {
 
         let tracerProvider = OpenTelemetrySDK.instance.tracerProvider
         tracerProvider.updateActiveSampler(Samplers.alwaysOn)
+        let spanLimits = tracerProvider.getActiveSpanLimits().settingAttributeCountLimit(1024)
+        tracerProvider.updateActiveSpanLimits(spanLimits)
 
         let bundle = Bundle.main
         let identifier = bundle.bundleIdentifier ?? "com.datadoghq.DatadogSDKTesting"

--- a/Tests/DatadogSDKTesting/DDTestObserverTests.swift
+++ b/Tests/DatadogSDKTesting/DDTestObserverTests.swift
@@ -42,7 +42,7 @@ internal class DDTestObserverTests: XCTestCase {
         let spanData = span.toSpanData()
 
         XCTAssertEqual(spanData.name, "-[DDTestObserverTests testWhenTestCaseWillStartIsCalled_testSpanIsCreated]")
-        XCTAssertEqual(spanData.attributes[DDGenericTags.language]?.description, "swift")
+        XCTAssertEqual(spanData.attributes[DDTracerTags.tracerLanguage]?.description, "swift")
         XCTAssertEqual(spanData.attributes[DDGenericTags.type]?.description, DDTagValues.typeTest)
         XCTAssertEqual(spanData.attributes[DDGenericTags.resourceName]?.description, "\(testBundle).\(testSuite).\(testName)")
         XCTAssertEqual(spanData.attributes[DDTestTags.testName]?.description, testName)
@@ -115,11 +115,13 @@ internal class DDTestObserverTests: XCTestCase {
 
         let spanData = testSpan.toSpanData()
         XCTAssertEqual(spanData.attributes[DDTestTags.testType]?.description, DDTagValues.typeBenchmark)
-        XCTAssertEqual(spanData.attributes[DDBenchmarkTags.durationMean]?.description, "3000000000.0")
-        XCTAssertEqual(spanData.attributes[DDBenchmarkTags.statisticsN]?.description, "5")
-        XCTAssertEqual(spanData.attributes[DDBenchmarkTags.statisticsMin]?.description, "1000000000.0")
-        XCTAssertEqual(spanData.attributes[DDBenchmarkTags.statisticsMax]?.description, "5000000000.0")
-        XCTAssertEqual(spanData.attributes[DDBenchmarkTags.statisticsMedian]?.description, "3000000000.0")
+
+        let measure = DDBenchmarkTags.benchmark + "." + DDBenchmarkMeasuresTags.duration.rawValue + "."
+        XCTAssertEqual(spanData.attributes[measure + DDBenchmarkTags.benchmarkMean]?.description, "3000000000.0")
+        XCTAssertEqual(spanData.attributes[measure + DDBenchmarkTags.statisticsN]?.description, "5")
+        XCTAssertEqual(spanData.attributes[measure + DDBenchmarkTags.statisticsMin]?.description, "1000000000.0")
+        XCTAssertEqual(spanData.attributes[measure + DDBenchmarkTags.statisticsMax]?.description, "5000000000.0")
+        XCTAssertEqual(spanData.attributes[measure + DDBenchmarkTags.statisticsMedian]?.description, "3000000000.0")
 
         self.setValue(nil, forKey: "_activePerformanceMetricIDs")
         self.setValue(nil, forKey: "_perfMetricsForID")


### PR DESCRIPTION
### What and why?

Xcode 13 added support for new benchmark types like memory, cpu and more. Overhaul all benchmarking tags to support any of the possible benchmarks that Xcode supports.

### How?

Parse any possible benchmark value that Xcode returns and use the new benchmark format to report them

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
