### PR TITLE
[SDTEST-3753] Added a proper log message for the bad API key (401/403 responses from the backend).

### DIFF
--- a/Sources/EventsExporter/Upload/DataUploadStatus.swift
+++ b/Sources/EventsExporter/Upload/DataUploadStatus.swift
@@ -62,7 +62,13 @@ extension DataUploadStatus {
         self.init(needsRetry: statusCode.needsRetry)
     }
 
-    init(networkError: Error) {
-        self.init(needsRetry: true)
+    init(networkError: HTTPClient.RequestError) {
+        switch networkError {
+        case .http(code: let code, body: nil):
+            let statusCode = HTTPResponseStatusCode(rawValue: code) ?? .unexpected
+            self.init(needsRetry: statusCode.needsRetry)
+        default:
+            self.init(needsRetry: true)
+        }
     }
 }

--- a/Sources/EventsExporter/Upload/DataUploader.swift
+++ b/Sources/EventsExporter/Upload/DataUploader.swift
@@ -38,7 +38,7 @@ internal final class DataUploader: DataUploaderType {
                 uploadStatus = DataUploadStatus(httpResponse: httpResponse)
             case .failure(let error):
                 uploadStatus = DataUploadStatus(networkError: error)
-                if error.isUnathorized {
+                if error.isUnauthorized {
                     Log.print("Datadog backend rejected the request as unathorized. Please verify that DD_API_KEY is correct.")
                 }
             }
@@ -64,7 +64,7 @@ internal final class DataUploader: DataUploaderType {
             case .success(let data):
                 returnData = data
             case .failure(let error):
-                if error.isUnathorized {
+                if error.isUnauthorized {
                     Log.print("Datadog backend rejected the request as unathorized. Please verify that DD_API_KEY is correct.")
                 }
                 returnData = nil

--- a/Sources/EventsExporter/Upload/DataUploader.swift
+++ b/Sources/EventsExporter/Upload/DataUploader.swift
@@ -38,6 +38,9 @@ internal final class DataUploader: DataUploaderType {
                 uploadStatus = DataUploadStatus(httpResponse: httpResponse)
             case .failure(let error):
                 uploadStatus = DataUploadStatus(networkError: error)
+                if error.isUnathorized {
+                    Log.print("Datadog backend rejected the request as unathorized. Please verify that DD_API_KEY is correct.")
+                }
             }
 
             semaphore.signal()
@@ -58,10 +61,13 @@ internal final class DataUploader: DataUploaderType {
 
         httpClient.sendWithResult(request: request) { result in
             switch result {
-                case .success(let data):
-                    returnData = data
-                case .failure:
-                    returnData = nil
+            case .success(let data):
+                returnData = data
+            case .failure(let error):
+                if error.isUnathorized {
+                    Log.print("Datadog backend rejected the request as unathorized. Please verify that DD_API_KEY is correct.")
+                }
+                returnData = nil
             }
 
             semaphore.signal()

--- a/Sources/EventsExporter/Upload/HTTPClient.swift
+++ b/Sources/EventsExporter/Upload/HTTPClient.swift
@@ -11,6 +11,22 @@ internal final class HTTPClient {
     private let session: URLSession
     private let debug: Bool
     
+    enum RequestError: Error {
+        case http(code: Int, body: Data?)
+        case transport(any Error)
+        /// An error returned if `URLSession` response state is inconsistent (like no data, no response and no error).
+        /// The code execution in `URLSessionTransport` should never reach its initialization.
+        case inconsistentSession
+        
+        var isUnathorized: Bool {
+            switch self {
+            case .http(code: 401, body: _), .http(code: 403, body: _):
+                return true
+            default: return false
+            }
+        }
+    }
+    
     convenience init(debug: Bool) {
         let configuration: URLSessionConfiguration = .ephemeral
         // NOTE: RUMM-610 Default behaviour of `.ephemeral` session is to cache requests.
@@ -27,7 +43,7 @@ internal final class HTTPClient {
         self.debug = debug
     }
     
-    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+    func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, RequestError>) -> Void) {
         let task = session.dataTask(with: request) { data, response, error in
             self.log(request: request, response: (data, response, error))
             completion(httpClientResult(for: (data, response, error)))
@@ -35,7 +51,7 @@ internal final class HTTPClient {
         task.resume()
     }
     
-    func sendWithResult(request: URLRequest, completion: @escaping (Result<Data, Error>) -> Void) {
+    func sendWithResult(request: URLRequest, completion: @escaping (Result<Data, RequestError>) -> Void) {
         let task = session.dataTask(with: request) { data, response, error in
             self.log(request: request, response: (data, response, error))
             completion(httpClientResultWithData(for: (data, response, error)))
@@ -68,32 +84,38 @@ internal struct URLSessionTransportInconsistencyException: Error {}
 
 /// As `URLSession` returns 3-values-tuple for request execution, this function applies consistency constraints and turns
 /// it into only two possible states of `HTTPTransportResult`.
-private func httpClientResult(for urlSessionTaskCompletion: (Data?, URLResponse?, Error?)) -> Result<HTTPURLResponse, Error> {
-    let (_, response, error) = urlSessionTaskCompletion
+private func httpClientResult(for urlSessionTaskCompletion: (Data?, URLResponse?, Error?)) -> Result<HTTPURLResponse, HTTPClient.RequestError> {
+    let (data, response, error) = urlSessionTaskCompletion
 
     if let error = error {
-        return .failure(error)
+        return .failure(.transport(error))
     }
 
     if let httpResponse = response as? HTTPURLResponse {
+        guard httpResponse.statusCode < 400 else {
+            return .failure(.http(code: httpResponse.statusCode, body: data))
+        }
         return .success(httpResponse)
     }
 
-    return .failure(URLSessionTransportInconsistencyException())
+    return .failure(.inconsistentSession)
 }
 
 /// As `URLSession` returns 3-values-tuple for request execution, this function applies consistency constraints and turns
 /// it into only two possible states of `HTTPTransportResult`.
-private func httpClientResultWithData(for urlSessionTaskCompletion: (Data?, URLResponse?, Error?)) -> Result<Data, Error> {
-    let (data, _ , error) = urlSessionTaskCompletion
+private func httpClientResultWithData(for urlSessionTaskCompletion: (Data?, URLResponse?, Error?)) -> Result<Data, HTTPClient.RequestError> {
+    let (data, response, error) = urlSessionTaskCompletion
 
     if let error = error {
-        return .failure(error)
+        return .failure(.transport(error))
     }
 
-    if let httpResponse = data {
-        return .success(httpResponse)
+    if let httpResponse = response as? HTTPURLResponse {
+        guard httpResponse.statusCode < 400 else {
+            return .failure(.http(code: httpResponse.statusCode, body: data))
+        }
+        return .success(data ?? Data())
     }
 
-    return .failure(URLSessionTransportInconsistencyException())
+    return .failure(.inconsistentSession)
 }

--- a/Sources/EventsExporter/Upload/HTTPClient.swift
+++ b/Sources/EventsExporter/Upload/HTTPClient.swift
@@ -18,7 +18,7 @@ internal final class HTTPClient {
         /// The code execution in `URLSessionTransport` should never reach its initialization.
         case inconsistentSession
         
-        var isUnathorized: Bool {
+        var isUnauthorized: Bool {
             switch self {
             case .http(code: 401, body: _), .http(code: 403, body: _):
                 return true

--- a/Tests/EventsExporter/Upload/DataUploaderTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploaderTests.swift
@@ -13,7 +13,7 @@ extension DataUploadStatus: EquatableInTests {}
 class DataUploaderTests: XCTestCase {
     func testWhenUploadCompletesWithSuccess_itReturnsExpectedUploadStatus() {
         // Given
-        let randomResponse: HTTPURLResponse = .mockResponseWith(statusCode: (100 ... 599).randomElement()!)
+        let randomResponse: HTTPURLResponse = .mockResponseWith(statusCode: (100 ... 399).randomElement()!)
 
         let server = ServerMock(delivery: .success(response: randomResponse))
         let uploader = DataUploader(
@@ -46,7 +46,7 @@ class DataUploaderTests: XCTestCase {
         let uploadStatus = uploader.upload(data: .mockAny())
 
         // Then
-        let expectedUploadStatus = DataUploadStatus(networkError: randomError)
+        let expectedUploadStatus = DataUploadStatus(networkError: .transport(randomError))
 
         XCTAssertEqual(uploadStatus, expectedUploadStatus)
         server.waitFor(requestsCompletion: 1)

--- a/Tests/EventsExporter/Upload/HTTPClientTests.swift
+++ b/Tests/EventsExporter/Upload/HTTPClientTests.swift
@@ -35,11 +35,10 @@ class HTTPClientTests: XCTestCase {
 
         client.send(request: .mockAny()) { result in
             switch result {
-            case .success:
-                break
-            case .failure(let error):
+            case .failure(.transport(let error)):
                 XCTAssertEqual((error as NSError).localizedDescription, "no internet connection")
                 expectation.fulfill()
+            default: break
             }
         }
 


### PR DESCRIPTION
### What and why?

If user will set a bad API key (malformed/revoked) requests will fail with 401/403 error. We need to show an error with explanation to user so they could fix it.

### How?

Added handlers for 401 and 403 response codes with log.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
