### PR TITLE
CIAPP-3060 Reenable NTP clock

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -16,6 +16,18 @@
 		E11295C825F63BA8002719E7 /* DDSymbolAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = E11295C725F63BA8002719E7 /* DDSymbolAddress.c */; };
 		E11295C925F63BA8002719E7 /* DDSymbolAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = E11295C725F63BA8002719E7 /* DDSymbolAddress.c */; };
 		E11295CA25F63BA8002719E7 /* DDSymbolAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = E11295C725F63BA8002719E7 /* DDSymbolAddress.c */; };
+		E114C131274F8A0000B57E08 /* NTPServer.h in Headers */ = {isa = PBXBuildFile; fileRef = E114C12D274F8A0000B57E08 /* NTPServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E114C132274F8A0000B57E08 /* NTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = E114C12E274F8A0000B57E08 /* NTPServer.m */; };
+		E114C133274F8A0000B57E08 /* NTPTypes.c in Sources */ = {isa = PBXBuildFile; fileRef = E114C12F274F8A0000B57E08 /* NTPTypes.c */; };
+		E114C134274F8A0000B57E08 /* NTPTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = E114C130274F8A0000B57E08 /* NTPTypes.h */; };
+		E114C135274F8A1200B57E08 /* NTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = E114C12E274F8A0000B57E08 /* NTPServer.m */; };
+		E114C136274F8A1200B57E08 /* NTPServer.h in Headers */ = {isa = PBXBuildFile; fileRef = E114C12D274F8A0000B57E08 /* NTPServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E114C137274F8A1200B57E08 /* NTPTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = E114C130274F8A0000B57E08 /* NTPTypes.h */; };
+		E114C138274F8A1200B57E08 /* NTPTypes.c in Sources */ = {isa = PBXBuildFile; fileRef = E114C12F274F8A0000B57E08 /* NTPTypes.c */; };
+		E114C139274F8A1400B57E08 /* NTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = E114C12E274F8A0000B57E08 /* NTPServer.m */; };
+		E114C13A274F8A1400B57E08 /* NTPServer.h in Headers */ = {isa = PBXBuildFile; fileRef = E114C12D274F8A0000B57E08 /* NTPServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E114C13B274F8A1400B57E08 /* NTPTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = E114C130274F8A0000B57E08 /* NTPTypes.h */; };
+		E114C13C274F8A1400B57E08 /* NTPTypes.c in Sources */ = {isa = PBXBuildFile; fileRef = E114C12F274F8A0000B57E08 /* NTPTypes.c */; };
 		E117CFC526306BB200ACE977 /* DDNetworkInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14AA0BF2555A9A1003FA711 /* DDNetworkInstrumentationTests.swift */; };
 		E117CFC726307B9A00ACE977 /* SpySpanProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E117CFC626307B9A00ACE977 /* SpySpanProcessor.swift */; };
 		E117CFC826307B9A00ACE977 /* SpySpanProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E117CFC626307B9A00ACE977 /* SpySpanProcessor.swift */; };
@@ -50,6 +62,9 @@
 		E15264AF25FA3C16008B8665 /* DDSymbolicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15264AE25FA3C16008B8665 /* DDSymbolicatorTests.swift */; };
 		E15264B025FA3C16008B8665 /* DDSymbolicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15264AE25FA3C16008B8665 /* DDSymbolicatorTests.swift */; };
 		E15264B125FA3C16008B8665 /* DDSymbolicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15264AE25FA3C16008B8665 /* DDSymbolicatorTests.swift */; };
+		E1550C45274F7FF700006F11 /* NTPClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1550C44274F7FF700006F11 /* NTPClock.swift */; };
+		E1550C46274F7FF700006F11 /* NTPClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1550C44274F7FF700006F11 /* NTPClock.swift */; };
+		E1550C47274F7FF700006F11 /* NTPClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1550C44274F7FF700006F11 /* NTPClock.swift */; };
 		E157A721256E9D1D00CBCA52 /* DatadogSDKTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = E1ABA04D25231E2500ED8AEF /* DatadogSDKTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E157A723256E9D1D00CBCA52 /* SwiftExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E116D7DA25248C390022779D /* SwiftExtensions.swift */; };
 		E157A724256E9D1D00CBCA52 /* DDTestMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA08A252341EA00ED8AEF /* DDTestMonitor.swift */; };
