### PR TITLE
[VULN-8074] added GH token write permissions for the release job

### DIFF
--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -25,6 +25,8 @@ jobs:
   release:
     needs: [test]
     runs-on: macos-13
+    permissions:
+      contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
### What and why?

Added permissions to the job so I can remove global token write permissions.

### How?

Updated workflow file with permissions property

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
