### PR TITLE
[BUGFIX] Added flush before the exit

### DIFF
--- a/Sources/DatadogSDKTesting/Coverage/DDCoverageHelper.swift
+++ b/Sources/DatadogSDKTesting/Coverage/DDCoverageHelper.swift
@@ -110,6 +110,7 @@ final class DDCoverageHelper: TestCoverageCollector {
         coverageWorkQueue.waitUntilAllOperationsAreFinished()
         coverageWorkQueue.qualityOfService = oldQos
         coverageWorkQueue.maxConcurrentOperationCount = oldConcurrency
+        let _ = exporter.flush()
     }
 
     fileprivate static func generateProfData(profrawFile: URL) -> URL? {

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -204,6 +204,8 @@ internal class DDTestMonitor {
         tia?.stop()
         knownTests?.stop()
         testManagement?.stop()
+        DDTestMonitor.tracer.flush()
+        let _ = DDTestMonitor.tracer.eventsExporter?.flush()
         gitUploadQueue.waitUntilAllOperationsAreFinished()
     }
 


### PR DESCRIPTION
### What and why?

Seems as I forgot to add one more flush on the exit so some coverage data could be lost, if it was parsed after the module end event (it will be converted but never sent).

### How?

Added flush at the TestMonitor deinit.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
