### PR TITLE
Add call stack to all network requests by default

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -2891,7 +2891,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = revision;
-				revision = 73d6eb7a0ebe7c0e595823e9b33273222f0e2411;
+				revision = 0b391683832a172bcb92dda69718d8f44b1adaf9;
 			};
 		};
 		E157A719256E9D1D00CBCA52 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {

--- a/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
+++ b/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
@@ -18,6 +18,8 @@ internal struct DDEnvironmentValues {
     let disableNetworkInstrumentation: Bool
     let disableHeadersInjection: Bool
     let enableRecordPayload: Bool
+    let disableNetworkCallStack: Bool
+    let enableNetworkCallStackSymbolicated: Bool
     let maxPayloadSize: Int?
     let enableStdoutInstrumentation: Bool
     let enableStderrInstrumentation: Bool
@@ -155,6 +157,12 @@ internal struct DDEnvironmentValues {
 
         let envRecordPayload = DDEnvironmentValues.getEnvVariable("DD_ENABLE_RECORD_PAYLOAD") as NSString?
         enableRecordPayload = envRecordPayload?.boolValue ?? false
+
+        let envNetworkCallStack = DDEnvironmentValues.getEnvVariable("DD_DISABLE_NETWORK_CALL_STACK") as NSString?
+        disableNetworkCallStack = envNetworkCallStack?.boolValue ?? false
+
+        let envNetworkCallStackSymbolicated = DDEnvironmentValues.getEnvVariable("DD_ENABLE_NETWORK_CALL_STACK_SYMBOLICATED") as NSString?
+        enableNetworkCallStackSymbolicated = envNetworkCallStackSymbolicated?.boolValue ?? false
 
         let envMaxPayloadSize = DDEnvironmentValues.getEnvVariable("DD_MAX_PAYLOAD_SIZE") as NSString?
         maxPayloadSize = envMaxPayloadSize?.integerValue

--- a/Sources/DatadogSDKTesting/DDTags.swift
+++ b/Sources/DatadogSDKTesting/DDTags.swift
@@ -28,6 +28,10 @@ internal enum DDTags {
     static let httpStatusCode = "http.status_code"
     /// Expected value: `String`
     static let httpUrl = "http.url"
+
+    /// Expected value: `String`
+    static let callStack = "call_stack"
+
 }
 
 internal enum DDGenericTags {

--- a/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
+++ b/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
@@ -42,6 +42,10 @@ extension String {
 
         return My.regex.stringByReplacingMatches(in: self, range: NSRange(0 ..< self.utf16.count), withTemplate: " $0").trimmingCharacters(in: CharacterSet(charactersIn: " "))
     }
+
+    func contains(exactWord: String) -> Bool {
+        return self.range(of: "\\b\(exactWord)\\b", options: .regularExpression) != nil
+    }
 }
 
 extension Data {

--- a/Tests/DatadogSDKTesting/Crashes/DDSymbolicatorTests.swift
+++ b/Tests/DatadogSDKTesting/Crashes/DDSymbolicatorTests.swift
@@ -8,6 +8,33 @@
 import XCTest
 
 class DDSymbolicatorTests: XCTestCase {
+    func testGetCallStack() {
+        let callStack = DDSymbolicator.getCallStack()
+        XCTAssert(callStack[0].hasPrefix("0 "))
+        XCTAssert(callStack[0].contains("DDSymbolicatorTests.testGetCallStack() -> ()"))
+    }
+
+    func testGetCallStackSymbolicated() {
+        let bundleName = Bundle(for: DDSymbolicatorTests.self).bundleURL.deletingPathExtension().lastPathComponent
+        DDSymbolicator.createDSYMFileIfNeeded(forImageName: bundleName)
+
+        let callStack = DDSymbolicator.getCallStackSymbolicated()
+#if os(tvOS)
+        XCTAssert(callStack[0].hasPrefix("0 "))
+        XCTAssert(callStack[0].contains("DDSymbolicatorTests.testGetCallStackSymbolicated() -> ()"))
+#else
+        XCTAssert(callStack[0].hasPrefix("0 "))
+        XCTAssert(callStack[0].contains("DDSymbolicatorTests.testGetCallStackSymbolicated()"))
+#if os(macOS)
+        XCTAssert(callStack[0].contains("(in DatadogSDKTestingTests_macOS)"))
+#else
+        XCTAssert(callStack[0].contains("(in DatadogSDKTestingTests_iOS)"))
+#endif
+        XCTAssert(callStack[0].contains("(/Users/nacho.bonafontearruga/projects/dd-sdk-swift-testing/Tests/DatadogSDKTesting/Crashes/DDSymbolicatorTests.swift:21)"))
+
+#endif
+    }
+
     func testGenerateSwiftName1() throws {
         let className = "Module.Class"
         let functionName = "testName"

--- a/Tests/DatadogSDKTesting/Crashes/DDSymbolicatorTests.swift
+++ b/Tests/DatadogSDKTesting/Crashes/DDSymbolicatorTests.swift
@@ -30,7 +30,7 @@ class DDSymbolicatorTests: XCTestCase {
 #else
         XCTAssert(callStack[0].contains("(in DatadogSDKTestingTests_iOS)"))
 #endif
-        XCTAssert(callStack[0].contains("(/Users/nacho.bonafontearruga/projects/dd-sdk-swift-testing/Tests/DatadogSDKTesting/Crashes/DDSymbolicatorTests.swift:21)"))
+        XCTAssert(callStack[0].contains("DDSymbolicatorTests.swift:21"))
 
 #endif
     }


### PR DESCRIPTION

### What and why?

Add `call_stack` to all network requests by default, it allows knowing what is the origin of any network request so the developer can know how it get there. It partially symbolicates the output and it has an option to fully symbolicate it, but is quite time consuming and must be enabled explicitly

### How?

It adds the `call_stack` tag to all network requests that are created in the app, removing the lines related to our own insrumentation and only showing user code at the top. It also includes two new environment variables to control the feature:
  - DD_DISABLE_NETWORK_CALL_STACK to disable the functionality
  - DD_ENABLE_NETWORK_CALL_STACK_SYMBOLICATED to enable full symbolication 
 
Fully symbolication can only be achievable when running on iOS simulator or macOS, and must be activated explicitly because it can be quite time consuming

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
