### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -30,7 +30,7 @@ jobs:
       run: make release
     - name: Get the tag version
       id: tag_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> "$GITHUB_OUTPUT"
     - name: Update swift binary and recreate tag
       run: sh Scripts/uploadBinary.sh $GITHUB_TOKEN ${{ steps.tag_version.outputs.VERSION }}
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter