### PR TITLE
push pod to the repository on release

### DIFF
--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Build and upload XCFrameworks, recreate tag
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+	COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
       run: make XC_LOG=archive version=${{ github.event.release.tag_name }} github
     - name: Attach Xcode logs
       if: '!cancelled()'

--- a/DatadogSDKTesting.podspec
+++ b/DatadogSDKTesting.podspec
@@ -2,8 +2,8 @@ Pod::Spec.new do |s|
   s.name          = 'DatadogSDKTesting'
   s.module_name   = 'DatadogSDKTesting'
   s.version       = '2.5.0-alpha1'
-  s.summary       = 'Swift testing framework for Datadog's CI Visibility product'
-  s.license       = { :type => 'Apache', :file => 'LICENSE' }
+  s.summary       = "Swift testing framework for Datadog's CI Visibility product"
+  s.license       = 'Apache 2.0'
   s.homepage      = 'https://www.datadoghq.com'
   s.social_media_url = 'https://twitter.com/datadoghq'
   

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ release:
 
 github: release
 	@:$(call check_defined, GH_TOKEN, GitHub token)
+	@:$(call check_defined, COCOAPODS_TRUNK_TOKEN, CocoaPods trunk token)
 	# Upload binary file to GitHub release
 	brew list gh &>/dev/null || brew install gh
 	# upload xcframework
@@ -98,6 +99,8 @@ github: release
 	git commit -m "Updated binary package version to $(version)"
 	git tag -f $(version)
 	git push -f --tags origin update-binary
+	# Push Podfile
+	pod trunk push --allow-warnings DatadogSDKTesting.podspec
 
 clean:
 	rm -rf ./build


### PR DESCRIPTION
### What and why?

Podspec should be pushed to the central repository for release.

### How?

Added step to makefile for publishing and env secret with token

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
