### PR TITLE
fallback if fetch_head doesn't have branch

### DIFF
--- a/IntegrationTests/UITests/IntegrationTestsUITests.xctestplan
+++ b/IntegrationTests/UITests/IntegrationTestsUITests.xctestplan
@@ -15,6 +15,18 @@
         "value" : "$(GITHUB_REPOSITORY)"
       },
       {
+        "key" : "GITHUB_REF",
+        "value" : "$(GITHUB_REF)"
+      },
+      {
+        "key" : "GITHUB_HEAD_REF",
+        "value" : "$(GITHUB_HEAD_REF)"
+      },
+      {
+        "key" : "GITHUB_ACTIONS",
+        "value" : "$(GITHUB_ACTIONS)"
+      },
+      {
         "key" : "DD_ENV",
         "value" : "internal-tests"
       },

--- a/Sources/DatadogSDKTesting/Utils/GitInfo.swift
+++ b/Sources/DatadogSDKTesting/Utils/GitInfo.swift
@@ -32,9 +32,14 @@ struct GitInfo {
             commit = refData.trimmingCharacters(in: .whitespacesAndNewlines)
         } else {
             let fetchHeadPath = gitFolder.appendingPathComponent("FETCH_HEAD")
-            if let records = FetchHeadRecord.from(file: fetchHeadPath)?
-                .filter({$0.commit == head && $0.type == "branch"}), records.count > 0 {
-                self.branch = records.first!.ref
+            if let records = FetchHeadRecord.from(file: fetchHeadPath)?.filter({$0.commit == head}),
+               records.count > 0
+            {
+                if let branchRef = records.first(where: { $0.type == "branch" }) {
+                    self.branch = branchRef.ref
+                } else { // Seems as we have only a tag ref
+                    self.branch = records.first!.ref
+                }
             }
             commit = head
         }


### PR DESCRIPTION
### What and why?

Git parser should save tag into branch info if there are no branches in the FETCH_HEAD file

### How?

Set branch if there is a branch or set first value for the commit. 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
