### PR TITLE
added env variable for ITR debug

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -43,6 +43,7 @@
 		A7B747C02C60E1E7009B4B93 /* SwiftUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B747BF2C60E1E7009B4B93 /* SwiftUtilsTests.swift */; };
 		A7CC6D862C07D624003C13BC /* Tags.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7CC6D852C07D624003C13BC /* Tags.swift */; };
 		A7CC6D882C0F3F83003C13BC /* Tags+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7CC6D872C0F3F83003C13BC /* Tags+ObjC.swift */; };
+		A7E0056D2C766EF7004D4B78 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7E0056C2C766EF7004D4B78 /* CoreTelephony.framework */; platformFilters = (ios, maccatalyst, macos, ); };
 		A7E232E52BC6E80A0087D8F8 /* CodeCoverage.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E232E42BC6E80A0087D8F8 /* CodeCoverage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7E232F52BC6EB470087D8F8 /* CoverageExporterJson.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E232EA2BC6EB460087D8F8 /* CoverageExporterJson.cpp */; };
 		A7E232F62BC6EB470087D8F8 /* CoverageReport.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E232EB2BC6EB460087D8F8 /* CoverageReport.h */; };
@@ -333,6 +334,7 @@
 		A7C292162B9B2DE0009C2979 /* DatadogSDKTesting.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = DatadogSDKTesting.podspec; sourceTree = "<group>"; };
 		A7CC6D852C07D624003C13BC /* Tags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tags.swift; sourceTree = "<group>"; };
 		A7CC6D872C0F3F83003C13BC /* Tags+ObjC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tags+ObjC.swift"; sourceTree = "<group>"; };
+		A7E0056C2C766EF7004D4B78 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		A7E232DC2BC6E68B0087D8F8 /* CDatadogSDKTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CDatadogSDKTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7E232E42BC6E80A0087D8F8 /* CodeCoverage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CodeCoverage.h; sourceTree = "<group>"; };
 		A7E232EA2BC6EB460087D8F8 /* CoverageExporterJson.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CoverageExporterJson.cpp; sourceTree = "<group>"; };
@@ -514,6 +516,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A7E0056D2C766EF7004D4B78 /* CoreTelephony.framework in Frameworks */,
 				A7FC26532BA1F1E600067E26 /* URLSessionInstrumentation in Frameworks */,
 				A7E233312BC82CD10087D8F8 /* Kronos in Frameworks */,
 				A7FC26502BA1F1E600067E26 /* CrashReporter in Frameworks */,
@@ -620,6 +623,7 @@
 		A7B39C6B2BCFC799007F98B2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A7E0056C2C766EF7004D4B78 /* CoreTelephony.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1767,7 +1771,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = "2.5.0";
+				MARKETING_VERSION = 2.5.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.CDatadogSDKTesting;
@@ -1807,7 +1811,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = "2.5.0";
+				MARKETING_VERSION = 2.5.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.CDatadogSDKTesting;
@@ -2162,7 +2166,7 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
-				MARKETING_VERSION = "2.5.0";
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.IntegrationTestsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -2186,7 +2190,7 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
-				MARKETING_VERSION = "2.5.0";
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.IntegrationTestsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -2260,7 +2264,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = "2.5.0";
+				MARKETING_VERSION = 2.5.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2332,7 +2336,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LLVM_LTO = YES_THIN;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = "2.5.0";
+				MARKETING_VERSION = 2.5.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,5 +2,5 @@ Component,Origin,License,Copyright
 import,opentelemetry-swift,Apache-2.0,Copyright 2020 - OpenTelemetry Authors
 import,PLCrashReporter,MIT,Copyright Microsoft Corporation
 import,SigmaSwiftStatistics,MIT,Copyright 2015 - Evgenii Neumerzhitckii
-import,NTPKit,BSD 2-Clause,Copyright 2016 - Nicholas Cvitak
+import,Kronos,Apache-2.0,Copyright Mobile Native Foundation
 import,LLVM,Apache-2.0 WITH LLVM-exception,Copyright LLVM Project

--- a/Sources/DatadogSDKTesting/Config.swift
+++ b/Sources/DatadogSDKTesting/Config.swift
@@ -66,6 +66,7 @@ final class Config {
     /// The framework has been launched with extra debug information
     var extraDebug: Bool = false
     var extraDebugNetwork: Bool = false
+    var extraDebugCodeCoverage: Bool = false
     var extraDebugCallStack: Bool = false
     
     init(env: EnvironmentReader? = nil) {
@@ -138,7 +139,8 @@ final class Config {
         reportHostname = env[.ciVisibilityReportHostname] ?? false
         extraDebugCallStack = env[.traceDebugCallStack] ?? false
         extraDebugNetwork = env[.traceDebugNetwork] ?? false
-        extraDebug = env[.traceDebug] ?? extraDebugCallStack || extraDebugNetwork
+        extraDebugCodeCoverage = env[.traceDebugCodeCoverage] ?? false
+        extraDebug = env[.traceDebug] ?? extraDebugCallStack || extraDebugNetwork || extraDebugCodeCoverage
         
         disableMachCrashHandler = env[.disableMachCrashHandler] ?? extraDebug
         
@@ -209,6 +211,7 @@ extension Config: CustomDebugStringConvertible {
         Message Channel UUID: \(messageChannelUUID ?? "nil")
         Extra Debug: \(extraDebug)
         Extra Debug Network: \(extraDebugNetwork)
+        Extra Debug Code Coverage: \(extraDebugCodeCoverage)
         Extra Debug Call Stack: \(extraDebugCallStack)
         """
     }

--- a/Sources/DatadogSDKTesting/Coverage/DDCoverageHelper.swift
+++ b/Sources/DatadogSDKTesting/Coverage/DDCoverageHelper.swift
@@ -59,7 +59,12 @@ class DDCoverageHelper {
     }
 
     func getURLForTest(name: String, testSessionId: UInt64, testSuiteId: UInt64, spanId: UInt64) -> URL {
-        let cleanedName = name.components(separatedBy: Self.nameNotAllowed).joined(separator: "+")
+        var cleanedName = name.components(separatedBy: Self.nameNotAllowed)
+            .filter { $0.count > 0 }
+            .joined(separator: "+")
+        if cleanedName.count > 20 {
+            cleanedName = "\(cleanedName.prefix(10))-\(cleanedName.suffix(10))"
+        }
         let finalName = "\(testSessionId)__\(testSuiteId)__\(spanId)__\(cleanedName)"
         return storagePath.url.appendingPathComponent(finalName).appendingPathExtension("profraw")
     }

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -46,7 +46,7 @@ internal class DDTestMonitor {
         return try? DDTestMonitor.cacheDir?.createSubdirectory(path: commit)
     }()
     
-    var tempDir: Directory? = try? Directory.temporary().createSubdirectory(path: UUID().uuidString)
+    var tempDir: Directory? = try? Directory.temporary().createSubdirectory(path: "com.datadog.civisibility-\(UUID().uuidString)")
 
     var networkInstrumentation: DDNetworkInstrumentation?
     var injectHeaders: Bool = false
@@ -126,8 +126,12 @@ internal class DDTestMonitor {
         guard let monitor = DDTestMonitor.instance else { return }
         DDTestMonitor.instance = nil
         Log.debug("Clearing monitor")
-        monitor.coverageHelper?.removeStoragePath()
-        try? monitor.tempDir?.delete()
+        if !config.extraDebugCodeCoverage {
+            monitor.coverageHelper?.removeStoragePath()
+            try? monitor.tempDir?.delete()
+        } else {
+            Log.debug("Temp files stored at: \(monitor.tempDir?.url.absoluteString ?? "nil")")
+        }
     }
 
     init() {

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -46,7 +46,7 @@ internal class DDTestMonitor {
         return try? DDTestMonitor.cacheDir?.createSubdirectory(path: commit)
     }()
     
-    var tempDir: Directory? = try? Directory.temporary().createSubdirectory(path: "com.datadog.civisibility-\(UUID().uuidString)")
+    static var tempDir: Directory? = try? Directory.temporary().createSubdirectory(path: "com.datadog.civisibility-\(UUID().uuidString)")
 
     var networkInstrumentation: DDNetworkInstrumentation?
     var injectHeaders: Bool = false
@@ -126,11 +126,12 @@ internal class DDTestMonitor {
         guard let monitor = DDTestMonitor.instance else { return }
         DDTestMonitor.instance = nil
         Log.debug("Clearing monitor")
+        try? DDSymbolicator.dsymFilesDir.delete()
         if !config.extraDebugCodeCoverage {
             monitor.coverageHelper?.removeStoragePath()
-            try? monitor.tempDir?.delete()
+            try? tempDir?.delete()
         } else {
-            Log.debug("Temp files stored at: \(monitor.tempDir?.url.absoluteString ?? "nil")")
+            Log.debug("Temp files stored at: \(tempDir?.url.absoluteString ?? "nil")")
         }
     }
 
@@ -316,7 +317,7 @@ internal class DDTestMonitor {
                 // Activate Coverage
                 if itrBackendConfig?.codeCoverage ?? false {
                     Log.debug("Coverage Enabled")
-                    guard let temp = tempDir else {
+                    guard let temp = DDTestMonitor.tempDir else {
                         Log.print("Coverage init failed. Can't create temp directiry.")
                         coverageHelper = nil
                         return

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -81,7 +81,8 @@ internal class DDTracer {
             performancePreset: .instantDataDelivery,
             exporterId: String(SpanId.random().rawValue),
             logger: Log.instance,
-            debugNetwork: conf.extraDebugNetwork
+            debug: .init(logNetworkRequests: conf.extraDebugNetwork,
+                         saveCodeCoverageFiles: conf.extraDebugCodeCoverage)
         )
         eventsExporter = try? EventsExporter(config: exporterConfiguration)
 

--- a/Sources/DatadogSDKTesting/Environment/EnvironmentKeys.swift
+++ b/Sources/DatadogSDKTesting/Environment/EnvironmentKeys.swift
@@ -33,6 +33,7 @@ internal enum EnvironmentKey: String, CaseIterable {
     case dontExport = "DD_DONT_EXPORT"
     case traceDebug = "DD_TRACE_DEBUG"
     case traceDebugNetwork = "DD_TRACE_DEBUG_NETWORK"
+    case traceDebugCodeCoverage = "DD_TRACE_DEBUG_CODE_COVERAGE"
     case traceDebugCallStack = "DD_TRACE_DEBUG_CALLSTACK"
     case disableNTPClock = "DD_DISABLE_NTPCLOCK"
     case enableCiVisibilityLogs = "DD_CIVISIBILITY_LOGS_ENABLED"

--- a/Sources/DatadogSDKTesting/ImageSymbols/DDSymbolicator.swift
+++ b/Sources/DatadogSDKTesting/ImageSymbols/DDSymbolicator.swift
@@ -13,11 +13,8 @@ enum DDSymbolicator {
     private static let crashLineRegex = try! NSRegularExpression(pattern: "^([0-9]+)(\\s+)((?:[\\w.] *[\\w.]*)+)(\\s+)(0x[0-9a-fA-F]+)([ \t]+)(0x[0-9a-fA-F]+)([ \t]+\\+[ \t]+[0-9]+)$?", options: .anchorsMatchLines)
     private static let callStackRegex = try! NSRegularExpression(pattern: "^([0-9]+)(\\s+)((?:[\\w.] *[\\w.]*)+)(\\s+)(0x[0-9a-fA-F]+)", options: .anchorsMatchLines)
     
-    internal static let dsymFilesPath: URL = {
-        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("DD-DSYMS-"+UUID().uuidString)
-        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
-    }()
+    internal static var dsymFilesPath: URL { dsymFilesDir.url }
+    internal static let dsymFilesDir: Directory = try! DDTestMonitor.tempDir!.createSubdirectory(path: "dsyms")
 
     internal static var dSYMFiles: [URL] = {
         var dSYMFiles = [URL]()

--- a/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
+++ b/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
@@ -53,7 +53,7 @@ internal class CoverageExporter {
                                        storage: coverageStorage,
                                        requestBuilder: requestBuilder,
                                        performance: configuration.performancePreset,
-                                       debug: config.debugNetwork)
+                                       debug: config.debug.logNetworkRequests)
         requestBuilder.addFieldsCallback = addCoverage
     }
 
@@ -71,14 +71,14 @@ internal class CoverageExporter {
                                                                 testSuiteId: testSuiteId, spanId: spanId, workspacePath: workspacePath,
                                                                 binaryImagePaths: binaryImagePaths)
 
-        if Log.isDebug == false {
-            try? FileManager.default.removeItem(at: coverage)
-            try? FileManager.default.removeItem(at: profData)
-        } else {
+        if configuration.debug.saveCodeCoverageFiles {
             let data = try? JSONEncoder.default().encode(ddCoverage)
             let testName = coverage.deletingPathExtension().lastPathComponent.components(separatedBy: "__").last!
             let jsonURL = coverage.deletingLastPathComponent().appendingPathComponent(testName).appendingPathExtension("json")
             try? data?.write(to: jsonURL)
+        } else {
+            try? FileManager.default.removeItem(at: coverage)
+            try? FileManager.default.removeItem(at: profData)
         }
         coverageStorage.writer.write(value: ddCoverage)
         Log.debug("End processing coverage: \(coverage.path)")

--- a/Sources/EventsExporter/ExporterConfiguration.swift
+++ b/Sources/EventsExporter/ExporterConfiguration.swift
@@ -35,10 +35,15 @@ public struct ExporterConfiguration {
     var exporterId: String
     
     var logger: Logger
-    
-    var debugNetwork: Bool
+    var debug: Debug
 
-    public init(serviceName: String, libraryVersion: String, applicationName: String, applicationVersion: String, environment: String, hostname: String?, apiKey: String, endpoint: Endpoint, payloadCompression: Bool = true, source: String = "ios", performancePreset: PerformancePreset = .default, exporterId: String, logger: Logger, debugNetwork: Bool) {
+    public init(
+        serviceName: String, libraryVersion: String, applicationName: String,
+        applicationVersion: String, environment: String, hostname: String?, apiKey: String,
+        endpoint: Endpoint, payloadCompression: Bool = true, source: String = "ios",
+        performancePreset: PerformancePreset = .default, exporterId: String, logger: Logger,
+        debug: Debug = .init()
+    ) {
         self.serviceName = serviceName
         self.libraryVersion = libraryVersion
         self.applicationName = applicationName
@@ -52,6 +57,19 @@ public struct ExporterConfiguration {
         self.performancePreset = performancePreset
         self.exporterId = exporterId
         self.logger = logger
-        self.debugNetwork = debugNetwork
+        self.debug = debug
+    }
+}
+
+
+extension ExporterConfiguration {
+    public struct Debug {
+        let logNetworkRequests: Bool
+        let saveCodeCoverageFiles: Bool
+        
+        public init(logNetworkRequests: Bool = false, saveCodeCoverageFiles: Bool = false) {
+            self.logNetworkRequests = logNetworkRequests
+            self.saveCodeCoverageFiles = saveCodeCoverageFiles
+        }
     }
 }

--- a/Sources/EventsExporter/IntelligentTestRunner/ITRService.swift
+++ b/Sources/EventsExporter/IntelligentTestRunner/ITRService.swift
@@ -87,22 +87,22 @@ internal class ITRService {
         )
 
         searchCommitUploader = DataUploader(
-            httpClient: HTTPClient(debug: config.debugNetwork),
+            httpClient: HTTPClient(debug: config.debug.logNetworkRequests),
             requestBuilder: searchCommitRequestBuilder
         )
 
         packFileUploader = DataUploader(
-            httpClient: HTTPClient(debug: config.debugNetwork),
+            httpClient: HTTPClient(debug: config.debug.logNetworkRequests),
             requestBuilder: packFileRequestBuilder
         )
 
         skippableTestsUploader = DataUploader(
-            httpClient: HTTPClient(debug: config.debugNetwork),
+            httpClient: HTTPClient(debug: config.debug.logNetworkRequests),
             requestBuilder: skippableTestsRequestBuilder
         )
 
         itrConfigUploader = DataUploader(
-            httpClient: HTTPClient(debug: config.debugNetwork),
+            httpClient: HTTPClient(debug: config.debug.logNetworkRequests),
             requestBuilder: itrConfigRequestBuilder
         )
     }

--- a/Sources/EventsExporter/Logs/LogsExporter.swift
+++ b/Sources/EventsExporter/Logs/LogsExporter.swift
@@ -71,7 +71,7 @@ internal class LogsExporter {
                                    storage: logsStorage,
                                    requestBuilder: requestBuilder,
                                    performance: configuration.performancePreset,
-                                   debug: config.debugNetwork)
+                                   debug: config.debug.logNetworkRequests)
     }
 
     func exportLogs(fromSpan span: SpanData) {

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -66,7 +66,7 @@ internal class SpansExporter {
                                     storage: spansStorage,
                                     requestBuilder: requestBuilder,
                                     performance: configuration.performancePreset,
-                                    debug: config.debugNetwork)
+                                    debug: config.debug.logNetworkRequests)
     }
 
     func exportSpan(span: SpanData) {

--- a/Sources/EventsExporter/Upload/HTTPClient.swift
+++ b/Sources/EventsExporter/Upload/HTTPClient.swift
@@ -45,23 +45,20 @@ internal final class HTTPClient {
     
     private func log(request: URLRequest, response: (Data?, URLResponse?, Error?)) {
         guard debug else { return }
-        Log.runOnDebug({
-            let (data, urlres, error) = response
-            guard let httpres = urlres as? HTTPURLResponse else {
-                let res = urlres?.description ?? "nil"
-                let err = error?.localizedDescription ?? "nil"
-                let data = data?.description ?? "nil"
-                Log.debug("[NET] => \(request)\n\tERR: \(err)\n\tRES: \(res)\n\tDATA: \(data))")
-                return
-            }
-            let log = """
-            [NET] => \(request.url!)
-                RES CODE: \(httpres.statusCode)
-                ERROR: \(error?.localizedDescription ?? "")
-                DATA: \(data.flatMap{String(data: $0, encoding: .utf8)} ?? "")
-            """
-            Log.debug(log)
-        }())
+        let (data, urlres, error) = response
+        guard let httpres = urlres as? HTTPURLResponse else {
+            let res = urlres?.description ?? "nil"
+            let err = error?.localizedDescription ?? "nil"
+            let data = data?.description ?? "nil"
+            Log.debug("[NET] => \(request)\n\tERR: \(err)\n\tRES: \(res)\n\tDATA: \(data))")
+            return
+        }
+        Log.debug("""
+                  [NET] => \(request.url!)
+                  RES CODE: \(httpres.statusCode)
+                  ERROR: \(error?.localizedDescription ?? "")
+                  DATA: \(data.flatMap{String(data: $0, encoding: .utf8)} ?? "")
+                  """)
     }
 }
 

--- a/Tests/EventsExporter/EventsExporterTests.swift
+++ b/Tests/EventsExporter/EventsExporterTests.swift
@@ -58,8 +58,7 @@ class EventsExporterTests: XCTestCase {
                                                               logsURL: URL(string: "http://localhost:33333/logs")!
                                                           ),
                                                           exporterId: "exporterId",
-                                                          logger: Log(),
-                                                          debugNetwork: false)
+                                                          logger: Log())
 
         let datadogExporter = try! EventsExporter(config: exporterConfiguration)
 

--- a/Tests/EventsExporter/Logs/LogsExporterTests.swift
+++ b/Tests/EventsExporter/Logs/LogsExporterTests.swift
@@ -49,8 +49,7 @@ class LogsExporterTests: XCTestCase {
                                                   ),
                                                   performancePreset: .instantDataDelivery,
                                                   exporterId: "exporterId",
-                                                  logger: Log(),
-                                                  debugNetwork: false)
+                                                  logger: Log())
 
         let logsExporter = try LogsExporter(config: configuration)
 

--- a/Tests/EventsExporter/Spans/SpansExporterTests.swift
+++ b/Tests/EventsExporter/Spans/SpansExporterTests.swift
@@ -50,8 +50,7 @@ class SpansExporterTests: XCTestCase {
                                                   ),
                                                   performancePreset: .instantDataDelivery,
                                                   exporterId: "exporterId",
-                                                  logger: Log(),
-                                                  debugNetwork: false)
+                                                  logger: Log())
 
         let spansExporter = try SpansExporter(config: configuration)
 


### PR DESCRIPTION
### What and why?

Test Code Coverage should be dumped for debugging only when it's needed, not in a general debug mode.

### How?

Added special env variable to enable test coverage debug. Save files only when explicitly enabled

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
