### PR TITLE
[SDTEST-3691] Test Impact Analysis

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		A7675D722F6CA00000A05B5F /* SwiftTestRunParametersParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7675D712F6CA00000A05B5F /* SwiftTestRunParametersParserTests.swift */; };
 		A7675D742F6CA00000A05B5F /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7675D732F6CA00000A05B5F /* SessionManagerTests.swift */; };
 		A76F0F992E2A9F0D009ACD06 /* TestImpactAnalysisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76F0F982E2A9F02009ACD06 /* TestImpactAnalysisTests.swift */; };
+		E5BF2275FF5E4C7D9EE74AD2 /* TestImpactAnalysisSwiftTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */; };
 		A77C122F2D89CFC2009C2BA1 /* SDKCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C122E2D89CFC2009C2BA1 /* SDKCapabilities.swift */; };
 		A77C12312D8C976B009C2BA1 /* TestManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C12302D8C976B009C2BA1 /* TestManagementService.swift */; };
 		A77C12332D8C9798009C2BA1 /* KnownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C12322D8C9798009C2BA1 /* KnownTests.swift */; };
@@ -399,6 +400,7 @@
 		A7675D712F6CA00000A05B5F /* SwiftTestRunParametersParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftTestRunParametersParserTests.swift; sourceTree = "<group>"; };
 		A7675D732F6CA00000A05B5F /* SessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
 		A76F0F982E2A9F02009ACD06 /* TestImpactAnalysisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisTests.swift; sourceTree = "<group>"; };
+		0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisSwiftTestingTests.swift; sourceTree = "<group>"; };
 		A77C122E2D89CFC2009C2BA1 /* SDKCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKCapabilities.swift; sourceTree = "<group>"; };
 		A77C12302D8C976B009C2BA1 /* TestManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestManagementService.swift; sourceTree = "<group>"; };
 		A77C12322D8C9798009C2BA1 /* KnownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KnownTests.swift; sourceTree = "<group>"; };
@@ -744,6 +746,7 @@
 			children = (
 				A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */,
 				A76F0F982E2A9F02009ACD06 /* TestImpactAnalysisTests.swift */,
+				0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */,
 				A70B91122DF0AE11003F284F /* AutoTestRetriesTests.swift */,
 				31F8747157604DB48FE692EB /* AutoTestRetriesSwiftTestingTests.swift */,
 				A7B6602E2C2E08A900AEBA6C /* TestImpactAnalysisSkippableTests.swift */,
@@ -1768,6 +1771,7 @@
 				A7FC26652BA1F6FC00067E26 /* GitInfoTests.swift in Sources */,
 				A7FC26692BA1F6FC00067E26 /* SwiftExtensionsTests.swift in Sources */,
 				A76F0F992E2A9F0D009ACD06 /* TestImpactAnalysisTests.swift in Sources */,
+				E5BF2275FF5E4C7D9EE74AD2 /* TestImpactAnalysisSwiftTestingTests.swift in Sources */,
 				A7FC26612BA1F67800067E26 /* DDSymbolicatorTests.swift in Sources */,
 				A7FC266A2BA1F6FC00067E26 /* SpySpanProcessor.swift in Sources */,
 				A7FC26642BA1F6BF00067E26 /* StdoutCaptureTests.swift in Sources */,

--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		A7675D742F6CA00000A05B5F /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7675D732F6CA00000A05B5F /* SessionManagerTests.swift */; };
 		A76F0F992E2A9F0D009ACD06 /* TestImpactAnalysisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76F0F982E2A9F02009ACD06 /* TestImpactAnalysisTests.swift */; };
 		E5BF2275FF5E4C7D9EE74AD2 /* TestImpactAnalysisSwiftTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */; };
+		A7DEAD022F3DEAD00000001A /* ParallelTestRunnerDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DEAD012F3DEAD00000001A /* ParallelTestRunnerDetector.swift */; };
+		A7DEAD042F3DEAD00000001A /* ParallelTestRunnerDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DEAD032F3DEAD00000001A /* ParallelTestRunnerDetectorTests.swift */; };
 		A77C122F2D89CFC2009C2BA1 /* SDKCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C122E2D89CFC2009C2BA1 /* SDKCapabilities.swift */; };
 		A77C12312D8C976B009C2BA1 /* TestManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C12302D8C976B009C2BA1 /* TestManagementService.swift */; };
 		A77C12332D8C9798009C2BA1 /* KnownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C12322D8C9798009C2BA1 /* KnownTests.swift */; };
@@ -401,6 +403,8 @@
 		A7675D732F6CA00000A05B5F /* SessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
 		A76F0F982E2A9F02009ACD06 /* TestImpactAnalysisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisTests.swift; sourceTree = "<group>"; };
 		0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisSwiftTestingTests.swift; sourceTree = "<group>"; };
+		A7DEAD012F3DEAD00000001A /* ParallelTestRunnerDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParallelTestRunnerDetector.swift; sourceTree = "<group>"; };
+		A7DEAD032F3DEAD00000001A /* ParallelTestRunnerDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParallelTestRunnerDetectorTests.swift; sourceTree = "<group>"; };
 		A77C122E2D89CFC2009C2BA1 /* SDKCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKCapabilities.swift; sourceTree = "<group>"; };
 		A77C12302D8C976B009C2BA1 /* TestManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestManagementService.swift; sourceTree = "<group>"; };
 		A77C12322D8C9798009C2BA1 /* KnownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KnownTests.swift; sourceTree = "<group>"; };
@@ -747,6 +751,7 @@
 				A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */,
 				A76F0F982E2A9F02009ACD06 /* TestImpactAnalysisTests.swift */,
 				0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */,
+				A7DEAD032F3DEAD00000001A /* ParallelTestRunnerDetectorTests.swift */,
 				A70B91122DF0AE11003F284F /* AutoTestRetriesTests.swift */,
 				31F8747157604DB48FE692EB /* AutoTestRetriesSwiftTestingTests.swift */,
 				A7B6602E2C2E08A900AEBA6C /* TestImpactAnalysisSkippableTests.swift */,
@@ -1066,6 +1071,7 @@
 				E146BC392869AEA80057C37B /* GitUploader.swift */,
 				E137366128A3BE3600420E26 /* TestImpactAnalysis.swift */,
 				A74245FF2BFF94FA00F7EC64 /* TestImpactAnalysisSkippabble.swift */,
+				A7DEAD012F3DEAD00000001A /* ParallelTestRunnerDetector.swift */,
 			);
 			path = TestImpactAnalysis;
 			sourceTree = "<group>";
@@ -1759,6 +1765,7 @@
 				A77C122F2D89CFC2009C2BA1 /* SDKCapabilities.swift in Sources */,
 				A7CC6D862C07D624003C13BC /* Tags.swift in Sources */,
 				A74246002BFF94FA00F7EC64 /* TestImpactAnalysisSkippabble.swift in Sources */,
+				A7DEAD022F3DEAD00000001A /* ParallelTestRunnerDetector.swift in Sources */,
 				A7A98C202C8F44BC00C93E59 /* CoverageSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1772,6 +1779,7 @@
 				A7FC26692BA1F6FC00067E26 /* SwiftExtensionsTests.swift in Sources */,
 				A76F0F992E2A9F0D009ACD06 /* TestImpactAnalysisTests.swift in Sources */,
 				E5BF2275FF5E4C7D9EE74AD2 /* TestImpactAnalysisSwiftTestingTests.swift in Sources */,
+				A7DEAD042F3DEAD00000001A /* ParallelTestRunnerDetectorTests.swift in Sources */,
 				A7FC26612BA1F67800067E26 /* DDSymbolicatorTests.swift in Sources */,
 				A7FC266A2BA1F6FC00067E26 /* SpySpanProcessor.swift in Sources */,
 				A7FC26642BA1F6BF00067E26 /* StdoutCaptureTests.swift in Sources */,

--- a/Sources/DatadogSDKTesting/AutomaticTestRetries.swift
+++ b/Sources/DatadogSDKTesting/AutomaticTestRetries.swift
@@ -24,7 +24,7 @@ final class AutomaticTestRetries: TestHooksFeature {
         self._failedTestTotalRetries = Synced(0)
     }
     