@@ -400,6 +415,11 @@
 		E10034D92703599D00439C9C /* DDTestSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTestSession.swift; sourceTree = "<group>"; };
 		E11295BA25F2483D002719E7 /* FileLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLocator.swift; sourceTree = "<group>"; };
 		E11295C725F63BA8002719E7 /* DDSymbolAddress.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = DDSymbolAddress.c; sourceTree = "<group>"; };
+		E114C12D274F8A0000B57E08 /* NTPServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NTPServer.h; sourceTree = "<group>"; };
+		E114C12E274F8A0000B57E08 /* NTPServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NTPServer.m; sourceTree = "<group>"; };
+		E114C12F274F8A0000B57E08 /* NTPTypes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NTPTypes.c; sourceTree = "<group>"; };
+		E114C130274F8A0000B57E08 /* NTPTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NTPTypes.h; sourceTree = "<group>"; };
+		E114C13D274F8A2600B57E08 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		E116D7DA25248C390022779D /* SwiftExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		E117CFC626307B9A00ACE977 /* SpySpanProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySpanProcessor.swift; sourceTree = "<group>"; };
 		E1193F8C272C24F900E4154E /* UIIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIIntegrationTests.swift; sourceTree = "<group>"; };
@@ -457,6 +477,7 @@
 		E14AA0BF2555A9A1003FA711 /* DDNetworkInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNetworkInstrumentationTests.swift; sourceTree = "<group>"; };
 		E14AA0C9255AE8D3003FA711 /* SignalUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalUtilsTests.swift; sourceTree = "<group>"; };
 		E15264AE25FA3C16008B8665 /* DDSymbolicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSymbolicatorTests.swift; sourceTree = "<group>"; };
+		E1550C44274F7FF700006F11 /* NTPClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPClock.swift; sourceTree = "<group>"; };
 		E157A74D256E9D1D00CBCA52 /* DatadogSDKTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogSDKTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E157A785256E9D3300CBCA52 /* DatadogSDKTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogSDKTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E157A7A3256EB0F000CBCA52 /* DatadogSDKTestingTests_macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogSDKTestingTests_macOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -642,6 +663,7 @@
 				E12515E4254892C500670D23 /* XCUIApplicationSwizzler.swift */,
 				E11295BA25F2483D002719E7 /* FileLocator.swift */,
 				E1A63F5B26789915002F48FA /* CodeOwners.swift */,
