### PR TITLE
Update to opentelemetry-swift 1.7.0

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -4283,7 +4283,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.5.0;
+				minimumVersion = 1.7.0;
 			};
 		};
 		E141EB5727EB44400057D747 /* XCRemoteSwiftPackageReference "swift-nio" */ = {

--- a/Sources/EventsExporter/EventsExporter.swift
+++ b/Sources/EventsExporter/EventsExporter.swift
@@ -23,7 +23,8 @@ public class EventsExporter: SpanExporter {
         Log.debug("EventsExporter created: \(spansExporter.runtimeId)")
     }
 
-    public func export(spans: [SpanData]) -> SpanExporterResultCode {
+    public func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        // TODO: Honor the timeout
         spans.forEach {
             if $0.traceFlags.sampled {
                 spansExporter.exportSpan(span: $0)
@@ -43,7 +44,8 @@ public class EventsExporter: SpanExporter {
         }
     }
 
-    public func flush() -> SpanExporterResultCode {
+    public func flush(explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
+        // TODO: Honor the timeout
         logsExporter.logsStorage.writer.queue.sync {}
         spansExporter.spansStorage.writer.queue.sync {}
         coverageExporter.coverageStorage.writer.queue.sync {}
@@ -77,8 +79,8 @@ public class EventsExporter: SpanExporter {
         return itrService.itrSetting(service: service, env: env, repositoryURL: repositoryURL, branch: branch, sha: sha, configurations: configurations, customConfigurations: customConfigurations)
     }
 
-    public func shutdown() {
-        _ = self.flush()
+    public func shutdown(explicitTimeout: TimeInterval?) {
+        _ = self.flush(explicitTimeout: explicitTimeout)
     }
 
     public func endpointURLs() -> Set<String> {

--- a/Sources/EventsExporter/Logs/LogEncoder.swift
+++ b/Sources/EventsExporter/Logs/LogEncoder.swift
@@ -100,6 +100,7 @@ internal struct DDLog: Encodable {
                     return value
                 case let .doubleArray(value):
                     return value
+                default: fatalError("Found user attribute of unsupported type")
             }
         }
         self.attributes = LogAttributes(userAttributes: userAttributes, internalAttributes: internalAttributes)


### PR DESCRIPTION
### What and why?

Update the code to build with the latest opentelemetry-swift. The build was failing because `SpanExporter` added a new timeout parameter in 1.7.0. This PR changes the signature of the function so it builds, but doesn't actually use the new parameter.
