### PR TITLE
[FIX] Fixed crash reports size

### DIFF
--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -20,9 +20,10 @@ enum DDHeaders: String, CaseIterable {
 internal class DDTracer {
     let tracerSdk: TracerSdk
     let tracerProviderSdk: TracerProviderSdk
+    let maxObjectSize: UInt64
     var eventsExporter: EventsExporterProtocol?
+    
     private var launchSpanContext: SpanContext?
-
     private let attributeCountLimit: UInt = 1024
 
     static var activeSpan: Span? { OpenTelemetry.instance.contextProvider.activeSpan ?? Test.current?.span }
@@ -38,6 +39,7 @@ internal class DDTracer {
     init(id: String, version: String, exporter: EventsExporterProtocol?, enabled: Bool, launchContext: SpanContext?) {
         self.launchSpanContext = launchContext
         self.eventsExporter = exporter
+        self.maxObjectSize = exporter?.maxObjectSize ?? 262144
         
         let exporterToUse: SpanExporter
         if !enabled {
@@ -201,6 +203,7 @@ internal class DDTracer {
         }
 
         attributes.updateValue(value: AttributeValue.string(DDTagValues.statusFail), forKey: DDTestTags.testStatus)
+        let error = error.trimmed(maxSize: maxObjectSize - 5120) // 5k for other tags and everything else for crash log
         attributes.updateValue(value: AttributeValue.string(error.type), forKey: DDTags.errorType)
         if let message = error.message {
             attributes.updateValue(value: AttributeValue.string(message), forKey: DDTags.errorMessage)

--- a/Sources/DatadogSDKTesting/Models.swift
+++ b/Sources/DatadogSDKTesting/Models.swift
@@ -208,6 +208,13 @@ struct TestError: Error, CustomDebugStringConvertible {
         }
     }
     
+    private init(type: String, message: String?, stack: String?, crashLog: [String]?) {
+        self.type = type
+        self.message = message
+        self.stack = stack
+        self.crashLog = crashLog
+    }
+    
     func joined(other error: Self) -> Self {
         var newMessage: String
         var newStack: String? = nil
@@ -241,11 +248,40 @@ struct TestError: Error, CustomDebugStringConvertible {
         return .init(type: type, message: newMessage, stack: newStack)
     }
     
+    func trimmed(maxSize: UInt64) -> Self {
+        var newMessage: String? = nil
+        var newStack: String? = nil
+        var newCrashLog: [String]? = nil
+        var maxSize = Int(maxSize) - type.utf8.count
+        if let message, maxSize > 0 {
+            newMessage = message.trimmed(maxLength: &maxSize)
+        }
+        if let stack, maxSize > 0 {
+            newStack = stack.trimmed(maxLength: &maxSize)
+        }
+        if let crashLog {
+            newCrashLog = []
+            for log in crashLog where maxSize > 0 {
+                newCrashLog?.append(log.trimmed(maxLength: &maxSize))
+            }
+        }
+        return .init(type: type,
+                     message: newMessage,
+                     stack: newStack,
+                     crashLog: newCrashLog)
+    }
+    
     var debugDescription: String {
         var text = type
         if let message { text += ": \(message)" }
         if let stack { text += "\n\(stack)" }
-        if let crashLog { text += "\n\n" + crashLog.joined(separator: "\n") }
+        if let crashLog {
+            var maxStack = 512
+            text += "\n\n" + crashLog.joined(separator: "\n").trimmed(maxLength: &maxStack)
+            if maxStack == 0 {
+                text += "\n(truncated)"
+            }
+        }
         return text
     }
 }

--- a/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
+++ b/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
@@ -34,6 +34,17 @@ extension String {
 
         return results.map { String($0) }
     }
+    
+    func trimmed(maxLength: inout Int) -> String {
+        let utf8Count = utf8.count
+        if utf8Count <= maxLength {
+            maxLength -= utf8Count
+            return self
+        } else {
+            defer { maxLength = 0 }
+            return String(bytes: utf8.prefix(maxLength), encoding: .utf8)!
+        }
+    }
 
     var separatedByWords: String {
         enum My {

--- a/Sources/EventsExporter/EventsExporter.swift
+++ b/Sources/EventsExporter/EventsExporter.swift
@@ -10,6 +10,7 @@ import CodeCoverageParser
 
 public protocol EventsExporterProtocol: SpanExporter {
     var endpointURLs: Set<String> { get }
+    var maxObjectSize: UInt64 { get }
     
     func exportEvent<T: Encodable>(event: T)
     func searchCommits(repositoryURL: String, commits: [String]) -> [String]
@@ -40,6 +41,8 @@ public final class EventsExporter: EventsExporterProtocol {
     var settingsService: SettingsService
     var knownTestsService: KnownTestsService
     var testManagementService: TestManagementService
+    
+    public var maxObjectSize: UInt64 { configuration.performancePreset.maxObjectSize }
 
     public init(config: ExporterConfiguration) throws {
         self.configuration = config


### PR DESCRIPTION
### What and why?

Crash reports are too big to be sent in one span. Trimmed them

### How?

Added trim for error so it will trim report before attaching it to the span

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
