### PR TITLE
[SDTEST-3121] Add `branch` parameter to test management API `test-management/tests`

### DIFF
--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -408,10 +408,12 @@ internal class DDTestMonitor {
             }
             let sha = DDTestMonitor.env.git.commitHead?.sha ?? commit
             let message = DDTestMonitor.env.git.commitHead?.message ?? DDTestMonitor.env.git.commit?.message
-            
+            let branch = DDTestMonitor.env.git.branch
+
             let factory = TestManagementFactory(repository: repository,
                                                 commitSha: sha,
                                                 commitMessage: message,
+                                                branch: branch,
                                                 module: module,
                                                 attemptToFixRetries: attemptToFixRetryCount,
                                                 exporter: eventsExporter,

--- a/Sources/DatadogSDKTesting/TestManagement.swift
+++ b/Sources/DatadogSDKTesting/TestManagement.swift
@@ -153,17 +153,18 @@ extension TestManagement {
 
 struct TestManagementFactory: FeatureFactory {
     typealias FT = TestManagement
-    
+
     let cacheFileName = "test_management_tests.json"
     let repository: String
     let commitSha: String
     let commitMessage: String?
+    let branch: String?
     let attemptToFixRetries: UInt
     let cacheFolder: Directory
     let exporter: EventsExporterProtocol
     let module: String
-    
-    init(repository: String, commitSha: String, commitMessage: String?,
+
+    init(repository: String, commitSha: String, commitMessage: String?, branch: String?,
          module: String, attemptToFixRetries: UInt,
          exporter: EventsExporterProtocol, cache: Directory
     ) {
@@ -171,6 +172,7 @@ struct TestManagementFactory: FeatureFactory {
         self.repository = repository
         self.commitSha = commitSha
         self.commitMessage = commitMessage
+        self.branch = branch
         self.attemptToFixRetries = attemptToFixRetries
         self.exporter = exporter
         self.module = module
@@ -212,7 +214,7 @@ struct TestManagementFactory: FeatureFactory {
     
     private func getTests(exporter: EventsExporterProtocol, log: Logger) -> TestManagementTestsInfo? {
         let tests = exporter.testManagementTests(repositoryURL: repository, sha: commitSha,
-                                                 commitMessage: commitMessage, module: module)
+                                                 commitMessage: commitMessage, module: module, branch: branch)
         guard let tests = tests else {
             Log.print("Test Management: tests request failed")
             return nil

--- a/Sources/EventsExporter/EventsExporter.swift
+++ b/Sources/EventsExporter/EventsExporter.swift
@@ -27,7 +27,7 @@ public protocol EventsExporterProtocol: SpanExporter {
         configurations: [String: String], customConfigurations: [String: String]
     ) -> KnownTestsMap?
     func testManagementTests(
-        repositoryURL: String, sha: String?, commitMessage: String?, module: String?
+        repositoryURL: String, sha: String?, commitMessage: String?, module: String?, branch: String?
     ) -> TestManagementTestsInfo?
 }
 
@@ -133,9 +133,9 @@ public class EventsExporter: EventsExporterProtocol {
     }
     
     public func testManagementTests(
-        repositoryURL: String, sha: String? = nil, commitMessage: String? = nil, module: String? = nil
+        repositoryURL: String, sha: String? = nil, commitMessage: String? = nil, module: String? = nil, branch: String? = nil
     ) -> TestManagementTestsInfo? {
-        testManagementService.tests(repositoryURL: repositoryURL, sha: sha, commitMessage: commitMessage, module: module)
+        testManagementService.tests(repositoryURL: repositoryURL, sha: sha, commitMessage: commitMessage, module: module, branch: branch)
     }
 
     public func shutdown(explicitTimeout: TimeInterval?) {

--- a/Sources/EventsExporter/TestManagementService.swift
+++ b/Sources/EventsExporter/TestManagementService.swift
@@ -37,9 +37,9 @@ internal final class TestManagementService {
     }
     
     func tests(
-        repositoryURL: String, sha: String? = nil, commitMessage: String? = nil, module: String? = nil
+        repositoryURL: String, sha: String? = nil, commitMessage: String? = nil, module: String? = nil, branch: String? = nil
     ) -> TestManagementTestsInfo? {
-        let testsPayload = TestsRequest(repositoryURL: repositoryURL, sha: sha, commitMessage: commitMessage, module: module)
+        let testsPayload = TestsRequest(repositoryURL: repositoryURL, sha: sha, commitMessage: commitMessage, module: module, branch: branch)
 
         guard let jsonData = testsPayload.jsonData,
               let response = testsUploader.uploadWithResponse(data: jsonData)
@@ -73,20 +73,22 @@ extension TestManagementService {
                 let commitMessage: String?
                 let module: String?
                 let sha: String?
-                
+                let branch: String?
+
                 enum CodingKeys: String, CodingKey {
                     case repositoryURL = "repository_url"
                     case commitMessage = "commit_message"
                     case module
                     case sha
+                    case branch
                 }
             }
         }
         
-        init(repositoryURL: String, sha: String? = nil, commitMessage: String? = nil, module: String? = nil) {
+        init(repositoryURL: String, sha: String? = nil, commitMessage: String? = nil, module: String? = nil, branch: String? = nil) {
             self.data = Data(
                 attributes: Data.Attributes(
-                    repositoryURL: repositoryURL, commitMessage: commitMessage, module: module, sha: sha
+                    repositoryURL: repositoryURL, commitMessage: commitMessage, module: module, sha: sha, branch: branch
                 )
             )
         }


### PR DESCRIPTION
### What and why?

https://datadoghq.atlassian.net/browse/SDTEST-3121

We're going to need a `branch` parameter for new flaky PR gates

### How?

Add `branch` parameter to the request done to `/api/v2/test/libraries/test-management/tests` to request the test management tests (including attempt to fix)

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