-    func testGroupConfiguration(for test: String, meta: UnskippableMethodCheckerFactory,
+    func testGroupConfiguration(for test: String, tags: any TestTags,
                                 in suite: any TestSuite,
                                 configuration: RetryGroupConfiguration.Iterator) -> RetryGroupConfiguration.Iterator
     {

--- a/Sources/DatadogSDKTesting/Config.swift
+++ b/Sources/DatadogSDKTesting/Config.swift
@@ -45,7 +45,7 @@ final class Config {
     /// TIA  related environment
     var gitUploadEnabled: Bool = true
     var tiaEnabled: Bool = true
-    var tiaSwiftTestingEnabled: Bool = false
+    var tiaSwiftTestingEnabled: Bool? = nil
     var codeCoverageEnabled: Bool = true
     var excludedBranches: Set<String> = []
     var codeCoveragePriority: CodeCoveragePriority = .utility
@@ -132,7 +132,7 @@ final class Config {
         /// Intelligent test runner related configuration
         gitUploadEnabled = env[.enableCiVisibilityGitUpload] ?? gitUploadEnabled
         tiaEnabled = env[.enableTIA] ?? env[.enableCiVisibilityITR] ?? tiaEnabled
-        tiaSwiftTestingEnabled = tiaEnabled && (env[.enableSwiftTestingTIA] ?? tiaSwiftTestingEnabled)
+        tiaSwiftTestingEnabled = env[.enableSwiftTestingTIA]
         excludedBranches = env[.ciVisibilityExcludedBranches] ?? excludedBranches
         codeCoverageEnabled = env[.enableCiVisibilityCodeCoverage] ?? tiaEnabled
         
@@ -233,7 +233,7 @@ extension Config: CustomDebugStringConvertible {
         Git Upload Enabled: \(gitUploadEnabled)
         Coverage Enabled: \(codeCoverageEnabled)
         Test Impact Analysis Enabled: \(tiaEnabled)
-        Test Impact Analysis for Swift Testing Enabled: \(tiaSwiftTestingEnabled)
+        Test Impact Analysis for Swift Testing Enabled: \(tiaSwiftTestingEnabled.map(String.init) ?? "auto-detect")
         Excluded Branches: \(excludedBranches)
         Test Management Enabled: \(testManagementEnabled)
         Test Management Attempt To Fix Retries: \(testManagementAttemptToFixRetries.map(String.init) ?? "nil")

--- a/Sources/DatadogSDKTesting/Config.swift
+++ b/Sources/DatadogSDKTesting/Config.swift
@@ -42,9 +42,10 @@ final class Config {
     var disableNTPClock: Bool = false
     var disableGitInformation: Bool = false
     
-    /// Intelligent test runner related environment
+    /// TIA  related environment
     var gitUploadEnabled: Bool = true
-    var itrEnabled: Bool = true
+    var tiaEnabled: Bool = true
+    var tiaSwiftTestingEnabled: Bool = false
     var codeCoverageEnabled: Bool = true
     var excludedBranches: Set<String> = []
     var codeCoveragePriority: CodeCoveragePriority = .utility
@@ -130,9 +131,10 @@ final class Config {
         
         /// Intelligent test runner related configuration
         gitUploadEnabled = env[.enableCiVisibilityGitUpload] ?? gitUploadEnabled
-        itrEnabled = env[.enableCiVisibilityITR] ?? itrEnabled
+        tiaEnabled = env[.enableTIA] ?? env[.enableCiVisibilityITR] ?? tiaEnabled
+        tiaSwiftTestingEnabled = tiaEnabled && (env[.enableSwiftTestingTIA] ?? tiaSwiftTestingEnabled)
         excludedBranches = env[.ciVisibilityExcludedBranches] ?? excludedBranches
-        codeCoverageEnabled = env[.enableCiVisibilityCodeCoverage] ?? itrEnabled
+        codeCoverageEnabled = env[.enableCiVisibilityCodeCoverage] ?? tiaEnabled
         
         /// EFD
         efdEnabled = env[.enableCiVisibilityEFD] ?? efdEnabled
@@ -230,7 +232,8 @@ extension Config: CustomDebugStringConvertible {
         Disable Git Information: \(disableGitInformation)
         Git Upload Enabled: \(gitUploadEnabled)
         Coverage Enabled: \(codeCoverageEnabled)
-        ITR Enabled: \(itrEnabled)
+        Test Impact Analysis Enabled: \(tiaEnabled)
+        Test Impact Analysis for Swift Testing Enabled: \(tiaSwiftTestingEnabled)
         Excluded Branches: \(excludedBranches)
         Test Management Enabled: \(testManagementEnabled)
         Test Management Attempt To Fix Retries: \(testManagementAttemptToFixRetries.map(String.init) ?? "nil")

--- a/Sources/DatadogSDKTesting/Coverage/DDCoverageHelper.swift
+++ b/Sources/DatadogSDKTesting/Coverage/DDCoverageHelper.swift
@@ -11,7 +11,7 @@ internal import CDatadogSDKTesting
 
 typealias cFunc = @convention(c) () -> Void
 
-protocol TestCoverageCollector: Feature {
+protocol TestCoverageCollector: Feature, Sendable {
     func startTest()
     func endTest(testSessionId: UInt64, testSuiteId: UInt64, spanId: UInt64)
 }
@@ -19,7 +19,7 @@ protocol TestCoverageCollector: Feature {
 final class DDCoverageHelper: TestCoverageCollector {
     static var id: FeatureId = "Coverage Helper"
     
-    let processor: CoverageProcessor
+    nonisolated(unsafe) let processor: CoverageProcessor
     let exporter: EventsExporterProtocol
     let workspacePath: String?
 

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -622,7 +622,7 @@ internal class DDTestMonitor {
         CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, CFRunLoopMode.commonModes)
     }
     
-    var activeFeatures: [any TestHooksFeature] {
+    var activeFeatures: any TestHooksFeatures {
         testOptimizationSetupQueue.waitUntilAllOperationsAreFinished()
         let features: [(any TestHooksFeature)?] = [
             testManagement, tia, efd, atr, knownTests,

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -446,6 +446,7 @@ internal class DDTestMonitor {
                                                     repository: repository,
                                                     cache: cache,
                                                     skippingEnabled: remote.itr.testsSkipping,
+                                                    swiftTestingEnabled: DDTestMonitor.config.tiaSwiftTestingEnabled,
                                                     coverage: coverage)
             self.tia = factory.create(log: Log.instance)
         }

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -446,7 +446,7 @@ internal class DDTestMonitor {
                                                     repository: repository,
                                                     cache: cache,
                                                     skippingEnabled: remote.itr.testsSkipping,
-                                                    swiftTestingEnabled: DDTestMonitor.config.tiaSwiftTestingEnabled,
+                                                    swiftTestingEnabled: DDTestMonitor.env.tiaSwiftTestingEnabled,
                                                     coverage: coverage)
             self.tia = factory.create(log: Log.instance)
         }

--- a/Sources/DatadogSDKTesting/EarlyFlakeDetection.swift
+++ b/Sources/DatadogSDKTesting/EarlyFlakeDetection.swift
@@ -91,7 +91,7 @@ final class EarlyFlakeDetection: TestHooksFeature {
         }
     }
     
-    func testGroupConfiguration(for test: String, meta: UnskippableMethodCheckerFactory,
+    func testGroupConfiguration(for test: String, tags: any TestTags,
                                 in suite: any TestSuite,
                                 configuration: RetryGroupConfiguration.Iterator) -> RetryGroupConfiguration.Iterator
     {

--- a/Sources/DatadogSDKTesting/Environment/Environment.swift
+++ b/Sources/DatadogSDKTesting/Environment/Environment.swift
@@ -19,6 +19,7 @@ internal final class Environment {
     let testCommand: String
     let service: String
     let isUserProvidedService: Bool
+    let tiaSwiftTestingEnabled: Bool
     
     var environment: String {
         config.environment ?? (ci != nil ? "ci" : "none")
@@ -34,9 +35,21 @@ internal final class Environment {
     init(config: Config, env: EnvironmentReader, log: Logger, ciReaders: [CIEnvironmentReader] = Environment.ciReaders) {
         self.env = env
         self.config = config
-        
+
         sourceRoot = env[.sourcesDir]
-        
+
+        // Determine whether Swift Testing TIA is enabled for this target.
+        // Explicit env var takes precedence; otherwise auto-detect from the test runner config.
+        let targetName: String? = Bundle.testBundle?.name ?? Bundle.main.name
+        if let explicit = config.tiaSwiftTestingEnabled {
+            tiaSwiftTestingEnabled = config.tiaEnabled && explicit
+        } else {
+            tiaSwiftTestingEnabled = config.tiaEnabled &&
+                ParallelTestRunnerDetector.isParallelizationDisabled(
+                    env: env, sourceRoot: sourceRoot, targetName: targetName
+                )
+        }
+
         /// Device Information
         let (runtimeName, runtimeVersion) = PlatformUtils.getRuntimeInfo()
         platform = Platform(deviceName: PlatformUtils.getDeviceName(),

--- a/Sources/DatadogSDKTesting/Environment/EnvironmentKeys.swift
+++ b/Sources/DatadogSDKTesting/Environment/EnvironmentKeys.swift
@@ -42,6 +42,8 @@ internal enum EnvironmentKey: String, CaseIterable {
     case enableCiVisibilityCodeCoverage = "DD_CIVISIBILITY_CODE_COVERAGE_ENABLED"
     case ciVisibilityCodeCoveragePriority = "DD_CIVISIBILITY_CODE_COVERAGE_PRIORITY"
     case enableCiVisibilityITR = "DD_CIVISIBILITY_ITR_ENABLED"
+    case enableTIA = "DD_TEST_IMPACT_ANALYSIS_ENABLED"
+    case enableSwiftTestingTIA = "DD_SWIFT_TESTING_TEST_IMPACT_ANALYSIS_ENABLED"
     case ciVisibilityExcludedBranches = "DD_CIVISIBILITY_EXCLUDED_BRANCHES"
     case ciVisibilityReportHostname = "DD_CIVISIBILITY_REPORT_HOSTNAME"
     case enableCiVisibilityEFD = "DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED"

--- a/Sources/DatadogSDKTesting/Feature.swift
+++ b/Sources/DatadogSDKTesting/Feature.swift
@@ -54,7 +54,7 @@ protocol TestHooksFeature: Feature, Sendable {
     // Test related callbacks
     /// Configuration for retry group. Feature can interrupt iteration or send it to the next feature with updated config.
     func testGroupConfiguration(for test: String,
-                                meta: UnskippableMethodCheckerFactory,
+                                tags: any TestTags,
                                 in suite: any TestSuite,
                                 configuration: RetryGroupConfiguration.Iterator) -> RetryGroupConfiguration.Iterator
     /// Start of the test case
@@ -399,12 +399,12 @@ protocol TestHooksFeatures: Sendable {
     func testGroupWillStart(for test: String, in suite: any TestSuite)
     
     func testGroupConfiguration(
-        for test: String, meta: UnskippableMethodCheckerFactory, in suite: any TestSuite,
+        for test: String, tags: any TestTags, in suite: any TestSuite,
         configuration: RetryGroupConfiguration.Iterator
     ) -> (feature: (any TestHooksFeature)?, configuration: RetryGroupConfiguration)
     
     func testGroupConfiguration(
-        for test: String, meta: UnskippableMethodCheckerFactory, in suite: any TestSuite
+        for test: String, tags: any TestTags, in suite: any TestSuite
     ) -> (feature: (any TestHooksFeature)?, configuration: RetryGroupConfiguration)
     
     func testWillStart(test: any TestRun, info: TestRunInfoStart)
@@ -430,9 +430,9 @@ protocol TestHooksFeatures: Sendable {
 
 extension TestHooksFeatures {
     func testGroupConfiguration(
-        for test: String, meta: UnskippableMethodCheckerFactory, in suite: any TestSuite
+        for test: String, tags: any TestTags, in suite: any TestSuite
     ) -> (feature: (any TestHooksFeature)?, configuration: RetryGroupConfiguration) {
-        testGroupConfiguration(for: test, meta: meta,
+        testGroupConfiguration(for: test, tags: tags,
                                in: suite, configuration: .init())
     }
     
@@ -460,7 +460,7 @@ extension TestHooksFeature {
     func testSuiteWillEnd(suite: any TestSuite) -> Void {}
     func testSuiteDidEnd(suite: any TestSuite) -> Void {}
     
-    func testGroupConfiguration(for test: String, meta: UnskippableMethodCheckerFactory,
+    func testGroupConfiguration(for test: String, tags: any TestTags,
                                 in suite: any TestSuite,
                                 configuration: RetryGroupConfiguration.Iterator) -> RetryGroupConfiguration.Iterator
     {
@@ -550,17 +550,13 @@ extension Array: TestHooksFeatures where Element == (any TestHooksFeature) {
     }
     
     func testGroupConfiguration(
-        for test: String, meta: UnskippableMethodCheckerFactory, in suite: any TestSuite,
+        for test: String, tags: any TestTags, in suite: any TestSuite,
         configuration: RetryGroupConfiguration.Iterator
     ) -> (feature: (any TestHooksFeature)?, configuration: RetryGroupConfiguration) {
         var configuration = configuration
         for feature in self {
-            configuration = feature.testGroupConfiguration(
-                for: test,
-                meta: meta,
-                in: suite,
-                configuration: configuration
-            )
+            configuration = feature.testGroupConfiguration(for: test, tags: tags, in: suite,
+                                                           configuration: configuration)
             if !configuration.hasNext {
                 return (feature, configuration.configuration)
             }

--- a/Sources/DatadogSDKTesting/Models.swift
+++ b/Sources/DatadogSDKTesting/Models.swift
@@ -149,6 +149,14 @@ extension TestRun {
     }
 }
 
+protocol TestTag {
+    associatedtype Value
+}
+
+protocol TestTags {
+    func get<T: TestTag>(tag: T) -> T.Value?
+}
+
 @objc(DDTestStatus)
 public enum TestStatus: Int, Sendable {
     case pass

--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingContext.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingContext.swift
@@ -716,7 +716,7 @@ struct SwiftTestingSuiteProvider: SwiftTestingSuiteProviderType {
     {
         let suite = try await self._state.suite(named: info.suite, in: info.module) { (mod, manager, config) in
             let count = try await self.registry.count(for: info)
-            let suite = mod.startSuite(named: info.suite, at: nil, framework: "Testing")
+            let suite = mod.startSuite(named: info.suite, at: nil, framework: Self.framework)
             return .init(suite: suite, configuration: config, info: info,
                          testsCount: count, observer: self.observer, moduleManager: manager)
         }
@@ -731,7 +731,7 @@ struct SwiftTestingSuiteProvider: SwiftTestingSuiteProviderType {
     {
         let suite = try await self._state.suite(named: test.suite, in: test.module) { (mod, manager, config) in
             let tests = try await self.registry.tests(for: test)
-            let suite = mod.startSuite(named: test.suite, at: nil, framework: "Testing")
+            let suite = mod.startSuite(named: test.suite, at: nil, framework: Self.framework)
             return SwiftTestingSuiteContext(suite: suite, configuration: config,
                                             tests: tests, info: test, observer: self.observer,
                                             moduleManager: manager)
@@ -761,6 +761,12 @@ struct SwiftTestingSuiteProvider: SwiftTestingSuiteProviderType {
     var session: any TestSessionManager {
         _state.session
     }
+    
+    static let framework = "Testing"
+}
+
+extension TestSuite {
+    var isSwiftTesting: Bool { testFramework ==  SwiftTestingSuiteProvider.framework }
 }
 
 extension Optional where Wrapped == SwiftTestingTestStatus.Errors {

--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingObserver.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingObserver.swift
@@ -57,7 +57,7 @@ struct SwiftTestingObserver: SwiftTestingObserverType {
         test: borrowing SwiftTestingTestContext
     ) async -> (feature: FeatureId?, configuration: RetryGroupConfiguration) {
         let (feautre, config) = test.configuration.activeFeatures.testGroupConfiguration(for: test.info.name,
-                                                                                         meta: Self.dummyChecker,
+                                                                                         tags: DummyTags(),
                                                                                          in: test.suite.suite)
         return (feautre?.id, config)
     }
@@ -106,11 +106,9 @@ struct SwiftTestingObserver: SwiftTestingObserverType {
 }
 
 extension SwiftTestingObserver {
-    final class DummyUnskippableCheckerFactory: UnskippableMethodCheckerFactory {
-        let classId: ObjectIdentifier = .init(DummyUnskippableCheckerFactory.self)
-        let unskippableMethods: UnskippableMethodChecker = .init(isSuiteUnskippable: false,
-                                                                 skippableMethods: [:])
+    struct DummyTags: TestTags {
+        func get<T: TestTag>(tag: T) -> T.Value? {
+            return nil
+        }
     }
-    
-    static let dummyChecker = DummyUnskippableCheckerFactory()
 }

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/ParallelTestRunnerDetector.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/ParallelTestRunnerDetector.swift
@@ -1,0 +1,241 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Detects whether test parallelization is disabled for the running test target.
+/// Used by `Environment` to automatically enable Swift Testing TIA when tests are
+/// confirmed to run serially.
+enum ParallelTestRunnerDetector {
+
+    /// Returns `true` when test parallelization is detected as disabled for `targetName`.
+    ///
+    /// Detection strategy (in priority order):
+    /// 1. **Xcode with test plan** (`XCODE_TEST_PLAN_NAME` set): reads `parallelizable` from the
+    ///    `.xctestplan` file for the target whose `name` matches `targetName`.
+    /// 2. **Xcode without test plan** (`XCODE_SCHEME_NAME` set, no `XCODE_TEST_PLAN_NAME`): reads
+    ///    `parallelizable` from the `.xcscheme` `TestableReference` whose `BlueprintName` matches
+    ///    `targetName`.
+    /// 3. **`swift test`** (neither env var set): checks `ProcessInfo.processInfo.arguments`
+    ///    for `--no-parallel`.
+    ///
+    /// When `targetName` is `nil` (unknown bundle), detection falls back to checking whether
+    /// *any* configured target has parallelization disabled.
+    static func isParallelizationDisabled(env: EnvironmentReader, sourceRoot: String?,
+                                          targetName: String?) -> Bool {
+        let testPlanName: String? = env.get(env: "XCODE_TEST_PLAN_NAME")
+        let schemeName: String? = env.get(env: "XCODE_SCHEME_NAME")
+
+        if let testPlanName {
+            guard let sourceRoot else { return false }
+            return checkTestPlan(named: testPlanName, sourceRoot: sourceRoot,
+                                 schemeName: schemeName, targetName: targetName) ?? false
+        }
+
+        if let schemeName {
+            guard let sourceRoot else { return false }
+            return checkScheme(named: schemeName, sourceRoot: sourceRoot,
+                               targetName: targetName) ?? false
+        }
+
+        return ProcessInfo.processInfo.arguments.contains("--no-parallel")
+    }
+
+    // MARK: - Test Plan
+
+    private static func checkTestPlan(named name: String, sourceRoot: String,
+                                      schemeName: String?, targetName: String?) -> Bool? {
+        guard let planPath = resolvePlanPath(named: name, sourceRoot: sourceRoot,
+                                            schemeName: schemeName),
+              let data = FileManager.default.contents(atPath: planPath) else { return nil }
+        return isTestPlanNonParallel(data: data, targetName: targetName)
+    }
+
+    private static func resolvePlanPath(named name: String, sourceRoot: String,
+                                        schemeName: String?) -> String? {
+        if let schemeName,
+           let schemeURL = findSchemeFile(named: schemeName, in: sourceRoot) {
+            let parser = XCSchemeParser()
+            if let scheme = parser.parse(url: schemeURL),
+               let path = scheme.testPlanPath(named: name, sourceRoot: sourceRoot) {
+                return path
+            }
+        }
+        return findFile(named: "\(name).xctestplan", in: sourceRoot, maxDepth: 5)
+    }
+
+    /// Checks whether the test plan data has parallelization disabled.
+    ///
+    /// When `targetName` is supplied the check is scoped to the matching target entry:
+    /// - target found with `parallelizable: false` → `true`
+    /// - target found without the key or `parallelizable: true` → `false`
+    /// - target not found → `nil` (can't determine)
+    ///
+    /// When `targetName` is `nil` any target with `parallelizable: false` returns `true`.
+    static func isTestPlanNonParallel(data: Data, targetName: String?) -> Bool? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let testTargets = json["testTargets"] as? [[String: Any]],
+              !testTargets.isEmpty else { return nil }
+
+        if let targetName {
+            guard let entry = testTargets.first(where: {
+                ($0["target"] as? [String: Any])?["name"] as? String == targetName
+            }) else { return nil }
+            return (entry["parallelizable"] as? Bool) == false
+        }
+
+        return testTargets.contains { ($0["parallelizable"] as? Bool) == false }
+    }
+
+    // MARK: - Scheme (no test plan)
+
+    private static func checkScheme(named name: String, sourceRoot: String,
+                                    targetName: String?) -> Bool? {
+        guard let schemeURL = findSchemeFile(named: name, in: sourceRoot) else { return nil }
+        let parser = XCSchemeParser()
+        guard let scheme = parser.parse(url: schemeURL) else { return nil }
+        guard !scheme.hasTestPlans, !scheme.testableReferences.isEmpty else { return nil }
+
+        if let targetName {
+            guard let ref = scheme.testableReferences.first(where: {
+                $0.targetName == targetName
+            }) else { return nil }
+            return ref.isNonParallel
+        }
+
+        return scheme.testableReferences.contains { $0.isNonParallel }
+    }
+
+    // MARK: - File utilities
+
+    /// Finds `<name>.xcscheme` inside any `*.xcodeproj` or `*.xcworkspace` located
+    /// directly under `sourceRoot`.
+    static func findSchemeFile(named name: String, in sourceRoot: String) -> URL? {
+        let fm = FileManager.default
+        let fileName = "\(name).xcscheme"
+        guard let items = try? fm.contentsOfDirectory(atPath: sourceRoot) else { return nil }
+        for item in items where item.hasSuffix(".xcodeproj") || item.hasSuffix(".xcworkspace") {
+            let schemesDir = (((sourceRoot as NSString).appendingPathComponent(item) as NSString)
+                .appendingPathComponent("xcshareddata/xcschemes"))
+            let schemePath = (schemesDir as NSString).appendingPathComponent(fileName)
+            if fm.fileExists(atPath: schemePath) {
+                return URL(fileURLWithPath: schemePath)
+            }
+        }
+        return nil
+    }
+
+    /// Recursively searches `directory` (up to `maxDepth` levels) for a file named `fileName`.
+    /// Hidden entries and Xcode/build artefact directories are skipped.
+    static func findFile(named fileName: String, in directory: String, maxDepth: Int) -> String? {
+        guard maxDepth >= 0 else { return nil }
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(atPath: directory) else { return nil }
+        for item in contents {
+            let path = (directory as NSString).appendingPathComponent(item)
+            if item == fileName { return path }
+            guard maxDepth > 0,
+                  !item.hasPrefix("."),
+                  !item.hasSuffix(".xcodeproj"),
+                  !item.hasSuffix(".xcworkspace"),
+                  item != "DerivedData", item != "build", item != ".build" else { continue }
+            var isDir: ObjCBool = false
+            fm.fileExists(atPath: path, isDirectory: &isDir)
+            if isDir.boolValue,
+               let found = findFile(named: fileName, in: path, maxDepth: maxDepth - 1) {
+                return found
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Xcscheme XML parser
+
+private final class XCSchemeParser: NSObject, XMLParserDelegate {
+
+    struct Scheme {
+        struct TestableRef {
+            /// `true` when the XML attribute `parallelizable = "NO"`.
+            let isNonParallel: Bool
+            /// The `BlueprintName` of the nested `BuildableReference` element.
+            let targetName: String?
+        }
+
+        var testPlanReferences: [String] = []
+        var testableReferences: [TestableRef] = []
+
+        var hasTestPlans: Bool { !testPlanReferences.isEmpty }
+
+        /// Resolves the file-system path to the test plan named `name` using the
+        /// `container:`-relative reference stored in the scheme.
+        func testPlanPath(named name: String, sourceRoot: String) -> String? {
+            let suffix = "\(name).xctestplan"
+            guard let reference = testPlanReferences.first(where: { $0.hasSuffix(suffix) }) else {
+                return nil
+            }
+            let relative = reference.replacingOccurrences(of: "container:", with: "")
+            return (sourceRoot as NSString).appendingPathComponent(relative)
+        }
+    }
+
+    // Mutable snapshot collected while parsing a single <TestableReference> element.
+    private struct PendingRef {
+        var isNonParallel: Bool
+        var targetName: String? = nil
+    }
+
+    private var scheme = Scheme()
+    private var inTestAction = false
+    private var pendingRef: PendingRef? = nil
+
+    func parse(url: URL) -> Scheme? {
+        guard let parser = XMLParser(contentsOf: url) else { return nil }
+        parser.delegate = self
+        return parser.parse() ? scheme : nil
+    }
+
+    // MARK: XMLParserDelegate
+
+    func parser(_ parser: XMLParser, didStartElement elementName: String,
+                namespaceURI: String?, qualifiedName qName: String?,
+                attributes attributeDict: [String: String]) {
+        switch elementName {
+        case "TestAction":
+            inTestAction = true
+        case "TestPlanReference" where inTestAction:
+            if let ref = attributeDict["reference"] {
+                scheme.testPlanReferences.append(ref)
+            }
+        case "TestableReference" where inTestAction:
+            let isNonParallel = attributeDict["parallelizable"].map {
+                $0.uppercased() == "NO"
+            } ?? false
+            pendingRef = PendingRef(isNonParallel: isNonParallel)
+        case "BuildableReference" where pendingRef != nil:
+            pendingRef?.targetName = attributeDict["BlueprintName"]
+        default:
+            break
+        }
+    }
+
+    func parser(_ parser: XMLParser, didEndElement elementName: String,
+                namespaceURI: String?, qualifiedName qName: String?) {
+        switch elementName {
+        case "TestableReference" where inTestAction:
+            if let ref = pendingRef {
+                scheme.testableReferences.append(
+                    .init(isNonParallel: ref.isNonParallel, targetName: ref.targetName)
+                )
+            }
+            pendingRef = nil
+        case "TestAction":
+            inTestAction = false
+        default:
+            break
+        }
+    }
+}

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
@@ -13,6 +13,7 @@ final class TestImpactAnalysis: TestHooksFeature {
     let modules: [String: [String: Suite]]
     let correlationId: String?
     let coverage: TestCoverageCollector?
+    let swiftTestingEnabled: Bool
     
     var skippedCount: UInt { _skippedCount.value }
     
@@ -21,7 +22,7 @@ final class TestImpactAnalysis: TestHooksFeature {
     
     private let _skippedCount: Synced<UInt>
     
-    init(tests: SkipTests?, coverage: TestCoverageCollector?) {
+    init(tests: SkipTests?, coverage: TestCoverageCollector?, swiftTestingEnabled: Bool) {
         if let tests = tests { // we have skipping enabled
             var modules = [String: [String: Suite]]()
             for test in tests.tests {
@@ -41,6 +42,7 @@ final class TestImpactAnalysis: TestHooksFeature {
             self.modules = [:]
             self.correlationId = nil
         }
+        self.swiftTestingEnabled = swiftTestingEnabled
         self._skippedCount = .init(0)
         self.coverage = coverage
     }
@@ -67,7 +69,7 @@ final class TestImpactAnalysis: TestHooksFeature {
             session.set(metric: DDTestSessionTags.testCoverageLines, value: linesCovered)
         }
     }
-
+    
     func testModuleWillEnd(module: any TestModule) {
         module.set(tag: DDTestSessionTags.testCodeCoverageEnabled, value: isCoverageEnabled)
         module.set(tag: DDTestSessionTags.testSkippingEnabled, value: isSkippingEnabled)
@@ -87,11 +89,14 @@ final class TestImpactAnalysis: TestHooksFeature {
             module.session.set(metric: DDTestSessionTags.testCoverageLines, value: linesCovered)
         }
     }
-
+    
     func testGroupConfiguration(for test: String, tags: any TestTags,
                                 in suite: any TestSuite,
                                 configuration: RetryGroupConfiguration.Iterator) -> RetryGroupConfiguration.Iterator
     {
+        guard !suite.isSwiftTesting || swiftTestingEnabled else {
+            return configuration.next()
+        }
         let status = status(named: test, suite: suite.name, module: suite.module.name,
                             skippable: tags.get(tag: .tiaSkippable) ?? true)
         if status.markedUnskippable {
@@ -109,6 +114,9 @@ final class TestImpactAnalysis: TestHooksFeature {
     }
     
     func testWillStart(test: any TestRun, info: TestRunInfoStart) {
+        guard !test.suite.isSwiftTesting || swiftTestingEnabled else {
+            return
+        }
         if let correlationId = correlationId {
             test.set(tag: DDItrTags.itrCorrelationId, value: correlationId)
         }
@@ -121,6 +129,9 @@ final class TestImpactAnalysis: TestHooksFeature {
     }
     
     func testWillFinish(test: any TestRun, duration: TimeInterval, withStatus status: TestStatus, andInfo info: TestRunInfoEnd) {
+        guard !test.suite.isSwiftTesting || swiftTestingEnabled else {
+            return
+        }
         switch status {
         case .pass, .fail:
             if info.skip.status.isForcedRun {
@@ -136,6 +147,9 @@ final class TestImpactAnalysis: TestHooksFeature {
     }
     
     func testDidFinish(test: any TestRun, info: TestRunInfoEnd) {
+        guard !test.suite.isSwiftTesting || swiftTestingEnabled else {
+            return
+        }
         if !info.skip.status.isSkipped {
             coverage?.endTest(testSessionId: test.session.id.rawValue,
                               testSuiteId: test.suite.id.rawValue,
@@ -147,8 +161,14 @@ final class TestImpactAnalysis: TestHooksFeature {
                         withStatus: TestStatus, retryStatus: RetryStatus.Iterator,
                         andInfo info: TestRunInfoStart) -> RetryStatus.Iterator
     {
+        guard !test.suite.isSwiftTesting || swiftTestingEnabled else {
+            return retryStatus.next()
+        }
+        guard info.skip.by?.feature == id else {
+            return retryStatus.next()
+        }
         // we have to return end value so test will not be passed for retry to other features
-        info.skip.status.isSkipped ? retryStatus.end() : retryStatus.next()
+        return info.skip.status.isSkipped ? retryStatus.end() : retryStatus.next()
     }
     
     func stop() {
@@ -186,6 +206,7 @@ struct TestImpactAnalysisFactory: FeatureFactory {
     let repository: String
     let exporter: EventsExporterProtocol
     let skippingEnabled: Bool
+    let swiftTestingEnabled: Bool
     let coverageConfig: Coverage?
     
     init(configurations: [String: String],
@@ -193,7 +214,7 @@ struct TestImpactAnalysisFactory: FeatureFactory {
          exporter: EventsExporterProtocol,
          commit: String, repository: String,
          cache: Directory, skippingEnabled: Bool,
-         coverage: Coverage?)
+         swiftTestingEnabled: Bool, coverage: Coverage?)
     {
         self.configurations = configurations
         self.customConfigurations = custom
@@ -203,10 +224,11 @@ struct TestImpactAnalysisFactory: FeatureFactory {
         self.commitSha = commit
         self.coverageConfig = coverage
         self.skippingEnabled = skippingEnabled
+        self.swiftTestingEnabled = swiftTestingEnabled
     }
     
     static func isEnabled(config: Config, env: Environment, remote: TracerSettings) -> Bool {
-        guard config.itrEnabled && remote.itr.itrEnabled else { return false }
+        guard config.tiaEnabled && remote.itr.itrEnabled else { return false }
         
         let isExcluded = { (branch: String) in
             let excludedBranches = config.excludedBranches
@@ -258,7 +280,7 @@ struct TestImpactAnalysisFactory: FeatureFactory {
         if coverage != nil {
             log.debug("Code Coverage Enabled")
         }
-        return TestImpactAnalysis(tests: tests, coverage: coverage)
+        return TestImpactAnalysis(tests: tests, coverage: coverage, swiftTestingEnabled: swiftTestingEnabled)
     }
     
     private func loadTestsFromDisk(log: Logger) -> SkipTests? {

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
@@ -21,8 +21,6 @@ final class TestImpactAnalysis: TestHooksFeature {
     
     private let _skippedCount: Synced<UInt>
     
-    let unskippableCache: Synced<[ObjectIdentifier: UnskippableMethodChecker]>
-    
     init(tests: SkipTests?, coverage: TestCoverageCollector?) {
         if let tests = tests { // we have skipping enabled
             var modules = [String: [String: Suite]]()
@@ -43,17 +41,13 @@ final class TestImpactAnalysis: TestHooksFeature {
             self.modules = [:]
             self.correlationId = nil
         }
-        self.unskippableCache = .init([:])
         self._skippedCount = .init(0)
         self.coverage = coverage
     }
     
-    func status(for clazz: UnskippableMethodCheckerFactory, named test: String, suite: String, module: String) -> SkipStatus {
-        let checker = unskippableCache.update { cache in
-            cache.get(key: clazz.classId, or: clazz.unskippableMethods)
-        }
+    func status(named test: String, suite: String, module: String, skippable: Bool) -> SkipStatus {
         return .init(canBeSkipped: modules[module]?[suite]?[test] != nil,
-                     markedUnskippable: !checker.canSkip(method: test))
+                     markedUnskippable: !skippable)
     }
     
     func testSessionWillEnd(session: any TestSession) {
@@ -94,11 +88,12 @@ final class TestImpactAnalysis: TestHooksFeature {
         }
     }
 
-    func testGroupConfiguration(for test: String, meta: UnskippableMethodCheckerFactory,
+    func testGroupConfiguration(for test: String, tags: any TestTags,
                                 in suite: any TestSuite,
                                 configuration: RetryGroupConfiguration.Iterator) -> RetryGroupConfiguration.Iterator
     {
-        let status = status(for: meta, named: test, suite: suite.name, module: suite.module.name)
+        let status = status(named: test, suite: suite.name, module: suite.module.name,
+                            skippable: tags.get(tag: .tiaSkippable) ?? true)
         if status.markedUnskippable {
             suite.set(tag: DDItrTags.itrUnskippable, value: true)
         }

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysisSkippabble.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysisSkippabble.swift
@@ -25,51 +25,22 @@ public extension DynamicTag where V == Bool {
     @objc static var tiaSkippableInstanceMethod: DDTag { DDTag(tag: .tiaSkippableInstanceMethod) }
 }
 
-protocol UnskippableMethodCheckerFactory: AnyObject {
-    var classId: ObjectIdentifier { get }
-    var unskippableMethods: UnskippableMethodChecker { get }
-}
-
-final class UnskippableMethodChecker {
-    let isSuiteUnskippable: Bool
-    let skippableMethods: [String: Bool]
+struct TIASkippableTag: XCTestTag {
+    typealias Value = Bool
     
-    convenience init(for type: XCTestCase.Type) {
-        let isSuiteUnskippable: Bool
-        let skippableMethods: [String: Bool]
-        
-        if let tags = type.maybeTypeTags {
-            let pairs = tags.tagged(dynamic: .tiaSkippableInstanceMethod,
-                                    prefixed: "test")
-                .compactMap { tag in
-                    tags[tag].map { (tag.to, $0) }
-                }
-            skippableMethods = Dictionary(uniqueKeysWithValues: pairs)
-            isSuiteUnskippable = tags.tagged(dynamic: .tiaSkippableType).first
-                .flatMap { tags[$0] }.map { !$0 } ?? false
-        } else {
-            isSuiteUnskippable = false
-            skippableMethods = [:]
+    func parse(tags: borrowing TypeTags, test: String) -> Bool? {
+        var isSuiteSkippable: Bool = true
+        var isTestSkippable: Bool? = nil
+        if let tag = tags.tagged(dynamic: .tiaSkippableType).first {
+            isSuiteSkippable = tags[tag] ?? true
         }
-        self.init(isSuiteUnskippable: isSuiteUnskippable, skippableMethods: skippableMethods)
-    }
-    
-    init(isSuiteUnskippable: Bool, skippableMethods: [String: Bool]) {
-        self.isSuiteUnskippable = isSuiteUnskippable
-        self.skippableMethods = skippableMethods
-    }
-    
-    @inlinable func canSkip(method name: String) -> Bool {
-        skippableMethods[name] ?? !isSuiteUnskippable
+        if let tag = tags.tagged(dynamic: .tiaSkippableInstanceMethod, prefixed: test).filter({ $0.to == test }).first {
+            isTestSkippable = tags[tag]
+        }
+        return isTestSkippable ?? isSuiteSkippable
     }
 }
 
-extension XCTestCase: UnskippableMethodCheckerFactory {
-    var classId: ObjectIdentifier {
-        ObjectIdentifier(type(of: self))
-    }
-    
-    var unskippableMethods: UnskippableMethodChecker {
-        UnskippableMethodChecker(for: type(of: self))
-    }
+extension TestTag where Self == TIASkippableTag {
+    static var tiaSkippable: Self { .init() }
 }

--- a/Sources/DatadogSDKTesting/TestManagement.swift
+++ b/Sources/DatadogSDKTesting/TestManagement.swift
@@ -21,7 +21,7 @@ final class TestManagement: TestHooksFeature {
         self.attemptToFixRetries = attemptToFixRetries
     }
     
-    func testGroupConfiguration(for test: String, meta: UnskippableMethodCheckerFactory,
+    func testGroupConfiguration(for test: String, tags: any TestTags,
                                 in suite: any TestSuite,
                                 configuration: RetryGroupConfiguration.Iterator) -> RetryGroupConfiguration.Iterator
     {

--- a/Sources/DatadogSDKTesting/XCTest/DDXCTestCase.swift
+++ b/Sources/DatadogSDKTesting/XCTest/DDXCTestCase.swift
@@ -374,3 +374,45 @@ extension RetryGroupSkipStrategy {
         }
     }
 }
+
+
+protocol XCTestTag: TestTag {
+    func parse(tags: borrowing TypeTags, test: String) -> Value?
+}
+
+// XCTest is synchronous so it's not synchronized
+final class XCTestSuiteTags: Identifiable<ObjectIdentifier> {
+    var id: ObjectIdentifier { ObjectIdentifier(_clazz) }
+    
+    private let _clazz: XCTestCase.Type
+    private(set) lazy var tags: TypeTags? = _clazz.maybeTypeTags
+    
+    init(for clazz: XCTestCase.Type) {
+        self._clazz = clazz
+    }
+    
+    func tags(for test: String) -> XCTestTags {
+        .init(suite: self, test: test)
+    }
+}
+
+struct XCTestTags: TestTags {
+    let suite: XCTestSuiteTags
+    let test: String
+        
+    init(suite: XCTestSuiteTags, test: String) {
+        self.suite = suite
+        self.test = test
+    }
+    
+    func get<T: TestTag>(tag: T) -> T.Value? {
+        guard let tag = tag as? any XCTestTag else {
+            return nil
+        }
+        guard let tags = suite.tags else {
+            return nil
+        }
+        // have to cast because normal types work from macOS 13 only
+        return tag.parse(tags: tags, test: test) as! T.Value?
+    }
+}

--- a/Sources/DatadogSDKTesting/XCTest/DDXCTestObserver.swift
+++ b/Sources/DatadogSDKTesting/XCTest/DDXCTestObserver.swift
@@ -147,9 +147,12 @@ final class DDXCTestObserver: NSObject, XCTestObservation, DDXCTestRetryDelegate
             return
         }
         
+        let testType = type(of: group.currentTest!)
+        let suiteTags = context.tags[ObjectIdentifier(testType), default: .init(for: testType)]
+        
         let testId = group.testId
         let (feature, config) = context.features.testGroupConfiguration(for: testId.test,
-                                                                        meta: group.currentTest!,
+                                                                        tags: suiteTags.tags(for: testId.test),
                                                                         in: suite)
         
         group.groupRun?.skipStrategy = config.skipStrategy.xcTest
@@ -429,12 +432,14 @@ extension DDXCTestObserver {
         let module: any TestModule & TestSuiteProvider
         let moduleContext: ModuleContext
         var features: any TestHooksFeatures { moduleContext.features }
+        var tags: [ObjectIdentifier: XCTestSuiteTags]
         
         init(parent: ContainerSuite?, module: any TestModule & TestSuiteProvider, context: ModuleContext)
         {
             self.parent = parent
             self.module = module
             self.moduleContext = context
+            self.tags = [:]
         }
         
         func back(from suite: any TestSuite) -> State {

--- a/Tests/DatadogSDKTesting/DatadogSDKTesting.xctestplan
+++ b/Tests/DatadogSDKTesting/DatadogSDKTesting.xctestplan
@@ -31,7 +31,6 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:DatadogSDKTesting.xcodeproj",
         "identifier" : "A7FC256C2BA1E83500067E26",

--- a/Tests/DatadogSDKTesting/Features/ParallelTestRunnerDetectorTests.swift
+++ b/Tests/DatadogSDKTesting/Features/ParallelTestRunnerDetectorTests.swift
@@ -1,0 +1,474 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSDKTesting
+
+final class ParallelTestRunnerDetectorTests: XCTestCase {
+
+    // MARK: - isTestPlanNonParallel (targetName: nil — any-target fallback)
+
+    func testNonParallelTestPlanReturnsTrueWhenAnyTargetHasParallelizableFalse() {
+        let json = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "TargetA"]],
+            ["target": ["name": "TargetB"]]
+        ])
+        XCTAssertEqual(ParallelTestRunnerDetector.isTestPlanNonParallel(data: json,
+                                                                         targetName: nil), true)
+    }
+
+    func testParallelTestPlanReturnsFalseWhenAllTargetsParallelizableTrue() {
+        let json = testPlanJSON(targets: [
+            ["parallelizable": true, "target": ["name": "TargetA"]],
+            ["parallelizable": true, "target": ["name": "TargetB"]]
+        ])
+        XCTAssertEqual(ParallelTestRunnerDetector.isTestPlanNonParallel(data: json,
+                                                                         targetName: nil), false)
+    }
+
+    func testDefaultTestPlanReturnsFalseWhenNoParallelizableKey() {
+        let json = testPlanJSON(targets: [["target": ["name": "TargetA"]]])
+        XCTAssertEqual(ParallelTestRunnerDetector.isTestPlanNonParallel(data: json,
+                                                                         targetName: nil), false)
+    }
+
+    func testEmptyTestTargetsReturnsNil() {
+        let json = testPlanJSON(targets: [])
+        XCTAssertNil(ParallelTestRunnerDetector.isTestPlanNonParallel(data: json, targetName: nil))
+    }
+
+    func testMalformedTestPlanReturnsNil() {
+        let invalid = "not json".data(using: .utf8)!
+        XCTAssertNil(ParallelTestRunnerDetector.isTestPlanNonParallel(data: invalid,
+                                                                       targetName: nil))
+    }
+
+    // MARK: - isTestPlanNonParallel (targetName provided)
+
+    func testTargetFoundWithParallelizableFalseReturnsTrue() {
+        let json = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "MyTarget"]],
+            ["parallelizable": true,  "target": ["name": "OtherTarget"]]
+        ])
+        XCTAssertEqual(ParallelTestRunnerDetector.isTestPlanNonParallel(data: json,
+                                                                         targetName: "MyTarget"), true)
+    }
+
+    func testTargetFoundWithParallelizableTrueReturnsFalse() {
+        let json = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "OtherTarget"]],
+            ["parallelizable": true,  "target": ["name": "MyTarget"]]
+        ])
+        XCTAssertEqual(ParallelTestRunnerDetector.isTestPlanNonParallel(data: json,
+                                                                         targetName: "MyTarget"), false)
+    }
+
+    func testTargetFoundWithoutParallelizableKeyReturnsFalse() {
+        // Absent key means Xcode default: parallel enabled
+        let json = testPlanJSON(targets: [
+            ["target": ["name": "MyTarget"]]
+        ])
+        XCTAssertEqual(ParallelTestRunnerDetector.isTestPlanNonParallel(data: json,
+                                                                         targetName: "MyTarget"), false)
+    }
+
+    func testTargetNotFoundReturnsNil() {
+        let json = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "OtherTarget"]]
+        ])
+        XCTAssertNil(ParallelTestRunnerDetector.isTestPlanNonParallel(data: json,
+                                                                       targetName: "MissingTarget"))
+    }
+
+    // MARK: - findSchemeFile
+
+    func testFindSchemeFileInXcodeproj() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        try createSchemeDir(in: tmpDir, container: "MyProject.xcodeproj",
+                            schemeName: "MyScheme", content: "")
+
+        let found = ParallelTestRunnerDetector.findSchemeFile(named: "MyScheme", in: tmpDir)
+        XCTAssertEqual(found?.lastPathComponent, "MyScheme.xcscheme")
+    }
+
+    func testFindSchemeFileInXcworkspace() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        try createSchemeDir(in: tmpDir, container: "MyWorkspace.xcworkspace",
+                            schemeName: "WS", content: "")
+
+        let found = ParallelTestRunnerDetector.findSchemeFile(named: "WS", in: tmpDir)
+        XCTAssertEqual(found?.lastPathComponent, "WS.xcscheme")
+    }
+
+    func testFindSchemeFileReturnsNilWhenNotFound() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+        XCTAssertNil(ParallelTestRunnerDetector.findSchemeFile(named: "Missing", in: tmpDir))
+    }
+
+    // MARK: - findFile
+
+    func testFindFileInRootDirectory() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        let filePath = (tmpDir as NSString).appendingPathComponent("Plan.xctestplan")
+        try "".write(toFile: filePath, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            ParallelTestRunnerDetector.findFile(named: "Plan.xctestplan", in: tmpDir, maxDepth: 0),
+            filePath
+        )
+    }
+
+    func testFindFileInSubdirectory() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        let subDir = (tmpDir as NSString).appendingPathComponent("Tests/Suite")
+        try FileManager.default.createDirectory(atPath: subDir, withIntermediateDirectories: true)
+        let filePath = (subDir as NSString).appendingPathComponent("Plan.xctestplan")
+        try "".write(toFile: filePath, atomically: true, encoding: .utf8)
+
+        XCTAssertNotNil(
+            ParallelTestRunnerDetector.findFile(named: "Plan.xctestplan", in: tmpDir, maxDepth: 3)
+        )
+    }
+
+    func testFindFileReturnsNilWhenDepthExceeded() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        let deepDir = (tmpDir as NSString).appendingPathComponent("a/b/c/d")
+        try FileManager.default.createDirectory(atPath: deepDir, withIntermediateDirectories: true)
+        let filePath = (deepDir as NSString).appendingPathComponent("Plan.xctestplan")
+        try "".write(toFile: filePath, atomically: true, encoding: .utf8)
+
+        XCTAssertNil(
+            ParallelTestRunnerDetector.findFile(named: "Plan.xctestplan", in: tmpDir, maxDepth: 2)
+        )
+    }
+
+    func testFindFileSkipsXcodeprojectDirectories() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        let xcprojDir = (tmpDir as NSString).appendingPathComponent("X.xcodeproj/hidden")
+        try FileManager.default.createDirectory(atPath: xcprojDir, withIntermediateDirectories: true)
+        let filePath = (xcprojDir as NSString).appendingPathComponent("Plan.xctestplan")
+        try "".write(toFile: filePath, atomically: true, encoding: .utf8)
+
+        XCTAssertNil(
+            ParallelTestRunnerDetector.findFile(named: "Plan.xctestplan", in: tmpDir, maxDepth: 5)
+        )
+    }
+
+    // MARK: - isParallelizationDisabled: env-var routing
+
+    func testNoEnvVarsUsesProcessArguments() {
+        let env = ProcessEnvironmentReader(environment: [:], infoDictionary: [:])
+        // --no-parallel is not present in the actual unit-test process arguments
+        XCTAssertFalse(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                             sourceRoot: nil,
+                                                                             targetName: nil))
+    }
+
+    func testTestPlanNameSetButNoSourceRootReturnsFalse() {
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_TEST_PLAN_NAME": "SomePlan"], infoDictionary: [:])
+        XCTAssertFalse(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                             sourceRoot: nil,
+                                                                             targetName: "T"))
+    }
+
+    func testSchemeNameSetButNoSourceRootReturnsFalse() {
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_SCHEME_NAME": "SomeScheme"], infoDictionary: [:])
+        XCTAssertFalse(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                             sourceRoot: nil,
+                                                                             targetName: "T"))
+    }
+
+    // MARK: - isParallelizationDisabled: test plan path
+
+    func testTestPlanNonParallelForMatchingTargetReturnsTrue() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        let json = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "MyTests"]],
+            ["parallelizable": true,  "target": ["name": "OtherTests"]]
+        ])
+        try json.write(to: URL(fileURLWithPath:
+            (tmpDir as NSString).appendingPathComponent("MyPlan.xctestplan")))
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_TEST_PLAN_NAME": "MyPlan"], infoDictionary: [:])
+        XCTAssertTrue(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                            sourceRoot: tmpDir,
+                                                                            targetName: "MyTests"))
+    }
+
+    func testTestPlanParallelForMatchingTargetReturnsFalse() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        let json = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "OtherTests"]],
+            ["parallelizable": true,  "target": ["name": "MyTests"]]
+        ])
+        try json.write(to: URL(fileURLWithPath:
+            (tmpDir as NSString).appendingPathComponent("MyPlan.xctestplan")))
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_TEST_PLAN_NAME": "MyPlan"], infoDictionary: [:])
+        XCTAssertFalse(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                             sourceRoot: tmpDir,
+                                                                             targetName: "MyTests"))
+    }
+
+    func testTestPlanTargetMissingReturnsFalse() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        let json = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "OtherTests"]]
+        ])
+        try json.write(to: URL(fileURLWithPath:
+            (tmpDir as NSString).appendingPathComponent("MyPlan.xctestplan")))
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_TEST_PLAN_NAME": "MyPlan"], infoDictionary: [:])
+        // Target not found → nil → false
+        XCTAssertFalse(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                             sourceRoot: tmpDir,
+                                                                             targetName: "Missing"))
+    }
+
+    // MARK: - isParallelizationDisabled: scheme path
+
+    func testSchemeNonParallelForMatchingTargetReturnsTrue() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        try createScheme(named: "MyScheme", in: tmpDir,
+                         testableRefs: [("MyTests", "NO"), ("OtherTests", "YES")],
+                         hasTestPlan: false)
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_SCHEME_NAME": "MyScheme"], infoDictionary: [:])
+        XCTAssertTrue(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                            sourceRoot: tmpDir,
+                                                                            targetName: "MyTests"))
+    }
+
+    func testSchemeParallelForMatchingTargetReturnsFalse() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        try createScheme(named: "MyScheme", in: tmpDir,
+                         testableRefs: [("OtherTests", "NO"), ("MyTests", "YES")],
+                         hasTestPlan: false)
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_SCHEME_NAME": "MyScheme"], infoDictionary: [:])
+        XCTAssertFalse(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                             sourceRoot: tmpDir,
+                                                                             targetName: "MyTests"))
+    }
+
+    func testSchemeTargetMissingReturnsFalse() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        try createScheme(named: "MyScheme", in: tmpDir,
+                         testableRefs: [("OtherTests", "NO")],
+                         hasTestPlan: false)
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_SCHEME_NAME": "MyScheme"], infoDictionary: [:])
+        XCTAssertFalse(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                             sourceRoot: tmpDir,
+                                                                             targetName: "Missing"))
+    }
+
+    func testSchemeWithTestPlanReferenceIgnoredWhenNoTestPlanEnvVar() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        // Scheme has a TestPlans section: detector must defer to test plan and return false
+        try createScheme(named: "MyScheme", in: tmpDir,
+                         testableRefs: [("MyTests", "NO")],
+                         hasTestPlan: true)
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_SCHEME_NAME": "MyScheme"], infoDictionary: [:])
+        XCTAssertFalse(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                             sourceRoot: tmpDir,
+                                                                             targetName: "MyTests"))
+    }
+
+    // MARK: - Precedence: test plan over scheme
+
+    func testTestPlanTakesPrecedenceOverScheme() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        // Non-parallel test plan for target
+        let planJSON = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "MyTests"]]
+        ])
+        try planJSON.write(to: URL(fileURLWithPath:
+            (tmpDir as NSString).appendingPathComponent("MyPlan.xctestplan")))
+
+        // Parallel scheme for same target
+        try createScheme(named: "MyScheme", in: tmpDir,
+                         testableRefs: [("MyTests", "YES")],
+                         hasTestPlan: false)
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_TEST_PLAN_NAME": "MyPlan", "XCODE_SCHEME_NAME": "MyScheme"],
+            infoDictionary: [:])
+        XCTAssertTrue(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                            sourceRoot: tmpDir,
+                                                                            targetName: "MyTests"))
+    }
+
+    // MARK: - container: path resolution via scheme
+
+    func testSchemeContainerReferenceResolvesTestPlanPath() throws {
+        let tmpDir = try makeTempDir()
+        defer { cleanup(tmpDir) }
+
+        // Test plan in a sub-directory
+        let planSubDir = (tmpDir as NSString).appendingPathComponent("Plans")
+        try FileManager.default.createDirectory(atPath: planSubDir, withIntermediateDirectories: true)
+        let planJSON = testPlanJSON(targets: [
+            ["parallelizable": false, "target": ["name": "MyTests"]]
+        ])
+        try planJSON.write(to: URL(fileURLWithPath:
+            (planSubDir as NSString).appendingPathComponent("MyPlan.xctestplan")))
+
+        // Scheme with container: reference pointing at the plan
+        try createScheme(named: "MyScheme", in: tmpDir,
+                         testableRefs: [("MyTests", "YES")],
+                         hasTestPlan: false,
+                         testPlanContainerRef: "container:Plans/MyPlan.xctestplan")
+
+        let env = ProcessEnvironmentReader(
+            environment: ["XCODE_TEST_PLAN_NAME": "MyPlan", "XCODE_SCHEME_NAME": "MyScheme"],
+            infoDictionary: [:])
+        XCTAssertTrue(ParallelTestRunnerDetector.isParallelizationDisabled(env: env,
+                                                                            sourceRoot: tmpDir,
+                                                                            targetName: "MyTests"))
+    }
+
+    // MARK: - Config: tiaSwiftTestingEnabled is Bool?
+
+    func testConfigStoresNilWhenEnvVarNotSet() {
+        let env = ProcessEnvironmentReader(environment: [:], infoDictionary: [:])
+        let config = Config(env: env)
+        XCTAssertNil(config.tiaSwiftTestingEnabled)
+    }
+
+    func testConfigStoresTrueWhenEnvVarIsOne() {
+        let env = ProcessEnvironmentReader(
+            environment: ["DD_SWIFT_TESTING_TEST_IMPACT_ANALYSIS_ENABLED": "1"],
+            infoDictionary: [:])
+        let config = Config(env: env)
+        XCTAssertEqual(config.tiaSwiftTestingEnabled, true)
+    }
+
+    func testConfigStoresFalseWhenEnvVarIsZero() {
+        let env = ProcessEnvironmentReader(
+            environment: ["DD_SWIFT_TESTING_TEST_IMPACT_ANALYSIS_ENABLED": "0"],
+            infoDictionary: [:])
+        let config = Config(env: env)
+        XCTAssertEqual(config.tiaSwiftTestingEnabled, false)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> String {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.path
+    }
+
+    private func cleanup(_ path: String) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    private func testPlanJSON(targets: [[String: Any]]) -> Data {
+        try! JSONSerialization.data(withJSONObject: ["testTargets": targets, "version": 1])
+    }
+
+    /// Creates a `<schemeName>.xcscheme` in `<sourceRoot>/MyProject.xcodeproj/xcshareddata/xcschemes/`.
+    /// Each element of `testableRefs` is `(blueprintName, parallelizable)`.
+    private func createScheme(named name: String,
+                               in sourceRoot: String,
+                               testableRefs: [(String, String)],
+                               hasTestPlan: Bool,
+                               testPlanContainerRef: String? = nil) throws {
+        let schemesDir = (((sourceRoot as NSString)
+            .appendingPathComponent("MyProject.xcodeproj") as NSString)
+            .appendingPathComponent("xcshareddata/xcschemes"))
+        try FileManager.default.createDirectory(atPath: schemesDir, withIntermediateDirectories: true)
+
+        let testPlansXML: String
+        if hasTestPlan || testPlanContainerRef != nil {
+            let ref = testPlanContainerRef ?? "container:SomePlan.xctestplan"
+            testPlansXML = """
+            <TestPlans>
+               <TestPlanReference reference = "\(ref)" default = "YES"/>
+            </TestPlans>
+            """
+        } else {
+            testPlansXML = ""
+        }
+
+        let refsXML = testableRefs.map { (blueprint, parallel) in
+            """
+               <TestableReference skipped = "NO" parallelizable = "\(parallel)">
+                  <BuildableReference
+                     BlueprintName = "\(blueprint)"
+                     BuildableName = "\(blueprint).xctest"
+                     ReferencedContainer = "container:MyProject.xcodeproj">
+                  </BuildableReference>
+               </TestableReference>
+            """
+        }.joined(separator: "\n")
+
+        let xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Scheme LastUpgradeVersion = "1640" version = "1.7">
+           <TestAction buildConfiguration = "Debug">
+              \(testPlansXML)
+              <Testables>
+        \(refsXML)
+              </Testables>
+           </TestAction>
+        </Scheme>
+        """
+
+        let schemePath = (schemesDir as NSString).appendingPathComponent("\(name).xcscheme")
+        try xml.write(toFile: schemePath, atomically: true, encoding: .utf8)
+    }
+
+    /// Creates an empty scheme file at the standard path.
+    private func createSchemeDir(in sourceRoot: String, container: String,
+                                  schemeName: String, content: String) throws {
+        let dir = (((sourceRoot as NSString).appendingPathComponent(container) as NSString)
+            .appendingPathComponent("xcshareddata/xcschemes"))
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = (dir as NSString).appendingPathComponent("\(schemeName).xcscheme")
+        try content.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+}

--- a/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSkippableTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSkippableTests.swift
@@ -9,9 +9,9 @@ import XCTest
 
 class UnskippableTypeTaggedTests: XCTestCase, ExtendableTaggedType {
     func testTiaSkippable() {
-        let skip = self.unskippableMethods
-        XCTAssertFalse(skip.canSkip(method: "testTiaSkippable"))
-        XCTAssertFalse(skip.canSkip(method: "testTiaSkippable123"))
+        let suite = XCTestSuiteTags(for: Self.self)
+        XCTAssertFalse(suite.tags(for: "testTiaSkippable").get(tag: .tiaSkippable)!)
+        XCTAssertFalse(suite.tags(for: "testTiaSkippable123").get(tag: .tiaSkippable)!)
     }
     
     static func extendableTypeTags() -> ExtendableTypeTags {
@@ -23,18 +23,18 @@ class UnskippableTypeTaggedTests: XCTestCase, ExtendableTaggedType {
 
 class UnskippableNoTagsTests: XCTestCase {
     func testTiaSkippable() {
-        let skip = self.unskippableMethods
-        XCTAssertTrue(skip.canSkip(method: "testTiaSkippable"))
-        XCTAssertTrue(skip.canSkip(method: "testTiaSkippable123"))
+        let suite = XCTestSuiteTags(for: Self.self)
+        XCTAssertTrue(suite.tags(for: "testTiaSkippable").get(tag: .tiaSkippable) ?? true)
+        XCTAssertTrue(suite.tags(for: "testTiaSkippable123").get(tag: .tiaSkippable) ?? true)
     }
 }
 
 final class UnskippableTypeTaggedOverrideTests: XCTestCase, FinalTaggedType {
     func testTiaSkippable() {
-        let skip = self.unskippableMethods
-        XCTAssertTrue(skip.canSkip(method: "testTiaSkippable"))
-        XCTAssertFalse(skip.canSkip(method: "testTiaSkippable123"))
-        XCTAssertFalse(skip.canSkip(method: "testTiaSkippable456"))
+        let suite = XCTestSuiteTags(for: Self.self)
+        XCTAssertTrue(suite.tags(for: "testTiaSkippable").get(tag: .tiaSkippable)!)
+        XCTAssertFalse(suite.tags(for: "testTiaSkippable123").get(tag: .tiaSkippable)!)
+        XCTAssertFalse(suite.tags(for: "testTiaSkippable456").get(tag: .tiaSkippable)!)
     }
     
     static let finalTypeTags: FinalTypeTags<UnskippableTypeTaggedOverrideTests> = {
@@ -48,10 +48,10 @@ final class UnskippableTypeTaggedOverrideTests: XCTestCase, FinalTaggedType {
 
 class UnskippableMethodTaggedTests: XCTestCase, DDTaggedType {
     func testTiaSkippable() {
-        let skip = self.unskippableMethods
-        XCTAssertFalse(skip.canSkip(method: "testTiaSkippable"))
-        XCTAssertTrue(skip.canSkip(method: "testTiaSkippable123"))
-        XCTAssertTrue(skip.canSkip(method: "testTiaSkippable456"))
+        let suite = XCTestSuiteTags(for: Self.self)
+        XCTAssertFalse(suite.tags(for: "testTiaSkippable").get(tag: .tiaSkippable)!)
+        XCTAssertTrue(suite.tags(for: "testTiaSkippable123").get(tag: .tiaSkippable)!)
+        XCTAssertTrue(suite.tags(for: "testTiaSkippable456").get(tag: .tiaSkippable)!)
     }
     
     static func attachedTypeTags() -> DDTypeTags {

--- a/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSwiftTestingTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSwiftTestingTests.swift
@@ -10,9 +10,9 @@ import XCTest
 
 final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
     func testTestImpactAnalysisSkipsTest() async throws {
-        let (runner, tia, _) = tiaRunner(skip: ["skipTest"],
-                                         tests: ["someTest": .fail("Always fails"),
-                                                 "skipTest": .fail("Always fails")])
+        let (runner, tia, collector) = tiaRunner(skip: ["skipTest"],
+                                                 tests: ["someTest": .fail("Always fails"),
+                                                         "skipTest": .fail("Always fails")])
         let tests = try extractTests(try await runner.run())
         XCTAssertNotNil(tests["skipTest"])
         XCTAssertEqual(tests["skipTest"]?.runs.count, 1)
@@ -40,11 +40,12 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
+        XCTAssertEqual(collector.tests.count, 1) // someTest ran once; skipTest was skipped
     }
 
     // TIA + EFD
     func testTestImpactAnalysisSkipsEFDKnownTest() async throws {
-        let (runner, tia, _) = tiaAndEfdRunner(skip: ["skipTest"], known: ["skipTest"],
+        let (runner, tia, collector) = tiaAndEfdRunner(skip: ["skipTest"], known: ["skipTest"],
                                                tests: ["someTest": .failOddRuns(),
                                                        "skipTest": .fail("Always fails")])
         let tests = try extractTests(try await runner.run())
@@ -80,10 +81,11 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 10) // someTest ran 10 times via EFD; skipTest was skipped
     }
 
     func testTestImpactAnalysisSkipsEFDUnknownTest() async throws {
-        let (runner, tia, _) = tiaAndEfdRunner(skip: ["skipTest"], known: [],
+        let (runner, tia, collector) = tiaAndEfdRunner(skip: ["skipTest"], known: [],
                                                tests: ["someTest": .failOddRuns(),
                                                        "skipTest": .fail("Always fails")])
         let tests = try extractTests(try await runner.run())
@@ -119,11 +121,12 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 10) // someTest ran 10 times via EFD; skipTest was skipped
     }
 
     // TIA + ATR
     func testTestImpactAnalysisAndATRWorksTogether() async throws {
-        let (runner, tia, _) = tiaAndAtrRunner(skip: ["skipTest"],
+        let (runner, tia, collector) = tiaAndAtrRunner(skip: ["skipTest"],
                                                tests: ["someTest": .fail(first: 3),
                                                        "skipTest": .fail("Always fails")])
         let tests = try extractTests(try await runner.run())
@@ -158,11 +161,12 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 4) // someTest ran 4 times via ATR; skipTest was skipped
     }
 
     // TIA + EFD + ATR
     func testTestImpactAnalysisSkipsEFDKnownTestAndATRRuns() async throws {
-        let (runner, tia, _) = tiaEfdAndAtrRunner(skip: ["skipTest"], known: ["skipTest", "knownTest"],
+        let (runner, tia, collector) = tiaEfdAndAtrRunner(skip: ["skipTest"], known: ["skipTest", "knownTest"],
                                                   tests: ["unknownTest": .failOddRuns(),
                                                           "knownTest": .fail(first: 3),
                                                           "skipTest": .fail("Always fails")])
@@ -217,6 +221,7 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["knownTest"]?.isSkipped, false)
         XCTAssertEqual(tests["knownTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["knownTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 14) // unknownTest 10 + knownTest 4; skipTest was skipped
     }
 
     func tiaRunner(skip: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.STRunner, TestImpactAnalysis, Mocks.CoverageCollector) {

--- a/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSwiftTestingTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSwiftTestingTests.swift
@@ -8,12 +8,12 @@ import XCTest
 @testable import DatadogSDKTesting
 @testable import EventsExporter
 
-class TestImpactAnalysisTests: XCTestCase {
+final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
     func testTestImpactAnalysisSkipsTest() async throws {
         let (runner, tia, _) = tiaRunner(skip: ["skipTest"],
                                          tests: ["someTest": .fail("Always fails"),
                                                  "skipTest": .fail("Always fails")])
-        let tests = try await extractTests(runner.run())
+        let tests = try extractTests(try await runner.run())
         XCTAssertNotNil(tests["skipTest"])
         XCTAssertEqual(tests["skipTest"]?.runs.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.status == .skip }.count, 1)
@@ -27,7 +27,7 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusSkip)
         XCTAssertEqual(tia.skippedCount, 1)
-        
+
         XCTAssertNotNil(tests["someTest"])
         XCTAssertEqual(tests["someTest"]?.runs.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.status == .fail }.count, 1)
@@ -41,46 +41,13 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
     }
-    
-    func testTestImpactAnalysisDoesntSkipUnskippable() async throws {
-        let (runner, tia, _) = tiaRunner(skip: ["skipTest"],
-                                         tests: ["someTest": .fail("Always fails"),
-                                                 "skipTest": .fail("Always fails", unskippable: true)])
-        let tests = try await extractTests(runner.run())
-        XCTAssertNotNil(tests["skipTest"])
-        XCTAssertEqual(tests["skipTest"]?.runs.count, 1)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.status == .fail }.count, 1)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.xcStatus == .fail }.count, 1)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testSkippedByITR] == nil }.count, 1)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDItrTags.itrUnskippable] == "true" }.count, 1)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDItrTags.itrForcedRun] == "true" }.count, 1)
-        XCTAssertNil(tests["skipTest"]?.runs.first?.tags[DDTestTags.testSkipReason])
-        XCTAssertEqual(tests["skipTest"]?.isSucceeded, false)
-        XCTAssertEqual(tests["skipTest"]?.isSkipped, false)
-        XCTAssertEqual(tia.skippedCount, 0)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["skipTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
-        
-        XCTAssertNotNil(tests["someTest"])
-        XCTAssertEqual(tests["someTest"]?.runs.count, 1)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.status == .fail }.count, 1)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.xcStatus == .fail }.count, 1)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testSkippedByITR] == nil }.count, 1)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDItrTags.itrUnskippable] == nil }.count, 1)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDItrTags.itrForcedRun] == nil }.count, 1)
-        XCTAssertNil(tests["someTest"]?.runs.first?.tags[DDTestTags.testSkipReason])
-        XCTAssertEqual(tests["someTest"]?.isSucceeded, false)
-        XCTAssertEqual(tests["someTest"]?.isSkipped, false)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
-    }
-    
+
     // TIA + EFD
     func testTestImpactAnalysisSkipsEFDKnownTest() async throws {
         let (runner, tia, _) = tiaAndEfdRunner(skip: ["skipTest"], known: ["skipTest"],
                                                tests: ["someTest": .failOddRuns(),
                                                        "skipTest": .fail("Always fails")])
-        let tests = try await extractTests(runner.run())
+        let tests = try extractTests(try await runner.run())
         XCTAssertNotNil(tests["skipTest"])
         XCTAssertEqual(tests["skipTest"]?.runs.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.status == .skip }.count, 1)
@@ -97,7 +64,7 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tia.skippedCount, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusSkip)
-        
+
         XCTAssertNotNil(tests["someTest"])
         XCTAssertEqual(tests["someTest"]?.runs.count, 10)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.status == .fail }.count, 5)
@@ -114,12 +81,12 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
     }
-    
+
     func testTestImpactAnalysisSkipsEFDUnknownTest() async throws {
         let (runner, tia, _) = tiaAndEfdRunner(skip: ["skipTest"], known: [],
                                                tests: ["someTest": .failOddRuns(),
                                                        "skipTest": .fail("Always fails")])
-        let tests = try await extractTests(runner.run())
+        let tests = try extractTests(try await runner.run())
         XCTAssertNotNil(tests["skipTest"])
         XCTAssertEqual(tests["skipTest"]?.runs.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.status == .skip }.count, 1)
@@ -136,7 +103,7 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tia.skippedCount, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusSkip)
-        
+
         XCTAssertNotNil(tests["someTest"])
         XCTAssertEqual(tests["someTest"]?.runs.count, 10)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.status == .fail }.count, 5)
@@ -153,52 +120,13 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
     }
-    
-    func testTestImpactAnalysisUnskippableEFDWorks() async throws {
-        let (runner, tia, _) = tiaAndEfdRunner(skip: ["skipTest"], known: [],
-                                               tests: ["someTest": .failOddRuns(),
-                                                       "skipTest": .failEvenRuns(unskippable: true)])
-        let tests = try await extractTests(runner.run())
-        XCTAssertNotNil(tests["skipTest"])
-        XCTAssertEqual(tests["skipTest"]?.runs.count, 10)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.status == .fail }.count, 5)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.xcStatus == .pass }.count, 10)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testSkippedByITR] == nil }.count, 10)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDItrTags.itrUnskippable] == "true" }.count, 10)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDItrTags.itrForcedRun] == "true" }.count, 10)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testIsNew] == "true" }.count, 10)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDEfdTags.testIsRetry] == "true" }.count, 9)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDEfdTags.testRetryReason] == DDTagValues.retryReasonEarlyFlakeDetection }.count, 9)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testSkipReason] == nil }.count, 10)
-        XCTAssertEqual(tests["skipTest"]?.isSucceeded, true)
-        XCTAssertEqual(tests["skipTest"]?.isSkipped, false)
-        XCTAssertEqual(tia.skippedCount, 0)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["skipTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
-        
-        XCTAssertNotNil(tests["someTest"])
-        XCTAssertEqual(tests["someTest"]?.runs.count, 10)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.status == .fail }.count, 5)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.xcStatus == .fail }.count, 0)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testSkippedByITR] == nil }.count, 10)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDItrTags.itrUnskippable] == nil }.count, 10)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDItrTags.itrForcedRun] == nil }.count, 10)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testIsNew] == "true" }.count, 10)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDEfdTags.testIsRetry] == "true" }.count, 9)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDEfdTags.testRetryReason] == DDTagValues.retryReasonEarlyFlakeDetection }.count, 9)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testSkipReason] == nil }.count, 10)
-        XCTAssertEqual(tests["someTest"]?.isSucceeded, true)
-        XCTAssertEqual(tests["someTest"]?.isSkipped, false)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
-    }
-    
+
     // TIA + ATR
     func testTestImpactAnalysisAndATRWorksTogether() async throws {
         let (runner, tia, _) = tiaAndAtrRunner(skip: ["skipTest"],
                                                tests: ["someTest": .fail(first: 3),
                                                        "skipTest": .fail("Always fails")])
-        let tests = try await extractTests(runner.run())
+        let tests = try extractTests(try await runner.run())
         XCTAssertNotNil(tests["skipTest"])
         XCTAssertEqual(tests["skipTest"]?.runs.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.status == .skip }.count, 1)
@@ -214,7 +142,7 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tia.skippedCount, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusSkip)
-        
+
         XCTAssertNotNil(tests["someTest"])
         XCTAssertEqual(tests["someTest"]?.runs.count, 4)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.status == .fail }.count, 3)
@@ -231,51 +159,14 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
     }
-    
-    func testTestImpactAnalysisAndATRWorksTogetherUnskippable() async throws {
-        let (runner, tia, _) = tiaAndAtrRunner(skip: ["skipTest"],
-                                               tests: ["someTest": .fail(first: 3),
-                                                       "skipTest": .fail(first: 4, unskippable: true)])
-        let tests = try await extractTests(runner.run())
-        XCTAssertNotNil(tests["skipTest"])
-        XCTAssertEqual(tests["skipTest"]?.runs.count, 5)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.status == .fail }.count, 4)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.xcStatus == .fail }.count, 0)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testSkippedByITR] == nil }.count, 5)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDItrTags.itrUnskippable] == "true" }.count, 5)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDItrTags.itrForcedRun] == "true" }.count, 5)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDEfdTags.testIsRetry] == "true" }.count, 4)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDEfdTags.testRetryReason] == DDTagValues.retryReasonAutoTestRetry }.count, 4)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testSkipReason] == nil }.count, 5)
-        XCTAssertEqual(tests["skipTest"]?.isSucceeded, true)
-        XCTAssertEqual(tests["skipTest"]?.isSkipped, false)
-        XCTAssertEqual(tia.skippedCount, 0)
-        XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["skipTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
-        
-        XCTAssertNotNil(tests["someTest"])
-        XCTAssertEqual(tests["someTest"]?.runs.count, 4)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.status == .fail }.count, 3)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.xcStatus == .fail }.count, 0)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testSkippedByITR] == nil }.count, 4)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDItrTags.itrUnskippable] == nil }.count, 4)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDItrTags.itrForcedRun] == nil }.count, 4)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDEfdTags.testIsRetry] == "true" }.count, 3)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDEfdTags.testRetryReason] == DDTagValues.retryReasonAutoTestRetry }.count, 3)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testSkipReason] == nil }.count, 4)
-        XCTAssertEqual(tests["someTest"]?.isSucceeded, true)
-        XCTAssertEqual(tests["someTest"]?.isSkipped, false)
-        XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
-    }
-    
+
     // TIA + EFD + ATR
     func testTestImpactAnalysisSkipsEFDKnownTestAndATRRuns() async throws {
         let (runner, tia, _) = tiaEfdAndAtrRunner(skip: ["skipTest"], known: ["skipTest", "knownTest"],
                                                   tests: ["unknownTest": .failOddRuns(),
                                                           "knownTest": .fail(first: 3),
                                                           "skipTest": .fail("Always fails")])
-        let tests = try await extractTests(runner.run())
+        let tests = try extractTests(try await runner.run())
         XCTAssertNotNil(tests["skipTest"])
         XCTAssertEqual(tests["skipTest"]?.runs.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.status == .skip }.count, 1)
@@ -292,7 +183,7 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tia.skippedCount, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["skipTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusSkip)
-        
+
         // EFD works
         XCTAssertNotNil(tests["unknownTest"])
         XCTAssertEqual(tests["unknownTest"]?.runs.count, 10)
@@ -309,7 +200,7 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["unknownTest"]?.isSkipped, false)
         XCTAssertEqual(tests["unknownTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["unknownTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
-        
+
         // ATR works
         XCTAssertNotNil(tests["knownTest"])
         XCTAssertEqual(tests["knownTest"]?.runs.count, 4)
@@ -327,18 +218,18 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["knownTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["knownTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
     }
-    
-    func tiaRunner(skip: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.Runner, TestImpactAnalysis, Mocks.CoverageCollector) {
+
+    func tiaRunner(skip: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.STRunner, TestImpactAnalysis, Mocks.CoverageCollector) {
         let skipped = SkipTests(correlationId: "abacaba",
                                 tests: skip.map { .init(name: $0,
                                                         suite: "TIASuite",
                                                         configuration: ["test.bundle": "TIAModule"]) })
         let collector = Mocks.CoverageCollector()
-        let tia = TestImpactAnalysis(tests: skipped, coverage: collector, swiftTestingEnabled: false)
-        return (Mocks.Runner(features: [tia, AdditionalTags()], tests: ["TIAModule": ["TIASuite": tests]]), tia, collector)
+        let tia = TestImpactAnalysis(tests: skipped, coverage: collector, swiftTestingEnabled: true)
+        return (Mocks.STRunner(features: [tia, AdditionalTags()], tests: ["TIAModule": ["TIASuite": tests]]), tia, collector)
     }
-    
-    func tiaAndEfdRunner(skip: [String], known: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.Runner, TestImpactAnalysis, Mocks.CoverageCollector) {
+
+    func tiaAndEfdRunner(skip: [String], known: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.STRunner, TestImpactAnalysis, Mocks.CoverageCollector) {
         let runner = tiaRunner(skip: skip, tests: tests)
         let efd = EarlyFlakeDetection(
             knownTests: KnownTests(tests: ["TIAModule": ["TIASuite": known]]),
@@ -353,8 +244,8 @@ class TestImpactAnalysisTests: XCTestCase {
         runner.0.features = features
         return runner
     }
-    
-    func tiaAndAtrRunner(skip: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.Runner, TestImpactAnalysis, Mocks.CoverageCollector) {
+
+    func tiaAndAtrRunner(skip: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.STRunner, TestImpactAnalysis, Mocks.CoverageCollector) {
         let runner = tiaRunner(skip: skip, tests: tests)
         let atr = AutomaticTestRetries(failedTestRetriesCount: 5, failedTestTotalRetriesMax: 1000)
         var features = runner.0.features.features
@@ -362,8 +253,8 @@ class TestImpactAnalysisTests: XCTestCase {
         runner.0.features = features
         return runner
     }
-    
-    func tiaEfdAndAtrRunner(skip: [String], known: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.Runner, TestImpactAnalysis, Mocks.CoverageCollector) {
+
+    func tiaEfdAndAtrRunner(skip: [String], known: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.STRunner, TestImpactAnalysis, Mocks.CoverageCollector) {
         let runner = tiaAndEfdRunner(skip: skip, known: known, tests: tests)
         let atr = AutomaticTestRetries(failedTestRetriesCount: 5, failedTestTotalRetriesMax: 1000)
         var features = runner.0.features.features
@@ -371,7 +262,7 @@ class TestImpactAnalysisTests: XCTestCase {
         runner.0.features = features
         return runner
     }
-    
+
     func extractTests(_ session: Mocks.Session) throws -> [String: Mocks.Group] {
         guard let suite = session["TIAModule"]?["TIASuite"] else {
             throw InternalError(description: "Can't get TIAModule and TIASuite")

--- a/Tests/DatadogSDKTesting/Features/TestImpactAnalysisTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestImpactAnalysisTests.swift
@@ -334,7 +334,7 @@ class TestImpactAnalysisTests: XCTestCase {
                                                         suite: "TIASuite",
                                                         configuration: ["test.bundle": "TIAModule"]) })
         let collector = Mocks.CoverageCollector()
-        let tia = TestImpactAnalysis(tests: skipped, coverage: Mocks.CoverageCollector())
+        let tia = TestImpactAnalysis(tests: skipped, coverage: Mocks.CoverageCollector(), swiftTestingEnabled: false)
         return (Mocks.Runner(features: [tia, AdditionalTags()], tests: ["TIAModule": ["TIASuite": tests]]), tia, collector)
     }
     

--- a/Tests/DatadogSDKTesting/Features/TestImpactAnalysisTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestImpactAnalysisTests.swift
@@ -10,9 +10,9 @@ import XCTest
 
 class TestImpactAnalysisTests: XCTestCase {
     func testTestImpactAnalysisSkipsTest() async throws {
-        let (runner, tia, _) = tiaRunner(skip: ["skipTest"],
-                                         tests: ["someTest": .fail("Always fails"),
-                                                 "skipTest": .fail("Always fails")])
+        let (runner, tia, collector) = tiaRunner(skip: ["skipTest"],
+                                                 tests: ["someTest": .fail("Always fails"),
+                                                         "skipTest": .fail("Always fails")])
         let tests = try await extractTests(runner.run())
         XCTAssertNotNil(tests["skipTest"])
         XCTAssertEqual(tests["skipTest"]?.runs.count, 1)
@@ -40,10 +40,11 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
+        XCTAssertEqual(collector.tests.count, 1) // someTest ran once; skipTest was skipped
     }
-    
+
     func testTestImpactAnalysisDoesntSkipUnskippable() async throws {
-        let (runner, tia, _) = tiaRunner(skip: ["skipTest"],
+        let (runner, tia, collector) = tiaRunner(skip: ["skipTest"],
                                          tests: ["someTest": .fail("Always fails"),
                                                  "skipTest": .fail("Always fails", unskippable: true)])
         let tests = try await extractTests(runner.run())
@@ -73,11 +74,12 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
+        XCTAssertEqual(collector.tests.count, 2) // both someTest and skipTest (unskippable) ran once each
     }
-    
+
     // TIA + EFD
     func testTestImpactAnalysisSkipsEFDKnownTest() async throws {
-        let (runner, tia, _) = tiaAndEfdRunner(skip: ["skipTest"], known: ["skipTest"],
+        let (runner, tia, collector) = tiaAndEfdRunner(skip: ["skipTest"], known: ["skipTest"],
                                                tests: ["someTest": .failOddRuns(),
                                                        "skipTest": .fail("Always fails")])
         let tests = try await extractTests(runner.run())
@@ -113,10 +115,11 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 10) // someTest ran 10 times via EFD; skipTest was skipped
     }
-    
+
     func testTestImpactAnalysisSkipsEFDUnknownTest() async throws {
-        let (runner, tia, _) = tiaAndEfdRunner(skip: ["skipTest"], known: [],
+        let (runner, tia, collector) = tiaAndEfdRunner(skip: ["skipTest"], known: [],
                                                tests: ["someTest": .failOddRuns(),
                                                        "skipTest": .fail("Always fails")])
         let tests = try await extractTests(runner.run())
@@ -152,10 +155,11 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 10) // someTest ran 10 times via EFD; skipTest was skipped
     }
-    
+
     func testTestImpactAnalysisUnskippableEFDWorks() async throws {
-        let (runner, tia, _) = tiaAndEfdRunner(skip: ["skipTest"], known: [],
+        let (runner, tia, collector) = tiaAndEfdRunner(skip: ["skipTest"], known: [],
                                                tests: ["someTest": .failOddRuns(),
                                                        "skipTest": .failEvenRuns(unskippable: true)])
         let tests = try await extractTests(runner.run())
@@ -191,11 +195,12 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 20) // someTest 10 + skipTest (unskippable) 10 runs via EFD
     }
-    
+
     // TIA + ATR
     func testTestImpactAnalysisAndATRWorksTogether() async throws {
-        let (runner, tia, _) = tiaAndAtrRunner(skip: ["skipTest"],
+        let (runner, tia, collector) = tiaAndAtrRunner(skip: ["skipTest"],
                                                tests: ["someTest": .fail(first: 3),
                                                        "skipTest": .fail("Always fails")])
         let tests = try await extractTests(runner.run())
@@ -230,10 +235,11 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 4) // someTest ran 4 times via ATR; skipTest was skipped
     }
-    
+
     func testTestImpactAnalysisAndATRWorksTogetherUnskippable() async throws {
-        let (runner, tia, _) = tiaAndAtrRunner(skip: ["skipTest"],
+        let (runner, tia, collector) = tiaAndAtrRunner(skip: ["skipTest"],
                                                tests: ["someTest": .fail(first: 3),
                                                        "skipTest": .fail(first: 4, unskippable: true)])
         let tests = try await extractTests(runner.run())
@@ -267,11 +273,12 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.isSkipped, false)
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 9) // skipTest (unskippable) 5 runs + someTest 4 runs via ATR
     }
-    
+
     // TIA + EFD + ATR
     func testTestImpactAnalysisSkipsEFDKnownTestAndATRRuns() async throws {
-        let (runner, tia, _) = tiaEfdAndAtrRunner(skip: ["skipTest"], known: ["skipTest", "knownTest"],
+        let (runner, tia, collector) = tiaEfdAndAtrRunner(skip: ["skipTest"], known: ["skipTest", "knownTest"],
                                                   tests: ["unknownTest": .failOddRuns(),
                                                           "knownTest": .fail(first: 3),
                                                           "skipTest": .fail("Always fails")])
@@ -326,8 +333,9 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(tests["knownTest"]?.isSkipped, false)
         XCTAssertEqual(tests["knownTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["knownTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(collector.tests.count, 14) // unknownTest 10 + knownTest 4; skipTest was skipped
     }
-    
+
     func tiaRunner(skip: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.Runner, TestImpactAnalysis, Mocks.CoverageCollector) {
         let skipped = SkipTests(correlationId: "abacaba",
                                 tests: skip.map { .init(name: $0,

--- a/Tests/DatadogSDKTesting/MockSwiftTesting.swift
+++ b/Tests/DatadogSDKTesting/MockSwiftTesting.swift
@@ -125,18 +125,22 @@ extension Mocks {
                           tests: KeyValuePairs<String, Runner.TestMethod>) async throws
         {
             for test in tests {
-                try await provider.provideScope(test: STTest(name: test.key, module: module, suite: suite)) {
-                    try await provider.provideScope(run: STTestRun(name: test.key, module: module, suite: suite)) {
-                        if let duration = test.value.duration {
-                            let test = Mocks.Test.active as! Mocks.Test
-                            test.duration = duration.toNanoseconds
-                        }
-                        switch test.value.method() {
-                        case .fail(let err): throw err
-                        case .skip(let reason): throw STSkipError(reason: reason)
-                        case .pass: break
+                do {
+                    try await provider.provideScope(test: STTest(name: test.key, module: module, suite: suite)) {
+                        try await provider.provideScope(run: STTestRun(name: test.key, module: module, suite: suite)) {
+                            if let duration = test.value.duration {
+                                let test = Mocks.Test.active as! Mocks.Test
+                                test.duration = duration.toNanoseconds
+                            }
+                            switch test.value.method() {
+                            case .fail(let err): throw err
+                            case .skip(let reason): throw STSkipError(reason: reason)
+                            case .pass: break
+                            }
                         }
                     }
+                } catch is STSkipError {
+                    // test was skipped by the framework (e.g., by TIA), continue with the next test
                 }
             }
         }

--- a/Tests/DatadogSDKTesting/MockSwiftTesting.swift
+++ b/Tests/DatadogSDKTesting/MockSwiftTesting.swift
@@ -185,10 +185,10 @@ extension Mocks {
         }
         
         func testGroupConfiguration(
-            for test: String, meta: any UnskippableMethodCheckerFactory,
+            for test: String, tags: any TestTags,
             in suite: any TestSuite, configuration: RetryGroupConfiguration.Iterator
         ) -> (feature: (any TestHooksFeature)?, configuration: RetryGroupConfiguration) {
-            let config = wrapped.testGroupConfiguration(for: test, meta: meta,
+            let config = wrapped.testGroupConfiguration(for: test, tags: tags,
                                                         in: suite, configuration: configuration)
             _configs.update {
                 $0[suite.name + "." + test] = config.configuration

--- a/Tests/DatadogSDKTesting/MockTestRunner.swift
+++ b/Tests/DatadogSDKTesting/MockTestRunner.swift
@@ -153,7 +153,7 @@ extension Mocks {
         func _run(group name: String, method: TestMethod, suite: Suite) {
             let group = suite.startGroup(named: name)
             
-            let (feature, config) = features.testGroupConfiguration(for: group.name, meta: group, in: suite)
+            let (feature, config) = features.testGroupConfiguration(for: group.name, tags: group, in: suite)
             
             group.skipStrategy = config.skipStrategy
             group.successStrategy = config.successStrategy

--- a/Tests/DatadogSDKTesting/MockTestTypes.swift
+++ b/Tests/DatadogSDKTesting/MockTestTypes.swift
@@ -355,7 +355,7 @@ enum Mocks {
         }
     }
     
-    final class Group: UnskippableMethodCheckerFactory, Equatable, Hashable, CustomDebugStringConvertible, Sendable {
+    final class Group: Equatable, Hashable, CustomDebugStringConvertible, Sendable, TestTags {
         struct GroupInfo {
             var unskippable: Bool = false
             var runs: [Test] = []
@@ -415,13 +415,6 @@ enum Mocks {
             return runs[run]
         }
         
-        var classId: ObjectIdentifier { ObjectIdentifier(self) }
-        
-        var unskippableMethods: UnskippableMethodChecker {
-            .init(isSuiteUnskippable: suite.unskippable,
-                  skippableMethods: [name: !unskippable])
-        }
-        
         var executionCount: Int { runs.filter { $0.duration > 0 }.count }
         var failedExecutionCount: Int { runs.filter { $0.status == .fail }.count }
         
@@ -443,6 +436,13 @@ enum Mocks {
                 return runs.allSatisfy { $0.status == .skip }
             case .atLeastOneSkipped:
                 return runs.contains { $0.status == .skip }
+            }
+        }
+        
+        func get<T: TestTag>(tag: T) -> T.Value? {
+            switch tag {
+            case is TIASkippableTag: return (!(suite.unskippable || unskippable) as! T.Value)
+            default: return nil
             }
         }
         

--- a/Tests/DatadogSDKTesting/SwiftTestingTraitTests.swift
+++ b/Tests/DatadogSDKTesting/SwiftTestingTraitTests.swift
@@ -249,18 +249,42 @@ private struct ObserverTesterTrait: SuiteTrait, TestTrait, TestScoping {
             for run in paramGroup.runs {
                 #expect(run.tags[DDTestTags.testParameters] != nil)
             }
+            let params = try paramGroup.runs.map {
+                try $0.tags[DDTestTags.testParameters].map { try decoder.decode(TestParameters.self, from: $0.utf8Data) }
+            }.sorted { g1, g2 in
+                g1?.arguments.first?.value ?? "" < g2?.arguments.first?.value ?? ""
+            }
             // Arguments are zip([1,2,3], ["1","2","3"]); the String value appears
             // with its surrounding quotes in the description, so it is JSON-escaped.
-            let expectedParams = [
-                try decoder.decode(JSONGeneric.self, from: #"{"arguments":[{"name":"p1","value":"1","type":"Swift.Int"},{"name":"p2","value":"\"1\"","type":"Swift.String"}]}"#.utf8Data),
-                try decoder.decode(JSONGeneric.self, from: #"{"arguments":[{"name":"p1","value":"2","type":"Swift.Int"},{"name":"p2","value":"\"2\"","type":"Swift.String"}]}"#.utf8Data),
-                try decoder.decode(JSONGeneric.self, from: #"{"arguments":[{"name":"p1","value":"3","type":"Swift.Int"},{"name":"p2","value":"\"3\"","type":"Swift.String"}]}"#.utf8Data)
+            let expectedParams: [TestParameters] = [
+                [(name: "p1", value: "1", type: "Swift.Int"), (name: "p2", value:"\"1\"", type:"Swift.String")],
+                [(name: "p1", value: "2", type: "Swift.Int"), (name: "p2", value:"\"2\"", type:"Swift.String")],
+                [(name: "p1", value: "3", type: "Swift.Int"), (name: "p2", value:"\"3\"", type:"Swift.String")]
             ]
-            for (run, expected) in zip(paramGroup.runs, expectedParams) {
-                let runParams = try run.tags[DDTestTags.testParameters].map { try decoder.decode(JSONGeneric.self, from: $0.utf8Data) }
-                #expect(runParams == expected)
+            for (run, expected) in zip(params, expectedParams) {
+                #expect(run == expected)
             }
         }
+    }
+}
+
+private struct TestParameters: Equatable, Codable, ExpressibleByArrayLiteral {
+    typealias ArrayLiteralElement = (name: String, value: String, type: String)
+    
+    struct Argument: Equatable, Codable {
+        let name: String
+        let value: String
+        let type: String
+        
+        init(_ t: (name: String, value: String, type: String)) {
+            name = t.name; value = t.value; type = t.type
+        }
+    }
+    
+    let arguments: [Argument]
+    
+    init(arrayLiteral elements: (name: String, value: String, type: String)...) {
+        arguments = elements.map(Argument.init)
     }
 }
 


### PR DESCRIPTION
### What and why?

Added serial Test Impact Analysis support for Swift Testing.

### How?

It's enabled only when Swift Testing runs in the serial mode (without parallelisation). SDK tries to detect it from the Xcode schemes/plans or it can be enabled by environment variable.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
