### PR TITLE
[CHORE] draft release has broken links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ github_release: release
 	@rm -f build/symbols/DatadogSDKTesting.symbols.zip
 	@mv build/symbols/DatadogSDKTesting.zip build/symbols/DatadogSDKTesting.symbols.zip
 	# make github release
-	@gh release create $(version) --draft --verify-tag --generate-notes \
+	@gh release create $(version) --prerelease --verify-tag --generate-notes \
 		build/xcframework/DatadogSDKTesting.zip build/symbols/DatadogSDKTesting.symbols.zip
 
 publish_pod:


### PR DESCRIPTION
### What and why?

Draft releases on GitHub have broken file links. It could lead to broken CI builds if someone will try to use new version before it was manually moved from the draft to release/prerelease.

### How?

Do a prerelease by default instead of the draft release. It could be edited after if needed

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
