### PR TITLE
Fix upload script again 

### DIFF
--- a/Scripts/uploadBinary.sh
+++ b/Scripts/uploadBinary.sh
@@ -18,4 +18,4 @@ git add Package@swift-5.3.swift
 git checkout -b update-binary
 git commit -m "Updated binary package version to $2"
 git tag -f $2
-git push -f --tags origin HEAD:main
+git push -f --tags origin update-binary


### PR DESCRIPTION
### What and why?

I missed the `HEAD:main` bit in https://github.com/DataDog/dd-sdk-swift-testing/pull/85, so the script fails again in https://github.com/DataDog/dd-sdk-swift-testing/actions/runs/7194920950/job/19596489937

