### PR TITLE
removed gh login from the release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ github: release
 	@:$(call check_defined, GITHUB_TOKEN, GitHub token)
 	# Upload binary file to GitHub release
 	brew list gh &>/dev/null || brew install gh
-	gh auth login
 	# upload xcframework
 	gh release upload $(version) ./build/xcframework/DatadogSDKTesting.zip --clobber
 	# upload symbols


### PR DESCRIPTION
### What and why?

gh login isn't needed for GH_TOKEN

### How?

Removed gh login call

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
