### PR TITLE
increase amount of open files for code coverage

### DIFF
--- a/Sources/DatadogSDKTesting/Coverage/DDCoverageHelper.swift
+++ b/Sources/DatadogSDKTesting/Coverage/DDCoverageHelper.swift
@@ -37,6 +37,7 @@ class DDCoverageHelper {
         coverageWorkQueue = OperationQueue()
         coverageWorkQueue.qualityOfService = .utility
         coverageWorkQueue.maxConcurrentOperationCount = max(ProcessInfo.processInfo.activeProcessorCount - 1, 1)
+        setFileLimit()
     }
 
     func clearCounters() {
@@ -45,6 +46,23 @@ class DDCoverageHelper {
                                  $0.endCountersFuncPtr,
                                  $0.beginDataFuncPtr,
                                  $0.endCountersFuncPtr)
+        }
+    }
+    
+    private func setFileLimit() {
+        var limit = rlimit()
+        let filesMax = 4096
+        guard getrlimit(RLIMIT_NOFILE, &limit) == 0 else {
+            Log.debug("Can't get open file limit")
+            return
+        }
+        guard limit.rlim_cur < filesMax else { return }
+        limit.rlim_cur = rlim_t(filesMax)
+        limit.rlim_max = rlim_t(filesMax * 8)
+        if setrlimit(RLIMIT_NOFILE, &limit) == 0 {
+            Log.debug("Updated open file limit to \(filesMax)")
+        } else {
+            Log.debug("Can't increase open file limit")
         }
     }
 

--- a/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
+++ b/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
@@ -63,7 +63,7 @@ internal class CoverageExporter {
         do {
             profData = try DDCoverageConversor.generateProfData(profrawFile: coverage)
         } catch {
-            Log.print("Profiler Data genetation failed: \(error)")
+            Log.print("Profiler Data generation failed: \(error)")
             return
         }
         

--- a/Sources/EventsExporter/Utils/Spawn.swift
+++ b/Sources/EventsExporter/Utils/Spawn.swift
@@ -51,7 +51,6 @@ public enum Spawn {
         
         var childActions: posix_spawn_file_actions_t?
         dd_posix_spawn_file_actions_init(&childActions)
-        defer { dd_posix_spawn_file_actions_destroy(&childActions) }
         
         let outFile: URL?
         let errFile: URL?
@@ -84,6 +83,8 @@ public enum Spawn {
         let ret = arguments.withCStringsNilTerminatedArray { argv in
             dd_posix_spawn(&pid, command, &childActions, nil, argv, nil)
         }
+        
+        dd_posix_spawn_file_actions_destroy(&childActions)
         
         do {
             try _wait(spawn: ret, pid: pid)


### PR DESCRIPTION
### What and why?

Test process crashes because open file limit is too small by default

### How?

Called `setrlimit` method when Code Coverage is enabled to increase open file limit

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
