### PR TITLE
Report UI settings

### DIFF
--- a/Sources/DatadogSDKTesting/DDTags.swift
+++ b/Sources/DatadogSDKTesting/DDTags.swift
@@ -62,6 +62,12 @@ internal enum DDDeviceTags {
     static let deviceModel = "device.model"
 }
 
+internal enum DDUISettingsTags {
+    static let uiSettingsAppearance = "ui.appearance"
+    static let uiSettingsOrientation = "ui.orientation"
+    static let uiSettingsLocalization = "ui.localization"
+}
+
 internal enum DDRuntimeTags {
     static let runtimeName = "runtime.name"
     static let runtimeVersion = "runtime.version"

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -162,7 +162,7 @@ internal class DDTestMonitor {
             if let data = data as Data? {
                 let decoded = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                 decoded?.forEach {
-                    DDTestMonitor.instance?.currentTest?.setAttribute(key: $0.key, value: $0.value)
+                    DDTestMonitor.instance?.currentTest?.setTag(key: $0.key, value: $0.value)
                 }
             }
 

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -8,9 +8,11 @@
 #if canImport(UIKit)
 import UIKit
 let launchNotificationName = UIApplication.didFinishLaunchingNotification
+let didBecomeActiveNotificationName = UIApplication.didBecomeActiveNotification
 #elseif canImport(Cocoa)
 import Cocoa
 let launchNotificationName = NSApplication.didFinishLaunchingNotification
+let didBecomeActiveNotificationName = NSApplication.didBecomeActiveNotification
 #endif
 
 internal class DDTestMonitor {
@@ -26,7 +28,8 @@ internal class DDTestMonitor {
     var injectHeaders: Bool = false
     var recordPayload: Bool = false
     var maxPayloadSize: Int = defaultPayloadSize
-    var notificationObserver: NSObjectProtocol?
+    var launchNotificationObserver: NSObjectProtocol?
+    var didBecomeActiveNotificationObserver: NSObjectProtocol?
 
     var rLock = NSRecursiveLock()
     private var privateCurrentTest: DDTest?
@@ -61,7 +64,7 @@ internal class DDTestMonitor {
         if DDTestMonitor.tracer.isBinaryUnderUITesting {
             /// If the library is being loaded in a binary launched from a UITest, dont start test observing,
             /// except if testing the tracer itself
-            notificationObserver = NotificationCenter.default.addObserver(
+            launchNotificationObserver = NotificationCenter.default.addObserver(
                 forName: launchNotificationName,
                 object: nil, queue: nil) { _ in
                     /// As crash reporter is initialized in testBundleWillStart() method, we initialize it here
@@ -71,6 +74,31 @@ internal class DDTestMonitor {
                         let launchedSpan = DDTestMonitor.tracer.createSpanFromLaunchContext()
                         let simpleSpan = SimpleSpanData(spanData: launchedSpan.toSpanData())
                         DDCrashes.setCustomData(customData: SimpleSpanSerializer.serializeSpan(simpleSpan: simpleSpan))
+                    }
+                }
+
+            didBecomeActiveNotificationObserver = NotificationCenter.default.addObserver(
+                forName: didBecomeActiveNotificationName,
+                object: nil, queue: nil) { _ in
+                    var data = [DDUISettingsTags.uiSettingsAppearance: PlatformUtils.getAppearance(),
+                                DDUISettingsTags.uiSettingsLocalization: PlatformUtils.getLocalization()]
+                    #if os(iOS)
+                    data[DDUISettingsTags.uiSettingsOrientation] = PlatformUtils.getOrientation()
+                    #endif
+                    let encoded = try? JSONSerialization.data(withJSONObject: data)
+                    let timeout: CFTimeInterval = 1.0
+                    let remotePort = CFMessagePortCreateRemote(nil, "DatadogTestingPort" as CFString)
+                    let status = CFMessagePortSendRequest(remotePort,
+                                                          0x1111, // Arbitrary
+                                                          encoded as CFData?,
+                                                          timeout,
+                                                          timeout,
+                                                          nil,
+                                                          nil)
+                    if status == kCFMessagePortSuccess {
+                        Log.debug("DatadogTestingPort Success: \(data)")
+                    } else {
+                        Log.debug("DatadogTestingPort Error: \(status)")
                     }
                 }
         }
@@ -127,5 +155,22 @@ internal class DDTestMonitor {
 
     func stopStderrCapture() {
         stderrCapturer.stopCapturing()
+    }
+
+    func startAttributeListener() {
+        func attributeCallback(port: CFMessagePort?, msgid: Int32, data: CFData?, info: UnsafeMutableRawPointer?) -> Unmanaged<CFData>? {
+            if let data = data as Data? {
+                let decoded = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+                decoded?.forEach {
+                    DDTestMonitor.instance?.currentTest?.setAttribute(key: $0.key, value: $0.value)
+                }
+            }
+
+            return nil
+        }
+
+        let port = CFMessagePortCreateLocal(nil, "DatadogTestingPort" as CFString, attributeCallback, nil, nil)
+        let runLoopSource = CFMessagePortCreateRunLoopSource(nil, port, 0)
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
     }
 }

--- a/Sources/DatadogSDKTesting/DDTestSession.swift
+++ b/Sources/DatadogSDKTesting/DDTestSession.swift
@@ -18,14 +18,12 @@ public class DDTestSession: NSObject {
     private var executionLock = NSLock()
     private var privateCurrentExecutionOrder = 0
     var currentExecutionOrder: Int {
-        get {
-            executionLock.lock()
-            defer {
-                privateCurrentExecutionOrder += 1
-                executionLock.unlock()
-            }
-            return privateCurrentExecutionOrder
+        executionLock.lock()
+        defer {
+            privateCurrentExecutionOrder += 1
+            executionLock.unlock()
         }
+        return privateCurrentExecutionOrder
     }
 
     init(bundleName: String, startTime: Date?) {
@@ -114,7 +112,6 @@ public class DDTestSuite: NSObject {
     @objc(endWithTime:) public func end(endTime: Date? = nil) {}
     @objc public func end() {}
 
-
     /// Starts a test in this suite
     /// - Parameters:
     ///   - name: name of the suite
@@ -122,6 +119,7 @@ public class DDTestSuite: NSObject {
     @objc public func testStart(name: String, startTime: Date? = nil) -> DDTest {
         return DDTest(name: name, suite: self, session: session, startTime: startTime)
     }
+
     @objc public func testStart(name: String) -> DDTest {
         return testStart(name: name, startTime: nil)
     }
@@ -240,6 +238,7 @@ public class DDTest: NSObject {
         }
 
         span.setAttribute(key: DDTestTags.testStatus, value: testStatus)
+
         DDTestMonitor.instance?.stderrCapturer.syncData()
         if let endTime = endTime {
             span.end(time: endTime)
@@ -307,5 +306,11 @@ public class DDTest: NSObject {
         if let percentile90 = Sigma.percentile(samples, percentile: 0.90) {
             span.setAttribute(key: tag + DDBenchmarkTags.statisticsP90, value: percentile90)
         }
+    }
+}
+
+private func setAttributeIfExist(toSpan span: Span, key: String, value: String?) {
+    if let value = value {
+        span.setAttribute(key: key, value: value)
     }
 }

--- a/Sources/DatadogSDKTesting/DDTestSession.swift
+++ b/Sources/DatadogSDKTesting/DDTestSession.swift
@@ -308,9 +308,3 @@ public class DDTest: NSObject {
         }
     }
 }
-
-private func setAttributeIfExist(toSpan span: Span, key: String, value: String?) {
-    if let value = value {
-        span.setAttribute(key: key, value: value)
-    }
-}

--- a/Sources/DatadogSDKTesting/Utils/PlatformUtils.swift
+++ b/Sources/DatadogSDKTesting/Utils/PlatformUtils.swift
@@ -8,6 +8,7 @@ import Foundation
 #if os(iOS) || os(tvOS) || os(watchOS)
     import UIKit
 #else
+    import Cocoa
     import SystemConfiguration
 #endif
 struct PlatformUtils {
@@ -86,5 +87,74 @@ struct PlatformUtils {
         } else {
             return (ProcessInfo.processInfo.processName, (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "")
         }
+    }
+
+    static func getAppearance() -> String {
+        #if os(iOS) || os(tvOS) || os(watchOS)
+            let appearance: String
+            if #available(iOS 13.0, tvOS 13.0, *) {
+                switch UITraitCollection.current.userInterfaceStyle {
+                    case .unspecified:
+                        appearance = "unspecified"
+                    case .light:
+                        appearance = "light"
+                    case .dark:
+                        appearance = "dark"
+                    @unknown default:
+                        appearance = "unknown"
+                }
+            } else if #available(iOS 12.0, tvOS 12.0, *) {
+                switch UIScreen.main.traitCollection.userInterfaceStyle {
+                    case .dark:
+                        appearance = "dark"
+                    case .light:
+                        appearance = "light"
+                    case .unspecified:
+                        appearance = "unspecified"
+                    @unknown default:
+                        appearance = "unknown"
+                }
+            } else {
+                appearance = "light"
+            }
+
+            return appearance
+        #else
+            if #available(OSX 10.14, *) {
+                return NSApp.effectiveAppearance.name.rawValue
+            } else {
+                return "light"
+            }
+        #endif
+    }
+
+    #if os(iOS)
+        static func getOrientation() -> String {
+            let orientation = UIApplication.shared.keyWindow?.rootViewController?.interfaceOrientation
+            switch orientation {
+                case .unknown:
+                    return "unknown"
+                case .portrait:
+                    return "portrait"
+                case .portraitUpsideDown:
+                    return "portraitUpsideDown"
+                case .landscapeLeft:
+                    return "landscapeRight"
+                case .landscapeRight:
+                    return "landscapeLeft"
+                case .none:
+                    return "unknown"
+                @unknown default:
+                    return "unknown"
+            }
+        }
+    #endif
+
+    static func getLocalization() -> String? {
+        #if os(iOS) || os(tvOS) || os(watchOS)
+            return Locale.current.languageCode
+        #else
+            return NSLocale.current.languageCode
+        #endif
     }
 }

--- a/Sources/DatadogSDKTesting/Utils/XCUIApplicationSwizzler.swift
+++ b/Sources/DatadogSDKTesting/Utils/XCUIApplicationSwizzler.swift
@@ -61,6 +61,7 @@ extension XCUIApplication {
                 "DD_DONT_EXPORT"
             ].forEach(addProcessEnvironmentToLaunch)
         }
+        DDTestMonitor.instance?.startAttributeListener()
         swizzled_launch()
     }
 }


### PR DESCRIPTION
### What and why?

Reports UI setting of tests running: appearance, localization and orientation (only with iOS).

Xcode 13 has a setting for running tests  `runsForEachTargetApplicationUIConfiguration`, this allow the user to run the test just changing these values. 

With the previous code a change in just the orientation of the device of the app would be treated as a retry, and a failure would be marked as flaky, but we really want to fail the test if it fails because of the change of one of these setting. The tags that we are reporting here will also be treated as a configuration tag by the backend, so will be differentiated from the same test running with other settings ( like a test failing in iOS 12 but not on iOS 14 is marked as a failure and not a flaky)

### How?

These settings are only reported on UI tests, and can only be read from the app binary under testing after loading
They are captured in the first  didBecomeActive notification and reported to the the test runner using a Mach port (Using a http server forced the user to allow incoming connections)

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