+				E1550C44274F7FF700006F11 /* NTPClock.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -952,6 +974,18 @@
 			path = heads;
 			sourceTree = "<group>";
 		};
+		E1550C32274F7E7900006F11 /* NTPKit */ = {
+			isa = PBXGroup;
+			children = (
+				E114C13D274F8A2600B57E08 /* LICENSE */,
+				E114C12D274F8A0000B57E08 /* NTPServer.h */,
+				E114C12E274F8A0000B57E08 /* NTPServer.m */,
+				E114C12F274F8A0000B57E08 /* NTPTypes.c */,
+				E114C130274F8A0000B57E08 /* NTPTypes.h */,
+			);
+			path = NTPKit;
+			sourceTree = "<group>";
+		};
 		E160A113252B3A6B003121A5 /* include */ = {
 			isa = PBXGroup;
 			children = (
@@ -1053,6 +1087,7 @@
 		E1ABA06B25231F3200ED8AEF /* Objc */ = {
 			isa = PBXGroup;
 			children = (
+				E1550C32274F7E7900006F11 /* NTPKit */,
 				E160A113252B3A6B003121A5 /* include */,
 				E1ABA06C25231F3200ED8AEF /* LibraryInitializer.m */,
 				E11295C725F63BA8002719E7 /* DDSymbolAddress.c */,
@@ -1205,7 +1240,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				E157A721256E9D1D00CBCA52 /* DatadogSDKTesting.h in Headers */,
+				E114C136274F8A1200B57E08 /* NTPServer.h in Headers */,
 				E1D6EFA325F6631E00E8C3AE /* DDSymbolAddress.h in Headers */,
+				E114C137274F8A1200B57E08 /* NTPTypes.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1214,7 +1251,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				E157A759256E9D3300CBCA52 /* DatadogSDKTesting.h in Headers */,
+				E114C13A274F8A1400B57E08 /* NTPServer.h in Headers */,
 				E1D6EFA425F6632B00E8C3AE /* DDSymbolAddress.h in Headers */,
+				E114C13B274F8A1400B57E08 /* NTPTypes.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1223,7 +1262,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				E1ABA05B25231E2500ED8AEF /* DatadogSDKTesting.h in Headers */,
+				E114C131274F8A0000B57E08 /* NTPServer.h in Headers */,
 				E1D6EFA225F6631200E8C3AE /* DDSymbolAddress.h in Headers */,
+				E114C134274F8A0000B57E08 /* NTPTypes.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1757,10 +1798,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				E11295BC25F2483D002719E7 /* FileLocator.swift in Sources */,
+				E114C135274F8A1200B57E08 /* NTPServer.m in Sources */,
+				E114C138274F8A1200B57E08 /* NTPTypes.c in Sources */,
 				E157A723256E9D1D00CBCA52 /* SwiftExtensions.swift in Sources */,
 				E10034DE27035A7800439C9C /* DDTestSession.swift in Sources */,
 				E1F422A82654F28200233B75 /* OriginSpanProcessor.swift in Sources */,
 				E1665A8225D13BBB00BA53CD /* DDSymbolicator.swift in Sources */,
+				E1550C46274F7FF700006F11 /* NTPClock.swift in Sources */,
 				E1C189BA270F193F00188C0E /* Log.swift in Sources */,
 				E1A63F5D26789915002F48FA /* CodeOwners.swift in Sources */,
 				E157A724256E9D1D00CBCA52 /* DDTestMonitor.swift in Sources */,
@@ -1793,10 +1837,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				E11295BD25F2483D002719E7 /* FileLocator.swift in Sources */,
+				E114C139274F8A1400B57E08 /* NTPServer.m in Sources */,
+				E114C13C274F8A1400B57E08 /* NTPTypes.c in Sources */,
 				E157A75B256E9D3300CBCA52 /* SwiftExtensions.swift in Sources */,
 				E10034E027035A7900439C9C /* DDTestSession.swift in Sources */,
 				E1F422A92654F28200233B75 /* OriginSpanProcessor.swift in Sources */,
 				E1665A8125D13BBB00BA53CD /* DDSymbolicator.swift in Sources */,
+				E1550C47274F7FF700006F11 /* NTPClock.swift in Sources */,
 				E1C189BB270F193F00188C0E /* Log.swift in Sources */,
 				E1A63F5E26789915002F48FA /* CodeOwners.swift in Sources */,
 				E157A75C256E9D3300CBCA52 /* DDTestMonitor.swift in Sources */,
@@ -1881,10 +1928,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				E11295BB25F2483D002719E7 /* FileLocator.swift in Sources */,
+				E114C132274F8A0000B57E08 /* NTPServer.m in Sources */,
+				E114C133274F8A0000B57E08 /* NTPTypes.c in Sources */,
 				E1AD079F252F5B00003705C1 /* SwiftExtensions.swift in Sources */,
 				E10034DC27035A7700439C9C /* DDTestSession.swift in Sources */,
 				E1F422A72654F28200233B75 /* OriginSpanProcessor.swift in Sources */,
 				E1D6EFA525F6647F00E8C3AE /* LibraryInitializer.m in Sources */,
+				E1550C45274F7FF700006F11 /* NTPClock.swift in Sources */,
 				E1C189B9270F193F00188C0E /* Log.swift in Sources */,
 				E1A63F5C26789915002F48FA /* CodeOwners.swift in Sources */,
 				E1665A8525D1524100BA53CD /* DDSymbolicator.swift in Sources */,

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,3 +2,4 @@ Component,Origin,License,Copyright
 import,opentelemetry-swift,Apache-2.0,Copyright 2020 - OpenTelemetry Authors
 import,PLCrashReporter,MIT,Copyright Microsoft Corporation
 import,SigmaSwiftStatistics,MIT,Copyright 2015 - Evgenii Neumerzhitckii
+import,NTPKit,BSD 2-Clause,Copyright 2016 - Nicholas Cvitak

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -54,8 +54,7 @@ internal class DDTracer {
         tracerProvider.updateActiveSampler(Samplers.alwaysOn)
         let spanLimits = tracerProvider.getActiveSpanLimits().settingAttributeCountLimit(1024)
         tracerProvider.updateActiveSpanLimits(spanLimits)
-        // This is currently not working as expected, reports duration 0 sometimes
-        // tracerProvider.updateActiveClock(NTPClock())
+        tracerProvider.updateActiveClock(NTPClock())
 
         let bundle = Bundle.main
         let identifier = bundle.bundleIdentifier ?? "com.datadoghq.DatadogSDKTesting"

--- a/Sources/DatadogSDKTesting/DatadogSDKTesting.h
+++ b/Sources/DatadogSDKTesting/DatadogSDKTesting.h
@@ -13,3 +13,4 @@ FOUNDATION_EXPORT double DatadogSDKTestingVersionNumber;
 FOUNDATION_EXPORT const unsigned char DatadogSDKTestingVersionString[];
 
 #import <DatadogSDKTesting/DDSymbolAddress.h>
+#import <DatadogSDKTesting/NTPServer.h>

--- a/Sources/DatadogSDKTesting/Objc/NTPKit/LICENSE
+++ b/Sources/DatadogSDKTesting/Objc/NTPKit/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2016, Nicholas Cvitak
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Sources/DatadogSDKTesting/Objc/NTPKit/NTPServer.h
+++ b/Sources/DatadogSDKTesting/Objc/NTPKit/NTPServer.h
@@ -1,0 +1,49 @@
+//
+//  NTPServer.h
+//  NTPKit
+//
+//  Created by Nico Cvitak on 2016-05-01.
+//  Copyright © 2016 Nicholas Cvitak. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NTPServer : NSObject
+
+NS_ASSUME_NONNULL_BEGIN
+
+//! The server's hostname.
+@property (readonly, strong, nonatomic) NSString *hostname;
+//! The server's port.
+@property (readonly, assign, nonatomic) NSUInteger port;
+//! The NTP request timeout.
+@property (assign, atomic) NSTimeInterval timeout;
+//! The server's connection status.
+@property (readonly, atomic, getter=isConnected) BOOL connected;
+//! The current offset with ntp server.
+@property (readonly, atomic) NSTimeInterval offset;
+
+//! The default NTP server.
+@property (class, readonly, nonatomic) NTPServer *defaultServer;
+
+//! Initializes an NTP server with it's hostname and port.
+- (instancetype)initWithHostname:(NSString *)hostname port:(NSUInteger)port NS_DESIGNATED_INITIALIZER;
+//! Initializes an NTP server with it's hostname and the default NTP port.
+- (instancetype)initWithHostname:(NSString *)hostname;
+//! Initializes an NTP server with the default hostname and port.
+- (instancetype)init;
+
+//! Attempts to connect to the NTP server.
+- (BOOL)connectWithError:(NSError *__autoreleasing _Nullable *_Nullable)error NS_REQUIRES_SUPER;
+//! Disconnects from the NTP server.
+- (void)disconnect NS_REQUIRES_SUPER;
+
+//! Attempts to perform an NTP sync request.
+- (BOOL)syncWithError:(NSError *__autoreleasing _Nullable *_Nullable)error NS_REQUIRES_SUPER;
+
+//! Returns the NTP date based on the last sync request.
+- (nullable NSDate *)dateWithError:(NSError *__autoreleasing _Nullable *_Nullable)error;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/Sources/DatadogSDKTesting/Objc/NTPKit/NTPServer.m
+++ b/Sources/DatadogSDKTesting/Objc/NTPKit/NTPServer.m
@@ -1,0 +1,238 @@
+//
+//  NTPServer.m
+//  NTPKit
+//
+//  Created by Nico Cvitak on 2016-05-01.
+//  Copyright © 2016 Nicholas Cvitak. All rights reserved.
+//
+
+#import "NTPServer.h"
+
+#import "NTPTypes.h"
+
+#import <arpa/inet.h>
+#import <assert.h>
+#import <netdb.h>
+#import <sys/time.h>
+
+@implementation NTPServer {
+    NSTimeInterval _timeout;
+    int _socket;
+}
+
+//! The number of seconds from 1900 to 1970
+static const uint32_t kSecondsFrom1900To1970 = 2208988800UL;
+
+//! Returns the local time as an NTP ufixed64 timestamp
+static ufixed64_t ntp_localtime_get_ufixed64() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return ufixed64((uint32_t)tv.tv_sec + kSecondsFrom1900To1970, tv.tv_usec * (pow(2, 32) / USEC_PER_SEC));
+}
+
++ (NTPServer *)defaultServer {
+    static NTPServer *server = nil;
+    static dispatch_once_t onceToken = 0;
+    dispatch_once(&onceToken, ^{
+        server = [[NTPServer alloc] init];
+    });
+    return server;
+}
+
+- (instancetype)initWithHostname:(NSString *)hostname port:(NSUInteger)port {
+    self = [super init];
+    if (self) {
+        _hostname = [hostname copy];
+        _port = port;
+        _timeout = 5.0;
+        _socket = -1;
+        
+        _offset = NAN;
+    }
+    return self;
+}
+
+- (instancetype)initWithHostname:(NSString *)hostname {
+    return [self initWithHostname:hostname port:123];
+}
+
+- (instancetype)init {
+    return [self initWithHostname:@"pool.ntp.org"];
+}
+
+- (void)dealloc {
+    [self disconnect];
+}
+
+- (void)setTimeout:(NSTimeInterval)timeout {
+    assert(timeout > 0 && isfinite(timeout));
+    @synchronized (self) {
+        _timeout = timeout;
+        if (_socket >= 0) {
+            struct timeval tv = { .tv_sec = _timeout, .tv_usec = (_timeout - trunc(_timeout)) * USEC_PER_SEC };
+            setsockopt(_socket, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+            setsockopt(_socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        }
+        
+    }
+}
+
+- (NSTimeInterval)timeout {
+    @synchronized (self) {
+        return _timeout;
+    }
+}
+
+- (BOOL)isConnected {
+    @synchronized (self) {
+        return _socket >= 0;
+    }
+}
+
+- (BOOL)connectWithError:(NSError *__autoreleasing _Nullable *_Nullable)error {
+    @synchronized (self) {
+        if (_socket >= 0) {
+            return YES;
+        }
+        
+        // setup hints.
+        struct addrinfo hints = {0}, *addrinfo = NULL;
+        hints.ai_family = AF_UNSPEC; // getaddrinfo will resolve (AF_INET or AF_INET6)
+        hints.ai_socktype = SOCK_DGRAM; // UDP
+        
+        // get port string.
+        NSString *port = [[NSString alloc] initWithFormat:@"%lu", (unsigned long) _port];
+        
+        // get address info.
+        int getaddrinfo_err = getaddrinfo(_hostname.UTF8String, port.UTF8String, &hints, &addrinfo);
+        if (getaddrinfo_err != 0) {
+            if (error) {
+                NSString *errorDescription = [[NSString alloc] initWithUTF8String:gai_strerror(getaddrinfo_err)];
+                NSDictionary *errorInfo = [[NSDictionary alloc] initWithObjectsAndKeys:errorDescription, NSLocalizedDescriptionKey, nil];
+                *error = [NSError errorWithDomain:@"netdb" code:getaddrinfo_err userInfo:errorInfo];
+            }
+            return NO;
+        }
+        
+        // create the socket.
+        const int sock = socket(addrinfo->ai_family, addrinfo->ai_socktype, addrinfo->ai_protocol);
+        if (sock < 0) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:nil];
+            }
+            freeaddrinfo(addrinfo);
+            return NO;
+        }
+        
+        // set nonblocking.
+        fcntl(sock, F_SETFL, fcntl(sock, F_GETFL, 0) | O_NONBLOCK);
+        
+        // connect async with timeout.
+        struct timeval timeout = { .tv_sec = _timeout, .tv_usec = (_timeout - trunc(_timeout)) * USEC_PER_SEC };
+        int connect_err = connect(sock, addrinfo->ai_addr, addrinfo->ai_addrlen) ? errno : 0;
+        if (connect_err == EINPROGRESS) {
+            fd_set fd;
+            FD_ZERO(&fd);
+            FD_SET(sock, &fd);
+            
+            const int select_err = select(sock + 1, &fd, &fd, NULL, &timeout);
+            if (select_err <= 0) {
+                connect_err = select_err ? errno : ETIMEDOUT;
+            } else {
+                socklen_t optlen = sizeof(connect_err);
+                getsockopt(sock, SOL_SOCKET, SO_ERROR, &connect_err, &optlen);
+            }
+        }
+        freeaddrinfo(addrinfo);
+        if (connect_err) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:connect_err userInfo:nil];
+            }
+            close(sock);
+            return NO;
+        }
+        
+        // set blocking.
+        fcntl(sock, F_SETFL, fcntl(sock, F_GETFL, 0) & ~O_NONBLOCK);
+        
+        // set timeout.
+        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+        
+        [self willChangeValueForKey:@"connected"];
+        _socket = sock;
+        [self didChangeValueForKey:@"connected"];
+        
+        return YES;
+    }
+}
+
+- (void)disconnect {
+    @synchronized (self) {
+        if (_socket >= 0) {
+            close(_socket);
+            
+            [self willChangeValueForKey:@"connected"];
+            _socket = -1;
+            [self didChangeValueForKey:@"connected"];
+        }
+    }
+}
+
+- (BOOL)syncWithError:(NSError *__autoreleasing _Nullable *_Nullable)error {
+    @synchronized (self) {
+        if (![self connectWithError:error]) {
+            return NO;
+        }
+        
+        // setup NTP packet.
+        ntp_packet_t packet = {0};
+        packet.version_number = 4; // NTPv4.
+        packet.mode = 3; // client mode.
+        packet.transmit_timestamp = ntp_localtime_get_ufixed64(); // client transmit time.
+        
+        // convert to network byte order.
+        packet = hton_ntp_packet(packet);
+        
+        // send packet to server.
+        const ssize_t send_s = send(_socket, &packet, sizeof(packet), 0);
+        const int send_err = send_s == sizeof(packet) ? 0 : send_s >= 0 ? EIO : errno;
+        if (send_err) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:send_err userInfo:nil];
+            }
+            return NO;
+        }
+        
+        // receive packet from server.
+        const ssize_t recv_s = recv(_socket, &packet, sizeof(packet), 0);
+        const int recv_err = recv_s == sizeof(packet) ? 0 : recv_s >= 0 ? EIO : errno;
+        if (recv_err) {
+            if (error) {
+                *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:recv_err userInfo:nil];
+            }
+            return NO;
+        }
+        
+        // convert to host byte order.
+        packet = ntoh_ntp_packet(packet);
+        
+        // calculate and update host delay.
+        const double T[4] = {
+            ufixed64_as_double(packet.originate_timestamp), // client transmit time.
+            ufixed64_as_double(packet.receive_timestamp), // server receive time.
+            ufixed64_as_double(packet.transmit_timestamp), // server transmit time.
+            ufixed64_as_double(ntp_localtime_get_ufixed64()), // client receive time.
+        };
+        _offset = ((T[1] - T[0]) + (T[2] - T[3])) / 2.0;
+        return YES;
+    }
+}
+
+- (nullable NSDate *)dateWithError:(NSError *__autoreleasing _Nullable *_Nullable)error {
+    @synchronized (self) {
+        return isfinite(_offset) || [self syncWithError:error] ? [NSDate dateWithTimeIntervalSinceNow:_offset] : nil;
+    }
+}
+
+@end

