### PR TITLE
[SDTEST-1351] creating tag and release after build to avoid errors

### DIFF
--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -1,8 +1,12 @@
 name: Create new release
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release Version'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -39,7 +43,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-      run: make XC_LOG=archive version=${{ github.event.release.tag_name }} github
+      run: make XC_LOG=archive version=${{ github.event.inputs.version }} github_release
     - name: Attach Xcode logs
       if: '!cancelled()'
       uses: actions/upload-artifact@v4

--- a/RELEASEMANAGEMENT.md
+++ b/RELEASEMANAGEMENT.md
@@ -2,16 +2,10 @@
 
 These are the necessary steps to release a version of the framework:
 
-1. In a terminal window, move to the root folder of `dd-sdk-swift-testing` project
-2. Confirm you are in `main` branch
-3. Run `make bump` and write the version number you want to release
-4. Commit and push the change to the repository
-5. In Github create a new release: [https://github.com/DataDog/dd-sdk-swift-testing/releases/new](https://github.com/DataDog/dd-sdk-swift-testing/releases/new) and select `main` branch
-6. Be sure to check box for **This is a pre-release**.
-7. Validate that frameworks builds correctly, passes the tests, and generates `DatadogSDKTesting.zip` in the release assets.
-8. Validate Performance:
+1. Go to release Github Action and run it on the `main` branch with the version number you want to release [Release Action](https://github.com/DataDog/dd-sdk-swift-testing/actions/workflows/createRelease.yml)
+2. Wait till action will do a build and a new **draft** release.
+3. Validate Performance:
    1. Go to https://github.com/DataDog/test-environment/actions/workflows/dd-sdk-swift-testing-tests.yml and manually trigger the GitHub Action.
    2. Wait for the workflow to finish and make sure it passes.
    3. Go to this [dashboard](https://app.datadoghq.com/dashboard/dyh-bqt-twa/tracers-performance-overhead-and-correctness-on-oss-projects?tpl_var_tracer_repository=dd-sdk-swift-testing) and check the `Max performance overhead (%)` graph. Max performance overhead shouldn’t have increased *significantly* on the latest data point. Keep in mind that values are noisy, so use your own judgement to decide whether an increase is something to worry about. 
-9. Go to the release page, and un-check **This is a pre-release**.
-10. Upload Cocoapods version: `pod trunk push DatadogSDKTesting.podspec`
+4. Go to the release page, and un-check **This is a pre-release**.


### PR DESCRIPTION
### What and why?

Current release process recreates release tag after xcframework build. This leads to cache and build problems on the users CI. Fixed this behaviour.

### How?

Release is done through workflow call. It will create tag and draft release automatically after the build

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
