### PR TITLE
[CHORE] Fixed syntax for old Xcode versions

### DIFF
--- a/Sources/DatadogSDKTesting/XCTest/DDXCTestCase.swift
+++ b/Sources/DatadogSDKTesting/XCTest/DDXCTestCase.swift
@@ -381,7 +381,9 @@ protocol XCTestTag: TestTag {
 }
 
 // XCTest is synchronous so it's not synchronized
-final class XCTestSuiteTags: Identifiable<ObjectIdentifier> {
+final class XCTestSuiteTags: Identifiable {
+    typealias ID = ObjectIdentifier
+    
     var id: ObjectIdentifier { ObjectIdentifier(_clazz) }
     
     private let _clazz: XCTestCase.Type


### PR DESCRIPTION
### What and why?

Seems as I used Xcode 26.4+ syntax at one place and it fails to compile on older Xcodes.

### How?

Changed to older syntax so old Swift versions will work

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
