### PR TITLE
Xcode <16.3 support for 2.6.0-beta1

### DIFF
--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -14,12 +14,12 @@ permissions:
 jobs:
   test:
     name: Run Tests
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Select Xcode 16.4
-      run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+    - name: Select Xcode 16.2
+      run: sudo xcode-select --switch /Applications/Xcode_16.2.app
     - name: Test
       run: make XC_LOG=tests tests
     - name: Attach Xcode logs
@@ -31,14 +31,14 @@ jobs:
 
   release:
     needs: [test]
-    runs-on: macos-15
+    runs-on: macos-14
     permissions:
       contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Select Xcode 16.4
-      run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+    - name: Select Xcode 16.2
+      run: sudo xcode-select --switch /Applications/Xcode_16.2.app
     - name: Build and upload XCFrameworks, recreate tag
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -7,47 +7,59 @@ on:
 
 jobs:
   test-15-Unit:
-    name: Run Unit Tests macOS 15.0
-    runs-on: macos-15
+    name: Run Unit Tests
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["Xcode_16.3", "Xcode_16.4"]
+        env:
+          - xcode: "Xcode_16.2"
+            os: "macos-14"
+          - xcode: "Xcode_16.3"
+            os: "macos-15"
+          - xcode: "Xcode_16.4"
+            os: "macos-15"
+    runs-on: ${{ matrix.env.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Select ${{ matrix.xcode }}
-      run: sudo xcode-select --switch /Applications/${{ matrix.xcode }}.app
+    - name: Select ${{ matrix.env.xcode }}
+      run: sudo xcode-select --switch /Applications/${{ matrix.env.xcode }}.app
     - name: Unit tests
       run: make XC_LOG=unit tests/unit
     - name: Attach Xcode logs
       if: '!cancelled()'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.xcode }}-unit-logs
+        name: ${{ matrix.env.xcode }}-unit-logs
         path: "*-unit.log"
 
   test-15-Integration:
-    name: Run Integration Tests macOS 15.0 Xcode 16.0
-    runs-on: macos-15
+    name: Run Integration Tests
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["Xcode_16.3", "Xcode_16.4"]
+        env:
+          - xcode: "Xcode_16.2"
+            os: "macos-14"
+          - xcode: "Xcode_16.3"
+            os: "macos-15"
+          - xcode: "Xcode_16.4"
+            os: "macos-15"
         platform: ["macOS", "iOSsim", "tvOSsim"]
+    runs-on: ${{ matrix.env.os }}
     env:
       DD_API_KEY: '${{ secrets.DD_API_KEY }}'
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Select ${{ matrix.xcode }}
-      run: sudo xcode-select --switch /Applications/${{ matrix.xcode }}.app
+    - name: Select ${{ matrix.env.xcode }}
+      run: sudo xcode-select --switch /Applications/${{ matrix.env.xcode }}.app
     - name: Run tests for ${{ matrix.platform }}
       run: make XC_LOG=integration tests/integration/${{ matrix.platform }}
     - name: Attach Xcode logs
       if: '!cancelled()'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.xcode }}-${{ matrix.platform }}-integration-log
+        name: ${{ matrix.env.xcode }}-${{ matrix.platform }}-integration-log
         path: "*-integration.log"
 

--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,12 @@ release:
 github_release: release
 	@:$(call check_defined, GH_TOKEN, GitHub token)
 	# Update gh utility if needed
-	brew list gh &>/dev/null || brew install gh
+	@brew install gh || brew upgrade gh
 	# Stash changes
 	@git stash
 	# Create and push branch for release
 	@git checkout -b release-$(version)
-	@git push -u origin release-$(version)
+	@git push -f -u origin release-$(version)
 	# Get changes back
 	@git stash pop
 	# Commit updated xcodeproj, podspec and Package.swift

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -253,12 +253,12 @@ internal class DDTestMonitor {
         
         guard let branch = DDTestMonitor.env.git.branch,
               let commit = DDTestMonitor.env.git.commitSHA else {
-            Log.print("Unknown branch and commit. ITR and EFD can't be started")
+            Log.print("Unknown branch and commit. Test Optimization can't be started")
             return
         }
         
         guard let repository = DDTestMonitor.env.git.repositoryURL?.spanAttribute else {
-            Log.print("Unknown repository URL. ITR and EFD can't be started")
+            Log.print("Unknown repository URL. Test Optimization can't be started")
             return
         }
         

--- a/Sources/DatadogSDKTesting/DDTestObserver.swift
+++ b/Sources/DatadogSDKTesting/DDTestObserver.swift
@@ -300,7 +300,7 @@ class DDTestObserver: NSObject, XCTestObservation {
             // We already registered failure for this test before.
             if testRun.suppressedFailures.count > 0 { // Check if it was suppressed
                 testRun.suppressFailure() // then suppress current error too
-                Log.print("Suppressed one more issue: \(issue) for test: \(testCase)")
+                Log.debug("Suppressed one more issue: \(issue) for test: \(testCase)")
             }
             return
         }
@@ -315,7 +315,7 @@ class DDTestObserver: NSObject, XCTestObservation {
         
         if suppress.0 {
             testRun.suppressFailure()
-            Log.print("Suppressed issue \(issue) for test \(testCase) reason \(suppress.1)")
+            Log.debug("Suppressed issue \(issue) for test \(testCase) reason \(suppress.1)")
         }
     }
 }


### PR DESCRIPTION
### What and why?

Binaries build by Xcode 16.4 couldn't be used properly in the code built by Xcode <16.3.

### How?

Switched build actions to use Xcode 16.2 for SDK builds.
Added more platforms for tests so SDK will be tested on them.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