--- a/Sources/DatadogSDKTesting/Objc/NTPKit/NTPTypes.c
+++ b/Sources/DatadogSDKTesting/Objc/NTPKit/NTPTypes.c
@@ -1,0 +1,69 @@
+//
+//  NTPTypes.c
+//  NTPKit
+//
+//  Created by Nico Cvitak on 2016-05-02.
+//  Copyright © 2016 Nicholas Cvitak. All rights reserved.
+//
+
+#include "NTPTypes.h"
+
+#include <assert.h>
+#include <math.h>
+#include <stdlib.h>
+
+ufixed32_t ufixed32(uint16_t whole, uint16_t fraction) {
+    return (struct ufixed32) { .whole = whole, .fraction = fraction };
+}
+
+ufixed64_t ufixed64(uint32_t whole, uint32_t fraction) {
+    return (struct ufixed64) { .whole = whole, .fraction = fraction };
+}
+
+double ufixed64_as_double(ufixed64_t uf64) {
+    return uf64.whole + uf64.fraction * pow(2, -32);
+}
+
+ufixed64_t ufixed64_with_double(double value) {
+    assert(value >= 0);
+    return ufixed64(value, (value - trunc(value) * pow(2, 32)));
+}
+
+ufixed32_t hton_ufixed32(ufixed32_t uf32) {
+    return ufixed32(htons(uf32.whole), htons(uf32.fraction));
+}
+ufixed32_t ntoh_ufixed32(ufixed32_t uf32) {
+    return ufixed32(ntohs(uf32.whole), ntohs(uf32.fraction));
+}
+
+ufixed64_t hton_ufixed64(ufixed64_t uf64) {
+    return ufixed64(htonl(uf64.whole), htonl(uf64.fraction));
+}
+ufixed64_t ntoh_ufixed64(ufixed64_t uf64) {
+    return ufixed64(ntohl(uf64.whole), ntohl(uf64.fraction));
+}
+
+ntp_packet_t hton_ntp_packet(ntp_packet_t p) {
+    p.root_delay = hton_ufixed32(p.root_delay);
+    p.root_dispersion = hton_ufixed32(p.root_dispersion);
+    
+    p.reference_timestamp = hton_ufixed64(p.reference_timestamp);
+    p.originate_timestamp = hton_ufixed64(p.originate_timestamp);
+    p.receive_timestamp = hton_ufixed64(p.receive_timestamp);
+    p.transmit_timestamp = hton_ufixed64(p.transmit_timestamp);
+    
+    return p;
+}
+
+ntp_packet_t ntoh_ntp_packet(ntp_packet_t p) {
+    p.root_delay = ntoh_ufixed32(p.root_delay);
+    p.root_dispersion = ntoh_ufixed32(p.root_dispersion);
+    
+    p.reference_timestamp = ntoh_ufixed64(p.reference_timestamp);
+    p.originate_timestamp = ntoh_ufixed64(p.originate_timestamp);
+    p.receive_timestamp = ntoh_ufixed64(p.receive_timestamp);
+    p.transmit_timestamp = ntoh_ufixed64(p.transmit_timestamp);
+    
+    return p;
+}
+

