### PR TITLE
[SDTEST-1351] fixed CI logic (publish pod after full release)

### DIFF
--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -42,7 +42,6 @@ jobs:
     - name: Build and upload XCFrameworks, recreate tag
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
       run: make XC_LOG=archive version=${{ github.event.inputs.version }} github_release
     - name: Attach Xcode logs
       if: '!cancelled()'

--- a/.github/workflows/publishPod.yml
+++ b/.github/workflows/publishPod.yml
@@ -1,0 +1,20 @@
+name: Publish to CocoaPods
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish-pod:
+    name: Publish Pod
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Publish
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      run: make publish_pod

--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -1448,7 +1448,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "FRAMEWORKS_DIR=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\nmkdir -p \"${FRAMEWORKS_DIR}\"\ncp -rf \"${BUILT_PRODUCTS_DIR}/CodeCoverage.framework\" \"${FRAMEWORKS_DIR}/\"\n";
+			shellScript = "FRAMEWORKS_DIR=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\nmkdir -p \"${FRAMEWORKS_DIR}\"\ncp -af \"${BUILT_PRODUCTS_DIR}/CodeCoverage.framework\" \"${FRAMEWORKS_DIR}/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,7 @@ release:
 
 github_release: release
 	@:$(call check_defined, GH_TOKEN, GitHub token)
-	@:$(call check_defined, COCOAPODS_TRUNK_TOKEN, CocoaPods trunk token)
-	# Upload binary file to GitHub release
+	# Update gh utility if needed
 	brew list gh &>/dev/null || brew install gh
 	# Commit updated xcodeproj and Package.swift
 	@git add Package.swift DatadogSDKTesting.podspec DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -99,8 +98,10 @@ github_release: release
 	# make github release
 	@gh release create $(version) --draft --verify-tag --generate-notes \
 		build/xcframework/DatadogSDKTesting.zip build/symbols/DatadogSDKTesting.symbols.zip
-	# Push Podfile
-	pod trunk push --allow-warnings DatadogSDKTesting.podspec
+
+publish_pod:
+	@:$(call check_defined, COCOAPODS_TRUNK_TOKEN, CocoaPods trunk token)
+	@pod trunk push --allow-warnings DatadogSDKTesting.podspec
 
 clean:
 	rm -rf ./build

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let url = "https://github.com/DataDog/dd-sdk-swift-testing/releases/download/\(r
 
 let package = Package(
     name: "dd-sdk-swift-testing",
-    platforms: [.macOS(.v10_13), .iOS(.v11), .tvOS(.v11)],
+    platforms: [.macOS(.v10_13), .macCatalyst(.v13), .iOS(.v11), .tvOS(.v11)],
     products: [
         .library(name: "DatadogSDKTesting",
                  targets: ["DatadogSDKTesting"]),


### PR DESCRIPTION
### What and why?

Draft release doesn't have proper versioned URL and CocoaPods publishing fails

### How?

Add one more Github Workflow, which triggered on release publishing (from draft). It will publish SDK to CocoaPods

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
