### PR TITLE
[CIVIS-10089] Better test skipping

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		A71E647D2BAA0AA100F2ACA5 /* CIEnvironmentReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71E64672BAA0AA100F2ACA5 /* CIEnvironmentReader.swift */; };
 		A71E647E2BAA0AA100F2ACA5 /* EnvironmentReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71E64682BAA0AA100F2ACA5 /* EnvironmentReader.swift */; };
 		A71E64802BAB442300F2ACA5 /* ConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71E647F2BAB442300F2ACA5 /* ConfigTests.swift */; };
+		A78557812BFE015B0031E2D8 /* SkippedTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78557802BFE015B0031E2D8 /* SkippedTest.swift */; };
 		A7B39C6C2BCFC799007F98B2 /* CDatadogSDKTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7E232DC2BC6E68B0087D8F8 /* CDatadogSDKTesting.framework */; };
 		A7B39C702BCFCD77007F98B2 /* SubprocessWait.c in Sources */ = {isa = PBXBuildFile; fileRef = A7B39C6F2BCFCD77007F98B2 /* SubprocessWait.c */; };
 		A7B39C722BCFD234007F98B2 /* SubprocessWait.h in Headers */ = {isa = PBXBuildFile; fileRef = A7B39C712BCFD234007F98B2 /* SubprocessWait.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -313,6 +314,7 @@
 		A71E64672BAA0AA100F2ACA5 /* CIEnvironmentReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CIEnvironmentReader.swift; sourceTree = "<group>"; };
 		A71E64682BAA0AA100F2ACA5 /* EnvironmentReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentReader.swift; sourceTree = "<group>"; };
 		A71E647F2BAB442300F2ACA5 /* ConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigTests.swift; sourceTree = "<group>"; };
+		A78557802BFE015B0031E2D8 /* SkippedTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkippedTest.swift; sourceTree = "<group>"; };
 		A7B39C6F2BCFCD77007F98B2 /* SubprocessWait.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = SubprocessWait.c; sourceTree = "<group>"; };
 		A7B39C712BCFD234007F98B2 /* SubprocessWait.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SubprocessWait.h; sourceTree = "<group>"; };
 		A7C292122B9B2B39009C2979 /* fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fixtures; sourceTree = "<group>"; };
@@ -911,6 +913,7 @@
 			children = (
 				E146BC392869AEA80057C37B /* GitUploader.swift */,
 				E137366128A3BE3600420E26 /* IntelligentTestRunner.swift */,
+				A78557802BFE015B0031E2D8 /* SkippedTest.swift */,
 			);
 			path = IntelligentTestRunner;
 			sourceTree = "<group>";
@@ -1444,6 +1447,7 @@
 				A7FC26142BA1EC0500067E26 /* XCUIApplicationSwizzler.swift in Sources */,
 				A71E64722BAA0AA100F2ACA5 /* BuildkiteCI.swift in Sources */,
 				A7FC260B2BA1EC0500067E26 /* InternalError.swift in Sources */,
+				A78557812BFE015B0031E2D8 /* SkippedTest.swift in Sources */,
 				A7FC25BF2BA1EAEB00067E26 /* DDCoverageHelper.swift in Sources */,
 				A7FC25B52BA1EADF00067E26 /* DDInstrumentationControl.swift in Sources */,
 				A71E646E2BAA0AA100F2ACA5 /* GithubCI.swift in Sources */,

--- a/Sources/CDatadogSDKTesting/AutoLoad.c
+++ b/Sources/CDatadogSDKTesting/AutoLoad.c
@@ -12,3 +12,9 @@
 __attribute__((constructor)) void AutoLoadHandler(void) {
     __AutoLoadHook();
 }
+
+// This code will run when the framework is unloaded from memory.
+// Reference: https://developer.apple.com/documentation/objectivec/nsobject/1418815-load
+__attribute__((destructor)) void AutoUnloadHandler(void) {
+    __AutoUnloadHook();
+}

--- a/Sources/CDatadogSDKTesting/include/AutoLoad.h
+++ b/Sources/CDatadogSDKTesting/include/AutoLoad.h
@@ -14,8 +14,13 @@ extern "C" {
 // Implement it in your Swift code as @_cdecl
 void __AutoLoadHook(void);
 
-// Never call this method directly. It will be called on framework load
+// This hook will be called by library.
+// Implement it in your Swift code as @_cdecl
+void __AutoUnloadHook(void);
+
+// Never call this methods directly. They will be called by system dynamic loader
 extern void AutoLoadHandler(void);
+extern void AutoUnloadHandler(void);
 
 #ifdef __cplusplus
 }

--- a/Sources/DatadogSDKTesting/FrameworkLoadHandler.swift
+++ b/Sources/DatadogSDKTesting/FrameworkLoadHandler.swift
@@ -15,7 +15,6 @@ enum FrameworkLoadHandler {
     }
 
     fileprivate static func libraryLoaded() {
-        Log.print("args \(ProcessInfo.processInfo.processName) \(ProcessInfo.processInfo.arguments)")
         let config = DDTestMonitor.config
         /// Only initialize test observer if user configured so and is running tests
         guard let enabled = config.isEnabled else {

--- a/Sources/DatadogSDKTesting/IntelligentTestRunner/SkippedTest.swift
+++ b/Sources/DatadogSDKTesting/IntelligentTestRunner/SkippedTest.swift
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+@_implementationOnly import XCTest
+
+final class SkippedTest: XCTestCase {
+    private var _test: XCTestCase! = nil
+    
+    override var name: String { _test.name }
+    override var testCaseCount: Int { _test.testCaseCount }
+    override var testRunClass: AnyClass? { _test.testRunClass }
+    
+    override func setUpWithError() throws {
+        throw XCTSkip("ITR")
+    }
+    
+    convenience init(for test: XCTestCase) {
+        self.init(selector: #selector(Self._empty))
+        self._test = test
+    }
+    
+    @objc func _empty() {}
+}


### PR DESCRIPTION
### What and why?

Current skip algorithm will remove tests at all, so Xcode will never show them as skipped in its logs. CI providers show UI for Xcode test run and this tests will be missed from it.

### How?

Test case is wrapped with special `SkippedTest` wrapper which will throw skip error in its setup code.

Xcode shows tests as skipped by `ITR` in the logs

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