--- a/Sources/DatadogSDKTesting/Objc/NTPKit/NTPTypes.h
+++ b/Sources/DatadogSDKTesting/Objc/NTPKit/NTPTypes.h
@@ -1,0 +1,59 @@
+//
+//  NTPTypes.h
+//  NTPKit
+//
+//  Created by Nico Cvitak on 2016-05-02.
+//  Copyright © 2016 Nicholas Cvitak. All rights reserved.
+//
+
+#ifndef NTPTypes_h
+#define NTPTypes_h
+
+#include <stdint.h>
+
+typedef struct ufixed32 {
+    uint16_t whole, fraction;
+} ufixed32_t;
+
+ufixed32_t ufixed32(uint16_t whole, uint16_t fraction);
+
+typedef struct ufixed64 {
+    uint32_t whole, fraction;
+} ufixed64_t;
+
+ufixed64_t ufixed64(uint32_t whole, uint32_t fraction);
+
+double ufixed64_as_double(ufixed64_t);
+ufixed64_t ufixed64_with_double(double);
+
+typedef struct ntp_packet_t {
+    uint8_t	mode : 3;
+    uint8_t	version_number : 3;
+    uint8_t	leap_indicator : 2;
+    
+    uint8_t stratum;
+    uint8_t poll;
+    uint8_t precision;
+    
+    ufixed32_t root_delay;
+    ufixed32_t root_dispersion;
+    uint8_t reference_identifier[4];
+    
+    ufixed64_t reference_timestamp;
+    ufixed64_t originate_timestamp;
+    ufixed64_t receive_timestamp;
+    ufixed64_t transmit_timestamp;
+} ntp_packet_t;
+
+
+
+ufixed32_t hton_ufixed32(ufixed32_t);
+ufixed32_t ntoh_ufixed32(ufixed32_t);
+
+ufixed64_t hton_ufixed64(ufixed64_t);
+ufixed64_t ntoh_ufixed64(ufixed64_t);
+
+ntp_packet_t hton_ntp_packet(ntp_packet_t);
+ntp_packet_t ntoh_ntp_packet(ntp_packet_t);
+
+#endif /* NTPTypes_h */

