### PR TITLE
CIAPP-3547 - iOS RUM integration implementation

### DIFF
--- a/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
+++ b/Sources/DatadogSDKTesting/DDEnvironmentValues.swift
@@ -25,7 +25,7 @@ internal struct DDEnvironmentValues {
     let enableStderrInstrumentation: Bool
     let extraHTTPHeaders: Set<String>?
     let excludedURLS: Set<String>?
-    let disableDDSDKIOSIntegration: Bool
+    let disableRUMIntegration: Bool
     let disableCrashHandler: Bool
     let disableTestInstrumenting: Bool
 
@@ -173,8 +173,8 @@ internal struct DDEnvironmentValues {
         let envStderr = DDEnvironmentValues.getEnvVariable("DD_ENABLE_STDERR_INSTRUMENTATION") as NSString?
         enableStderrInstrumentation = envStderr?.boolValue ?? false
 
-        let envDisableDDSDKIOSIntegration = DDEnvironmentValues.getEnvVariable("DD_DISABLE_SDKIOS_INTEGRATION") as NSString?
-        disableDDSDKIOSIntegration = envDisableDDSDKIOSIntegration?.boolValue ?? false
+        let envDisableRUMIntegration = DDEnvironmentValues.getEnvVariable("DD_DISABLE_RUM_INTEGRATION") as NSString?
+        disableRUMIntegration = envDisableRUMIntegration?.boolValue ?? false
 
         let envDisableCrashReporting = DDEnvironmentValues.getEnvVariable("DD_DISABLE_CRASH_HANDLER") as NSString?
         disableCrashHandler = envDisableCrashReporting?.boolValue ?? false

--- a/Sources/DatadogSDKTesting/DDTags.swift
+++ b/Sources/DatadogSDKTesting/DDTags.swift
@@ -57,6 +57,7 @@ internal enum DDTestTags {
     static let testExecutionProcessId = "test.execution.processId"
     static let testCodeowners = "test.codeowners"
     static let testIsUITest = "test.is_ui_test"
+    static let testIsRUMActive = "test.is_rum_active"
 }
 
 internal enum DDOSTags {
@@ -167,4 +168,10 @@ internal enum DDTagValues {
     static let statusPass = "pass"
     static let statusFail = "fail"
     static let statusSkip = "skip"
+}
+
+internal enum DDCFMessageID {
+    static let customTags: Int32 = 0x1111
+    static let enableRUM: Int32 = 0x2222
+    static let forceFlush: Int32 = 0x3333
 }

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -28,6 +28,7 @@ internal class DDTestMonitor {
     var maxPayloadSize: Int = defaultPayloadSize
     var launchNotificationObserver: NSObjectProtocol?
     var didBecomeActiveNotificationObserver: NSObjectProtocol?
+    var isRumActive: Bool = false
 
     var rLock = NSRecursiveLock()
     private var privateCurrentTest: DDTest?
@@ -91,7 +92,7 @@ internal class DDTestMonitor {
                             return
                         }
                         let status = CFMessagePortSendRequest(remotePort,
-                                                              0x1111, // Arbitrary
+                                                              DDCFMessageID.customTags,
                                                               encoded as CFData?,
                                                               timeout,
                                                               timeout,
@@ -161,13 +162,22 @@ internal class DDTestMonitor {
     }
 
     func startAttributeListener() {
-        #if targetEnvironment(simulator) || os(macOS)
             func attributeCallback(port: CFMessagePort?, msgid: Int32, data: CFData?, info: UnsafeMutableRawPointer?) -> Unmanaged<CFData>? {
-                if let data = data as Data? {
-                    let decoded = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
-                    decoded?.forEach {
-                        DDTestMonitor.instance?.currentTest?.setTag(key: $0.key, value: $0.value)
-                    }
+                switch msgid {
+                    case DDCFMessageID.customTags:
+                        if let data = data as Data? {
+                            let decoded = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+                            decoded?.forEach {
+                                DDTestMonitor.instance?.currentTest?.setTag(key: $0.key, value: $0.value)
+                            }
+                        }
+                    case DDCFMessageID.enableRUM:
+                        DDTestMonitor.instance?.isRumActive = true
+                        DDTestMonitor.instance?.currentTest?.setTag(key: DDTestTags.testIsRUMActive, value: true)
+                    case DDCFMessageID.forceFlush:
+                        Log.debug("CFMessagePort forceFlush")
+                    default:
+                        Log.debug("CFMessagePort unknown message")
                 }
 
                 return nil
@@ -180,6 +190,5 @@ internal class DDTestMonitor {
             }
             let runLoopSource = CFMessagePortCreateRunLoopSource(nil, port, 0)
             CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
-        #endif
     }
 }

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -293,6 +293,26 @@ internal class DDTracer {
     }
 
     func flush() {
+        if DDTestMonitor.instance?.isRumActive ?? false,
+           let remotePort = CFMessagePortCreateRemote(nil, "DatadogRUMTestingPort" as CFString)
+        {
+            let timeout: CFTimeInterval = 1000.0
+            let status = CFMessagePortSendRequest(
+                remotePort,
+                DDCFMessageID.forceFlush, // Message ID for asking RUM to flush all data
+                nil,
+                timeout,
+                timeout,
+                "kCFRunLoopDefaultMode" as CFString,
+                nil
+            )
+            if status == kCFMessagePortSuccess {
+            } else {
+                Log.debug("CFMessagePortCreateRemote request to DatadogRUMTestingPort failed")
+            }
+        }
+        print("DDCFMessageID.forceFlush finished")
+
         backgroundWorkQueue.sync {
             OpenTelemetrySDK.instance.tracerProvider.forceFlush()
         }
@@ -330,7 +350,7 @@ internal class DDTracer {
         }
 
         OpenTelemetry.instance.propagators.textMapPropagator.inject(spanContext: propagationContext, carrier: &headers, setter: HeaderSetter())
-        if !DDTestMonitor.env.disableDDSDKIOSIntegration {
+        if !DDTestMonitor.env.disableRUMIntegration {
             headers.merge(datadogHeaders(forContext: propagationContext)) { current, _ in current }
         }
         return headers
@@ -350,8 +370,8 @@ internal class DDTracer {
         }
 
         EnvironmentContextPropagator().inject(spanContext: propagationContext, carrier: &headers, setter: HeaderSetter())
-        if !DDTestMonitor.env.disableDDSDKIOSIntegration {
-            headers.merge(datadogHeaders(forContext: propagationContext)) { current, _ in current }
+        if !DDTestMonitor.env.disableRUMIntegration {
+            headers["CI_VISIBILITY_TEST_EXECUTION_ID"] = String(propagationContext.traceId.rawLowerLong)
         }
         return headers
     }


### PR DESCRIPTION
### What and why?

It enables the new RUM integration, it allows to show RUM sessions as part of a UI test. There is another PR in dd-sdk-io

### How?

* Detects when RUM is active with a message that RUM sdk sends to its CFMessagePort, and sets proper tags
* If RUM is active sends the flush messsage to a RUM CFMessagePort
* It changes the environment variable used for setting and activating the RUM integration

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