--- a/Sources/DatadogSDKTesting/Utils/NTPClock.swift
+++ b/Sources/DatadogSDKTesting/Utils/NTPClock.swift
@@ -14,7 +14,14 @@ class NTPClock: Clock {
         let ntpServer = NTPServer.default
         do {
             try ntpServer.sync()
-            ntpOffset = ntpServer.offset
+            let serverOffset = ntpServer.offset
+            if serverOffset.isFinite {
+                ntpOffset = serverOffset
+            } else {
+                ntpOffset = 0
+                Log.debug("NTP server invalid time")
+            }
+
         } catch {
             ntpOffset = 0
             Log.debug("NTP server fail to connect")

--- a/Sources/DatadogSDKTesting/Utils/NTPClock.swift
+++ b/Sources/DatadogSDKTesting/Utils/NTPClock.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-2021 Datadog, Inc.
+ */
+
+import Foundation
+@_implementationOnly import OpenTelemetrySdk
+
+class NTPClock: Clock {
+    let ntpOffset: TimeInterval
+
+    init() {
+        let ntpServer = NTPServer.default
+        do {
+            try ntpServer.sync()
+            ntpOffset = ntpServer.offset
+        } catch {
+            ntpOffset = 0
+            Log.debug("NTP server fail to connect")
+        }
+    }
+
+    var now: Date {
+        let current = Date()
+        return current.addingTimeInterval(ntpOffset)
+    }
+}


### PR DESCRIPTION
### What and why?

Reenabled NTP clock functionality, since previous implementation was removed after returning some invalid values. 

### How?

Changed from Kronos to good-old NTPKit that we only use to recover the time offset. We are providing NTPKit here because it does not support SPM and is not going to change


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
