### PR TITLE
[SDTEST-3525] Added error tags for configuration requests

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		A77C12372D8DCB87009C2BA1 /* AutomaticTestRetries.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C12362D8DCB87009C2BA1 /* AutomaticTestRetries.swift */; };
 		A77C12392D8DD2A9009C2BA1 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C12382D8DD2A9009C2BA1 /* Feature.swift */; };
 		A77C123C2D9425C7009C2BA1 /* KnownTestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */; };
+		A7EE000000020000000000A2 /* LibraryConfigurationErrorTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */; };
 		A77C123E2D9474E6009C2BA1 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C123D2D9474E6009C2BA1 /* Models.swift */; };
 		A794A8FF2E7990D20044FE3C /* TestManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */; };
 		A79DA5B42F928F87004BCA8C /* SwiftTestingSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79DA5B32F928F87004BCA8C /* SwiftTestingSmokeTests.swift */; };
@@ -235,6 +236,7 @@
 		A7FC26772BA1F80500067E26 /* LogsExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E141EAE527EB3B9E0057D747 /* LogsExporterTests.swift */; };
 		A7FC26782BA1F80500067E26 /* LogSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E141EAE627EB3B9E0057D747 /* LogSanitizerTests.swift */; };
 		A7FC26792BA1F80800067E26 /* EventsExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E141EAE727EB3B9E0057D747 /* EventsExporterTests.swift */; };
+		A7EE000000010000000000A2 /* LibraryConfigurationErrorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000010000000000A1 /* LibraryConfigurationErrorsTests.swift */; };
 		A7FC267A2BA1F80E00067E26 /* FileReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E141EAE927EB3B9E0057D747 /* FileReaderTests.swift */; };
 		A7FC267B2BA1F80E00067E26 /* FileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E141EAEA27EB3B9E0057D747 /* FileWriterTests.swift */; };
 		A7FC267C2BA1F80E00067E26 /* FilesOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E141EAEB27EB3B9E0057D747 /* FilesOrchestratorTests.swift */; };
@@ -463,6 +465,7 @@
 		A77C12362D8DCB87009C2BA1 /* AutomaticTestRetries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticTestRetries.swift; sourceTree = "<group>"; };
 		A77C12382D8DD2A9009C2BA1 /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownTestsTests.swift; sourceTree = "<group>"; };
+		A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationErrorTagsTests.swift; sourceTree = "<group>"; };
 		A77C123D2D9474E6009C2BA1 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestManagementTests.swift; sourceTree = "<group>"; };
 		A79DA5B22F928F71004BCA8C /* IntegrationTests-UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "IntegrationTests-UnitTests.xctestplan"; sourceTree = "<group>"; };
@@ -546,6 +549,7 @@
 		E141EAE527EB3B9E0057D747 /* LogsExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogsExporterTests.swift; sourceTree = "<group>"; };
 		E141EAE627EB3B9E0057D747 /* LogSanitizerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogSanitizerTests.swift; sourceTree = "<group>"; };
 		E141EAE727EB3B9E0057D747 /* EventsExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsExporterTests.swift; sourceTree = "<group>"; };
+		A7EE000000010000000000A1 /* LibraryConfigurationErrorsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationErrorsTests.swift; sourceTree = "<group>"; };
 		E141EAE927EB3B9E0057D747 /* FileReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileReaderTests.swift; sourceTree = "<group>"; };
 		E141EAEA27EB3B9E0057D747 /* FileWriterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileWriterTests.swift; sourceTree = "<group>"; };
 		E141EAEB27EB3B9E0057D747 /* FilesOrchestratorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilesOrchestratorTests.swift; sourceTree = "<group>"; };
@@ -839,6 +843,7 @@
 				A718EC342CC7F32A00C5F0D9 /* EarlyFlakeDetectionTests.swift */,
 				CC931D86ADB841B6969C7A7A /* EarlyFlakeDetectionSwiftTestingTests.swift */,
 				A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */,
+				A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -972,6 +977,7 @@
 				E141EAFB27EB3B9E0057D747 /* Upload */,
 				A7FC26E42BA8648300067E26 /* EventsExporter.xctestplan */,
 				E141EAE727EB3B9E0057D747 /* EventsExporterTests.swift */,
+				A7EE000000010000000000A1 /* LibraryConfigurationErrorsTests.swift */,
 				A74EB8E32D0AFD3C00FAD9B8 /* CodeCoverageModelTests.swift */,
 			);
 			path = EventsExporter;
@@ -2007,6 +2013,7 @@
 				A7675D4D2F64847300A05B5F /* SwiftTestingTraitTests.swift in Sources */,
 				A7675D722F6CA00000A05B5F /* SwiftTestRunParametersParserTests.swift in Sources */,
 				A77C123C2D9425C7009C2BA1 /* KnownTestsTests.swift in Sources */,
+				A7EE000000020000000000A2 /* LibraryConfigurationErrorTagsTests.swift in Sources */,
 				A7FC266E2BA1F70200067E26 /* DDXCTestObserverTests.swift in Sources */,
 				A7675D742F6CA00000A05B5F /* SessionManagerTests.swift in Sources */,
 				A7FC266C2BA1F70200067E26 /* FrameworkLoadHandlerTests.swift in Sources */,
@@ -2094,6 +2101,7 @@
 				A7FC26782BA1F80500067E26 /* LogSanitizerTests.swift in Sources */,
 				A7FC268A2BA1F82300067E26 /* DataUploaderTests.swift in Sources */,
 				A7FC26792BA1F80800067E26 /* EventsExporterTests.swift in Sources */,
+				A7EE000000010000000000A2 /* LibraryConfigurationErrorsTests.swift in Sources */,
 				A7FC267B2BA1F80E00067E26 /* FileWriterTests.swift in Sources */,
 				A7FC268D2BA1F82300067E26 /* DataUploadDelayTests.swift in Sources */,
 				A71D89262BD6CACD00531A90 /* Logger.swift in Sources */,

--- a/Sources/DatadogSDKTesting/AdditionalTagsFeature.swift
+++ b/Sources/DatadogSDKTesting/AdditionalTagsFeature.swift
@@ -6,6 +6,32 @@
 
 import Foundation
 
+/// Tracks communication errors that occurred while fetching library
+/// configuration data from the backend (settings, skippable tests, flaky tests,
+/// known tests, test management tests). Each flag is sticky: once set to
+/// `true` it stays `true` until the tracker is discarded.
+final class LibraryConfigurationErrors: @unchecked Sendable {
+    enum Kind: Hashable, CaseIterable {
+        case settings
+        case skippableTests
+        case flakyTests
+        case knownTests
+        case testManagementTests
+    }
+
+    private let lock = NSLock()
+    private var flags: Set<Kind> = []
+
+    subscript(_ kind: Kind) -> Bool {
+        lock.withLock { flags.contains(kind) }
+    }
+
+    /// Marks the request kind as having failed with a communication error.
+    func recordCommunicationError(_ kind: Kind) {
+        lock.withLock { _ = flags.insert(kind) }
+    }
+}
+
 final class AdditionalTags: TestHooksFeature {
     static let id: FeatureId = "Additional Test Tags"
 
@@ -85,6 +111,51 @@ final class AdditionalTags: TestHooksFeature {
             test.set(tag: DDTestTags.testFinalStatus,
                      value: status.final(ignoreErrors: info.retry.status.ignoreErrors))
         }
+    }
+
+    func stop() {}
+}
+
+/// Adds `_dd.ci.library_configuration_error.*` hidden tags to every test,
+/// suite, module and session event whenever a backend communication error
+/// occurred while fetching library configuration data.
+final class LibraryConfigurationErrorTags: TestHooksFeature {
+    static let id: FeatureId = "Library Configuration Error Tags"
+
+    let errors: LibraryConfigurationErrors
+
+    init(errors: LibraryConfigurationErrors) {
+        self.errors = errors
+    }
+
+    private static let tagByKind: [LibraryConfigurationErrors.Kind: String] = [
+        .settings: DDLibraryConfigurationErrorTags.settings,
+        .skippableTests: DDLibraryConfigurationErrorTags.skippableTests,
+        .flakyTests: DDLibraryConfigurationErrorTags.flakyTests,
+        .knownTests: DDLibraryConfigurationErrorTags.knownTests,
+        .testManagementTests: DDLibraryConfigurationErrorTags.testManagementTests
+    ]
+
+    private func apply(_ setter: (String, String) -> Void) {
+        for (kind, tag) in Self.tagByKind where errors[kind] {
+            setter(tag, "true")
+        }
+    }
+
+    func testSessionWillEnd(session: any TestSession) {
+        apply { session.set(tag: $0, value: $1) }
+    }
+
+    func testModuleWillEnd(module: any TestModule) {
+        apply { module.set(tag: $0, value: $1) }
+    }
+
+    func testSuiteWillEnd(suite: any TestSuite) {
+        apply { suite.set(tag: $0, value: $1) }
+    }
+
+    func testWillStart(test: any TestRun, info: TestRunInfoStart) {
+        apply { test.set(tag: $0, value: $1) }
     }
 
     func stop() {}

--- a/Sources/DatadogSDKTesting/DDTags.swift
+++ b/Sources/DatadogSDKTesting/DDTags.swift
@@ -252,6 +252,14 @@ internal enum DDTestManagementTags {
     static let testIsAttemptToFix = "test.test_management.is_attempt_to_fix"
 }
 
+internal enum DDLibraryConfigurationErrorTags {
+    static let settings = "_dd.ci.library_configuration_error.settings"
+    static let skippableTests = "_dd.ci.library_configuration_error.skippable_tests"
+    static let flakyTests = "_dd.ci.library_configuration_error.flaky_tests"
+    static let knownTests = "_dd.ci.library_configuration_error.known_tests"
+    static let testManagementTests = "_dd.ci.library_configuration_error.test_management_tests"
+}
+
 internal enum DDLibraryCapabilitiesTags {
     static let testImpactAnalysis = "_dd.library_capabilities.test_impact_analysis"
     static let earlyFlakeDetection = "_dd.library_capabilities.early_flake_detection"

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -81,6 +81,7 @@ internal class DDTestMonitor {
     var efd: EarlyFlakeDetection? = nil
     var atr: AutomaticTestRetries? = nil
     var testManagement: TestManagement? = nil
+    let libraryConfigurationErrors = LibraryConfigurationErrors()
     
     let lock: UnfairLock = .init()
     
@@ -255,10 +256,13 @@ internal class DDTestMonitor {
             return
         }
         
-        let getTracerConfig = { (log: String) in
-            if let eventsExporter = DDTestMonitor.tracer.eventsExporter {
-                return Log.measure(name: log) {
-                    eventsExporter.tracerSettings(
+        let getTracerConfig = { [self] (log: String) -> TracerSettings? in
+            guard let eventsExporter = DDTestMonitor.tracer.eventsExporter else {
+                return nil
+            }
+            do {
+                return try Log.measure(name: log) {
+                    try eventsExporter.tracerSettings(
                         service: service,
                         env: DDTestMonitor.env.environment,
                         repositoryURL: repository,
@@ -269,7 +273,9 @@ internal class DDTestMonitor {
                         customConfigurations: DDTestMonitor.config.customConfigurations
                     )
                 }
-            } else {
+            } catch {
+                Log.print("\(error)")
+                self.libraryConfigurationErrors.recordCommunicationError(.settings)
                 return nil
             }
         }
@@ -341,7 +347,8 @@ internal class DDTestMonitor {
                                             environment: DDTestMonitor.env.environment,
                                             configurations: DDTestMonitor.env.baseConfigurations,
                                             custom: DDTestMonitor.config.customConfigurations,
-                                            exporter: eventsExporter, cache: cache)
+                                            exporter: eventsExporter, cache: cache,
+                                            libraryConfigurationErrors: self.libraryConfigurationErrors)
             self.knownTests = factory.create(log: Log.instance)
         }
         knownTestsSetup.addDependency(updateTracerConfig)
@@ -402,7 +409,8 @@ internal class DDTestMonitor {
                                                 module: module,
                                                 attemptToFixRetries: attemptToFixRetryCount,
                                                 exporter: eventsExporter,
-                                                cache: cache)
+                                                cache: cache,
+                                                libraryConfigurationErrors: self.libraryConfigurationErrors)
             self.testManagement = factory.create(log: Log.instance)
         }
         testManagementSetup.addDependency(updateTracerConfig)
@@ -447,7 +455,8 @@ internal class DDTestMonitor {
                                                     cache: cache,
                                                     skippingEnabled: remote.itr.testsSkipping,
                                                     swiftTestingEnabled: DDTestMonitor.env.tiaSwiftTestingEnabled,
-                                                    coverage: coverage)
+                                                    coverage: coverage,
+                                                    libraryConfigurationErrors: self.libraryConfigurationErrors)
             self.tia = factory.create(log: Log.instance)
         }
         tiaSetup.addDependency(updateTracerConfig)
@@ -630,7 +639,8 @@ internal class DDTestMonitor {
             AdditionalTags(codeCoverage: tia == nil,
                            bundleFunctions: bundleFunctionInfo,
                            codeOwners: codeOwners,
-                           workspacePath: DDTestMonitor.env.workspacePath)
+                           workspacePath: DDTestMonitor.env.workspacePath),
+            LibraryConfigurationErrorTags(errors: libraryConfigurationErrors)
         ]
         return features.compactMap { $0 }
     }

--- a/Sources/DatadogSDKTesting/KnownTests.swift
+++ b/Sources/DatadogSDKTesting/KnownTests.swift
@@ -68,7 +68,7 @@ extension KnownTests {
 
 struct KnownTestsFactory: FeatureFactory {
     typealias FT = KnownTests
-    
+
     let repository: String
     let service: String
     let environment: String
@@ -76,11 +76,13 @@ struct KnownTestsFactory: FeatureFactory {
     let customConfigurations: [String: String]
     let cacheFolder: Directory
     let exporter: EventsExporterProtocol
+    let libraryConfigurationErrors: LibraryConfigurationErrors
     let cacheFileName = "known_tests.json"
-    
+
     init(repository: String, service: String, environment: String,
          configurations: [String: String], custom: [String: String],
-         exporter: EventsExporterProtocol, cache: Directory
+         exporter: EventsExporterProtocol, cache: Directory,
+         libraryConfigurationErrors: LibraryConfigurationErrors
     ) {
         self.configurations = configurations
         self.customConfigurations = custom
@@ -89,6 +91,7 @@ struct KnownTestsFactory: FeatureFactory {
         self.service = service
         self.environment = environment
         self.exporter = exporter
+        self.libraryConfigurationErrors = libraryConfigurationErrors
     }
     
     static func isEnabled(config: Config, env: Environment, remote: TracerSettings) -> Bool {
@@ -125,15 +128,18 @@ struct KnownTestsFactory: FeatureFactory {
     }
     
     private func getTests(exporter: EventsExporterProtocol, log: Logger) -> KnownTestsMap? {
-        let tests = exporter.knownTests(
-            service: service, env: environment, repositoryURL: repository,
-            configurations: configurations, customConfigurations: customConfigurations
-        )
-        guard let tests = tests else {
-            Log.print("Known Tests: tests request failed")
+        let tests: KnownTestsMap
+        do {
+            tests = try exporter.knownTests(
+                service: service, env: environment, repositoryURL: repository,
+                configurations: configurations, customConfigurations: customConfigurations
+            )
+        } catch {
+            log.print("\(error)")
+            libraryConfigurationErrors.recordCommunicationError(.knownTests)
             return nil
         }
-        Log.debug("Known Tests: tests: \(tests)")
+        log.debug("Known Tests: tests: \(tests)")
         // if we have empty array we should disable Known Tests functionality
         guard tests.count > 0 else { return nil }
         return tests

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/GitUploader.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/GitUploader.swift
@@ -131,8 +131,14 @@ final class GitUploader {
             log.print("sendGitInfo failed, can't get latest commits")
             return nil
         }
-        let existingCommits = log.measure(name: "searchRepositoryCommits") {
-            exporter.searchCommits(repositoryURL: repositoryURL, commits: latestCommits)
+        let existingCommits: [String]
+        do {
+            existingCommits = try log.measure(name: "searchRepositoryCommits") {
+                try exporter.searchCommits(repositoryURL: repositoryURL, commits: latestCommits)
+            }
+        } catch {
+            log.print("\(error)")
+            return nil
         }
         let commits = Set(latestCommits).subtracting(existingCommits)
         if commits.isEmpty { return [] }

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
@@ -208,13 +208,15 @@ struct TestImpactAnalysisFactory: FeatureFactory {
     let skippingEnabled: Bool
     let swiftTestingEnabled: Bool
     let coverageConfig: Coverage?
-    
+    let libraryConfigurationErrors: LibraryConfigurationErrors
+
     init(configurations: [String: String],
          custom: [String: String],
          exporter: EventsExporterProtocol,
          commit: String, repository: String,
          cache: Directory, skippingEnabled: Bool,
-         swiftTestingEnabled: Bool, coverage: Coverage?)
+         swiftTestingEnabled: Bool, coverage: Coverage?,
+         libraryConfigurationErrors: LibraryConfigurationErrors)
     {
         self.configurations = configurations
         self.customConfigurations = custom
@@ -225,6 +227,7 @@ struct TestImpactAnalysisFactory: FeatureFactory {
         self.coverageConfig = coverage
         self.skippingEnabled = skippingEnabled
         self.swiftTestingEnabled = swiftTestingEnabled
+        self.libraryConfigurationErrors = libraryConfigurationErrors
     }
     
     static func isEnabled(config: Config, env: Environment, remote: TracerSettings) -> Bool {
@@ -300,15 +303,18 @@ struct TestImpactAnalysisFactory: FeatureFactory {
     }
     
     private func getTests(exporter: EventsExporterProtocol, log: Logger) -> SkipTests? {
-        let tests = exporter.skippableTests(
-            repositoryURL: repository.spanAttribute, sha: commitSha, testLevel: .test,
-            configurations: configurations, customConfigurations: customConfigurations
-        )
-        guard let tests = tests else {
-            Log.print("TIA: tests request failed")
+        let tests: SkipTests
+        do {
+            tests = try exporter.skippableTests(
+                repositoryURL: repository.spanAttribute, sha: commitSha, testLevel: .test,
+                configurations: configurations, customConfigurations: customConfigurations
+            )
+        } catch {
+            log.print("\(error)")
+            libraryConfigurationErrors.recordCommunicationError(.skippableTests)
             return nil
         }
-        Log.debug("TIA: tests: \(tests)")
+        log.debug("TIA: tests: \(tests)")
         return tests
     }
     

--- a/Sources/DatadogSDKTesting/TestManagement.swift
+++ b/Sources/DatadogSDKTesting/TestManagement.swift
@@ -194,10 +194,12 @@ struct TestManagementFactory: FeatureFactory {
     let cacheFolder: Directory
     let exporter: EventsExporterProtocol
     let module: String
+    let libraryConfigurationErrors: LibraryConfigurationErrors
 
     init(repository: String, commitSha: String, commitMessage: String?, branch: String?,
          module: String, attemptToFixRetries: UInt,
-         exporter: EventsExporterProtocol, cache: Directory
+         exporter: EventsExporterProtocol, cache: Directory,
+         libraryConfigurationErrors: LibraryConfigurationErrors
     ) {
         self.cacheFolder = cache
         self.repository = repository
@@ -207,6 +209,7 @@ struct TestManagementFactory: FeatureFactory {
         self.attemptToFixRetries = attemptToFixRetries
         self.exporter = exporter
         self.module = module
+        self.libraryConfigurationErrors = libraryConfigurationErrors
     }
     
     static func isEnabled(config: Config, env: Environment, remote: TracerSettings) -> Bool {
@@ -244,13 +247,16 @@ struct TestManagementFactory: FeatureFactory {
     }
     
     private func getTests(exporter: EventsExporterProtocol, log: Logger) -> TestManagementTestsInfo? {
-        let tests = exporter.testManagementTests(repositoryURL: repository, sha: commitSha,
-                                                 commitMessage: commitMessage, module: module, branch: branch)
-        guard let tests = tests else {
-            Log.print("Test Management: tests request failed")
+        let tests: TestManagementTestsInfo
+        do {
+            tests = try exporter.testManagementTests(repositoryURL: repository, sha: commitSha,
+                                                     commitMessage: commitMessage, module: module, branch: branch)
+        } catch {
+            log.print("\(error)")
+            libraryConfigurationErrors.recordCommunicationError(.testManagementTests)
             return nil
         }
-        Log.debug("Test Management: tests: \(tests)")
+        log.debug("Test Management: tests: \(tests)")
         // if we have empty array we can disable Test Management functionality
         guard tests.modules.count > 0 else { return nil }
         return tests

--- a/Sources/EventsExporter/EventsExporter.swift
+++ b/Sources/EventsExporter/EventsExporter.swift
@@ -8,28 +8,83 @@ import Foundation
 import OpenTelemetrySdk
 import CodeCoverageParser
 
+/// Thrown by `EventsExporterProtocol` library configuration requests
+/// (`tracerSettings`, `skippableTests`, `knownTests`, `testManagementTests`).
+/// Carries enough context (request name, payload, and the failure reason) for
+/// the caller to log a meaningful diagnostic. `.unauthorized` and
+/// `.communicationFailed` count as communication failures with the backend;
+/// the other reasons surface payload encoding or response decoding issues.
+public struct LibraryConfigurationCommunicationError: Error, CustomStringConvertible {
+    public enum Reason {
+        /// The request payload could not be encoded as JSON.
+        case payloadEncodingFailed
+        /// The backend rejected the request with HTTP 401 or 403, usually
+        /// meaning that DD_API_KEY is missing or incorrect.
+        case unauthorized
+        /// The backend could not be reached: transport error, non-2xx HTTP
+        /// status, or an inconsistent URLSession response. The underlying
+        /// upload error is included.
+        case communicationFailed(any Error)
+        /// The backend responded but the body could not be decoded into the
+        /// expected shape. The raw response body and the decoding error are
+        /// both included.
+        case responseDecodingFailed(body: Data, error: any Error)
+    }
+
+    public let requestName: String
+    public let payload: String
+    public let reason: Reason
+
+    public init(requestName: String, payload: String, reason: Reason) {
+        self.requestName = requestName
+        self.payload = payload
+        self.reason = reason
+    }
+
+    public var description: String {
+        var lines: [String]
+        switch reason {
+        case .payloadEncodingFailed:
+            lines = ["\(requestName): request payload could not be encoded"]
+        case .unauthorized:
+            lines = ["\(requestName): Datadog backend rejected the request as unauthorized. " +
+                     "Please verify that DD_API_KEY is correct."]
+        case .communicationFailed(let error):
+            lines = ["\(requestName): no response from backend: \(error)"]
+        case .responseDecodingFailed(let body, let error):
+            lines = ["\(requestName): invalid response body: \(error)",
+                     "Response: \(String(decoding: body, as: UTF8.self))"]
+        }
+        lines.append("Payload: \(payload)")
+        return lines.joined(separator: "\n")
+    }
+}
+
 public protocol EventsExporterProtocol: SpanExporter {
     var endpointURLs: Set<String> { get }
     var maxObjectSize: UInt64 { get }
-    
+
     func exportEvent<T: Encodable>(event: T)
-    func searchCommits(repositoryURL: String, commits: [String]) -> [String]
+    func searchCommits(
+        repositoryURL: String, commits: [String]
+    ) throws(LibraryConfigurationCommunicationError) -> [String]
     func export(coverage: URL, parser: CoverageParser, workspacePath: String?,
                 testSessionId: UInt64, testSuiteId: UInt64, spanId: UInt64)
     func uploadPackFiles(packFilesDirectory: Directory, commit: String, repository: String) throws
     func skippableTests(repositoryURL: String, sha: String, testLevel: ITRTestLevel,
-                        configurations: [String: String], customConfigurations: [String: String]) -> SkipTests?
+                        configurations: [String: String], customConfigurations: [String: String]
+    ) throws(LibraryConfigurationCommunicationError) -> SkipTests
     func tracerSettings(
         service: String, env: String, repositoryURL: String, branch: String, sha: String,
         testLevel: ITRTestLevel, configurations: [String: String], customConfigurations: [String: String]
-    ) -> TracerSettings?
+    ) throws(LibraryConfigurationCommunicationError) -> TracerSettings
     func knownTests(
         service: String, env: String, repositoryURL: String,
         configurations: [String: String], customConfigurations: [String: String]
-    ) -> KnownTestsMap?
+    ) throws(LibraryConfigurationCommunicationError) -> KnownTestsMap
     func testManagementTests(
         repositoryURL: String, sha: String?, commitMessage: String?, module: String?, branch: String?
-    ) -> TestManagementTestsInfo?
+    ) throws(LibraryConfigurationCommunicationError) -> TestManagementTestsInfo
 }
 
 public final class EventsExporter: EventsExporterProtocol {
@@ -41,7 +96,7 @@ public final class EventsExporter: EventsExporterProtocol {
     var settingsService: SettingsService
     var knownTestsService: KnownTestsService
     var testManagementService: TestManagementService
-    
+
     public var maxObjectSize: UInt64 { configuration.performancePreset.maxObjectSize }
 
     public init(config: ExporterConfiguration) throws {
@@ -98,8 +153,10 @@ public final class EventsExporter: EventsExporterProtocol {
                                         testSessionId: testSessionId, testSuiteId: testSuiteId, spanId: spanId)
     }
 
-    public func searchCommits(repositoryURL: String, commits: [String]) -> [String] {
-        return itrService.searchExistingCommits(repositoryURL: repositoryURL, commits: commits)
+    public func searchCommits(
+        repositoryURL: String, commits: [String]
+    ) throws(LibraryConfigurationCommunicationError) -> [String] {
+        try itrService.searchExistingCommits(repositoryURL: repositoryURL, commits: commits)
     }
 
     public func uploadPackFiles(packFilesDirectory: Directory, commit: String, repository: String) throws {
@@ -108,33 +165,33 @@ public final class EventsExporter: EventsExporterProtocol {
 
     public func skippableTests(
         repositoryURL: String, sha: String, testLevel: ITRTestLevel,
-        configurations: [String: String], customConfigurations: [String: String]) -> SkipTests?
-    {
-        itrService.skippableTests(repositoryURL: repositoryURL, sha: sha,
-                                  testLevel: testLevel,
-                                  configurations: configurations,
-                                  customConfigurations: customConfigurations)
+        configurations: [String: String], customConfigurations: [String: String]
+    ) throws(LibraryConfigurationCommunicationError) -> SkipTests {
+        try itrService.skippableTests(repositoryURL: repositoryURL, sha: sha,
+                                      testLevel: testLevel,
+                                      configurations: configurations,
+                                      customConfigurations: customConfigurations)
     }
 
     public func tracerSettings(
         service: String, env: String, repositoryURL: String, branch: String, sha: String,
         testLevel: ITRTestLevel, configurations: [String: String], customConfigurations: [String: String]
-    ) -> TracerSettings? {
-        settingsService.settings(
+    ) throws(LibraryConfigurationCommunicationError) -> TracerSettings {
+        try settingsService.settings(
             service: service, env: env, repositoryURL: repositoryURL,
             branch: branch, sha: sha, testLevel: testLevel, configurations: configurations,
             customConfigurations: customConfigurations
         )
     }
-    
+
     /// Returns all known tests by fetching every page and merging results.
     public func knownTests(
         service: String, env: String, repositoryURL: String,
         configurations: [String: String], customConfigurations: [String: String]
-    ) -> KnownTestsMap? {
-        knownTestsService.tests(service: service, env: env, repositoryURL: repositoryURL,
-                                configurations: configurations,
-                                customConfigurations: customConfigurations)?.tests
+    ) throws(LibraryConfigurationCommunicationError) -> KnownTestsMap {
+        try knownTestsService.tests(service: service, env: env, repositoryURL: repositoryURL,
+                                    configurations: configurations,
+                                    customConfigurations: customConfigurations).tests
     }
 
     /// Returns a single page of known tests with pagination info when provided.
@@ -142,16 +199,16 @@ public final class EventsExporter: EventsExporterProtocol {
         service: String, env: String, repositoryURL: String,
         configurations: [String: String], customConfigurations: [String: String],
         page: KnownTestsPageInfo
-    ) -> KnownTestsResult? {
-        knownTestsService.tests(service: service, env: env, repositoryURL: repositoryURL,
-                                configurations: configurations, customConfigurations: customConfigurations,
-                                pageInfo: page)
+    ) throws(LibraryConfigurationCommunicationError) -> KnownTestsResult {
+        try knownTestsService.tests(service: service, env: env, repositoryURL: repositoryURL,
+                                    configurations: configurations, customConfigurations: customConfigurations,
+                                    pageInfo: page)
     }
-    
+
     public func testManagementTests(
         repositoryURL: String, sha: String? = nil, commitMessage: String? = nil, module: String? = nil, branch: String? = nil
-    ) -> TestManagementTestsInfo? {
-        testManagementService.tests(repositoryURL: repositoryURL, sha: sha, commitMessage: commitMessage, module: module, branch: branch)
+    ) throws(LibraryConfigurationCommunicationError) -> TestManagementTestsInfo {
+        try testManagementService.tests(repositoryURL: repositoryURL, sha: sha, commitMessage: commitMessage, module: module, branch: branch)
     }
 
     public func shutdown(explicitTimeout: TimeInterval?) {

--- a/Sources/EventsExporter/IntelligentTestRunner/ITRService.swift
+++ b/Sources/EventsExporter/IntelligentTestRunner/ITRService.swift
@@ -84,19 +84,44 @@ internal class ITRService {
         )
     }
 
-    func searchExistingCommits(repositoryURL: String, commits: [String]) -> [String] {
+    func searchExistingCommits(
+        repositoryURL: String, commits: [String]
+    ) throws(LibraryConfigurationCommunicationError) -> [String] {
         let commitPayload = CommitRequesFormat(repositoryURL: repositoryURL, commits: commits)
-        guard let jsonData = commitPayload.jsonData,
-              let response = searchCommitUploader.uploadWithResponse(data: jsonData),
-              let commitResponse = try? JSONDecoder().decode(CommitResponseFormat.self, from: response)
-        else {
-            Log.debug("CommitRequestFormat payload: \(commitPayload.jsonString)")
-            Log.debug("searchCommits invalid response")
-            return []
+        let payloadString = commitPayload.jsonString
+
+        guard let jsonData = commitPayload.jsonData else {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SearchCommitsRequest",
+                payload: payloadString,
+                reason: .payloadEncodingFailed
+            )
         }
 
-        let commits = commitResponse.data.map { $0.id }
-        return commits
+        let response: Data
+        switch searchCommitUploader.uploadWithResult(data: jsonData) {
+        case .success(let data):
+            response = data
+        case .failure(let error):
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SearchCommitsRequest",
+                payload: payloadString,
+                reason: error.isUnauthorized ? .unauthorized : .communicationFailed(error)
+            )
+        }
+
+        let commitResponse: CommitResponseFormat
+        do {
+            commitResponse = try JSONDecoder().decode(CommitResponseFormat.self, from: response)
+        } catch {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SearchCommitsRequest",
+                payload: payloadString,
+                reason: .responseDecodingFailed(body: response, error: error)
+            )
+        }
+
+        return commitResponse.data.map { $0.id }
     }
 
     func uploadPackFiles(packFilesDirectory: Directory, commit: String, repository: String) throws {
@@ -113,7 +138,8 @@ internal class ITRService {
     }
 
     func skippableTests(repositoryURL: String, sha: String, testLevel: ITRTestLevel,
-                        configurations: [String: String], customConfigurations: [String: String]) -> SkipTests? {
+                        configurations: [String: String], customConfigurations: [String: String]
+    ) throws(LibraryConfigurationCommunicationError) -> SkipTests {
         var itrConfig: [String: JSONGeneric] = configurations.mapValues { .string($0) }
         itrConfig["custom"] = .init(customConfigurations)
 
@@ -123,18 +149,37 @@ internal class ITRService {
                                                       sha: sha,
                                                       testLevel: testLevel,
                                                       configurations: itrConfig)
+        let payloadString = skippablePayload.jsonString
 
-        Log.debug("SkipTestsRequestFormat payload: \(skippablePayload.jsonString)")
-        guard let jsonData = skippablePayload.jsonData,
-              let response = skippableTestsUploader.uploadWithResponse(data: jsonData)
-        else {
-            Log.debug("skippableTests no response")
-            return nil
+        guard let jsonData = skippablePayload.jsonData else {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SkipTestsRequest",
+                payload: payloadString,
+                reason: .payloadEncodingFailed
+            )
         }
 
-        guard let skipTests = try? JSONDecoder().decode(SkipTestsResponseFormat.self, from: response) else {
-            Log.debug("skippableTests invalid response: \(String(decoding: response, as: UTF8.self))")
-            return nil
+        let response: Data
+        switch skippableTestsUploader.uploadWithResult(data: jsonData) {
+        case .success(let data):
+            response = data
+        case .failure(let error):
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SkipTestsRequest",
+                payload: payloadString,
+                reason: error.isUnauthorized ? .unauthorized : .communicationFailed(error)
+            )
+        }
+
+        let skipTests: SkipTestsResponseFormat
+        do {
+            skipTests = try JSONDecoder().decode(SkipTestsResponseFormat.self, from: response)
+        } catch {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SkipTestsRequest",
+                payload: payloadString,
+                reason: .responseDecodingFailed(body: response, error: error)
+            )
         }
 
         let tests = skipTests.data.map { skipTest in

--- a/Sources/EventsExporter/KnownTestsService.swift
+++ b/Sources/EventsExporter/KnownTestsService.swift
@@ -46,10 +46,10 @@ public struct KnownTestsPageInfo {
 internal final class KnownTestsService {
     let exporterConfiguration: ExporterConfiguration
     let testsUploader: DataUploader
-    
+
     init(config: ExporterConfiguration) throws {
         self.exporterConfiguration = config
-        
+
         let testsRequestBuilder = SingleRequestBuilder(
             url: exporterConfiguration.endpoint.knownTestsURL,
             queryItems: [],
@@ -79,22 +79,20 @@ internal final class KnownTestsService {
         service: String, env: String, repositoryURL: String,
         configurations: [String: String], customConfigurations: [String: String],
         pageInfo: KnownTestsPageInfo? = nil
-    ) -> KnownTestsResult? {
+    ) throws(LibraryConfigurationCommunicationError) -> KnownTestsResult {
         var configurations: [String: JSONGeneric] = configurations.mapValues { .string($0) }
         configurations["custom"] = .init(customConfigurations)
-        
+
         let onePageOnly: Bool = (pageInfo != nil)
         var tests: KnownTestsMap = [:]
         var pageInfo: KnownTestsPageInfo = pageInfo ?? .init()
         var size: Int = 0
         repeat {
-            guard let result = fetchPage(
+            let result = try fetchPage(
                 service: service, env: env, repositoryURL: repositoryURL,
                 configurations: configurations,
                 pageInfo: pageInfo.requestParameters
-            ) else {
-                return nil
-            }
+            )
             tests = tests.merging(result.tests) { (current, new) in
                 current.merging(new) { (current, new) in
                     Array(Set(current).union(new))
@@ -116,24 +114,43 @@ internal final class KnownTestsService {
         service: String, env: String, repositoryURL: String,
         configurations: [String: JSONGeneric],
         pageInfo: PageInfoRequest
-    ) -> KnownTestsResult? {
+    ) throws(LibraryConfigurationCommunicationError) -> KnownTestsResult {
         let testsPayload = TestsRequest(
             service: service, env: env, repositoryURL: repositoryURL,
             configurations: configurations,
             pageInfo: pageInfo
         )
+        let payloadString = testsPayload.jsonString
 
-        guard let jsonData = testsPayload.jsonData,
-              let response = testsUploader.uploadWithResponse(data: jsonData)
-        else {
-            Log.debug("Known Tests Request payload: \(testsPayload.jsonString)")
-            Log.debug("Known Tests Request no response")
-            return nil
+        guard let jsonData = testsPayload.jsonData else {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "Known Tests Request",
+                payload: payloadString,
+                reason: .payloadEncodingFailed
+            )
         }
 
-        guard let known = try? JSONDecoder().decode(TestsResponse.self, from: response) else {
-            Log.debug("Known Tests Request invalid response: \(String(decoding: response, as: UTF8.self))")
-            return nil
+        let response: Data
+        switch testsUploader.uploadWithResult(data: jsonData) {
+        case .success(let data):
+            response = data
+        case .failure(let error):
+            throw LibraryConfigurationCommunicationError(
+                requestName: "Known Tests Request",
+                payload: payloadString,
+                reason: error.isUnauthorized ? .unauthorized : .communicationFailed(error)
+            )
+        }
+
+        let known: TestsResponse
+        do {
+            known = try JSONDecoder().decode(TestsResponse.self, from: response)
+        } catch {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "Known Tests Request",
+                payload: payloadString,
+                reason: .responseDecodingFailed(body: response, error: error)
+            )
         }
         Log.debug("Known Tests Request response: \(String(decoding: response, as: UTF8.self))")
 

--- a/Sources/EventsExporter/SettingsService.swift
+++ b/Sources/EventsExporter/SettingsService.swift
@@ -119,10 +119,10 @@ public struct TracerSettings {
 internal class SettingsService {
     let exporterConfiguration: ExporterConfiguration
     let settingsUploader: DataUploader
-    
+
     init(config: ExporterConfiguration) throws {
         self.exporterConfiguration = config
-        
+
         let settingsRequestBuilder = SingleRequestBuilder(
             url: exporterConfiguration.endpoint.settingsURL,
             queryItems: [],
@@ -149,26 +149,44 @@ internal class SettingsService {
     func settings(
         service: String, env: String, repositoryURL: String, branch: String, sha: String,
         testLevel: ITRTestLevel, configurations: [String: String], customConfigurations: [String: String]
-    ) -> TracerSettings? {
+    ) throws(LibraryConfigurationCommunicationError) -> TracerSettings {
         var configurations: [String: JSONGeneric] = configurations.mapValues { .string($0) }
         configurations["custom"] = .init(customConfigurations)
-        
+
         let settingsPayload = SettingsRequest(service: service, env: env, repositoryURL: repositoryURL,
                                               branch: branch, sha: sha, configurations: configurations,
                                               testLevel: testLevel)
+        let payloadString = settingsPayload.jsonString
 
-        guard let jsonData = settingsPayload.jsonData,
-              let response = settingsUploader.uploadWithResponse(data: jsonData)
-        else {
-            Log.debug("SettingsRequest payload: \(settingsPayload.jsonString)")
-            Log.debug("SettingsRequest no response")
-            return nil
+        guard let jsonData = settingsPayload.jsonData else {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SettingsRequest",
+                payload: payloadString,
+                reason: .payloadEncodingFailed
+            )
         }
 
-        guard let settings = try? JSONDecoder().decode(SettingsResponse.self, from: response) else {
-            Log.debug("SettingsRequest payload: \(settingsPayload.jsonString)")
-            Log.debug("SettingsRequest invalid response: \(String(decoding: response, as: UTF8.self))")
-            return nil
+        let response: Data
+        switch settingsUploader.uploadWithResult(data: jsonData) {
+        case .success(let data):
+            response = data
+        case .failure(let error):
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SettingsRequest",
+                payload: payloadString,
+                reason: error.isUnauthorized ? .unauthorized : .communicationFailed(error)
+            )
+        }
+
+        let settings: SettingsResponse
+        do {
+            settings = try JSONDecoder().decode(SettingsResponse.self, from: response)
+        } catch {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "SettingsRequest",
+                payload: payloadString,
+                reason: .responseDecodingFailed(body: response, error: error)
+            )
         }
         Log.debug("SettingsRequest response: \(String(decoding: response, as: UTF8.self))")
 

--- a/Sources/EventsExporter/TestManagementService.swift
+++ b/Sources/EventsExporter/TestManagementService.swift
@@ -9,10 +9,10 @@ import Foundation
 internal final class TestManagementService {
     let exporterConfiguration: ExporterConfiguration
     let testsUploader: DataUploader
-    
+
     init(config: ExporterConfiguration) throws {
         self.exporterConfiguration = config
-        
+
         let testsRequestBuilder = SingleRequestBuilder(
             url: exporterConfiguration.endpoint.testManagementTestsURL,
             queryItems: [],
@@ -38,20 +38,39 @@ internal final class TestManagementService {
     
     func tests(
         repositoryURL: String, sha: String? = nil, commitMessage: String? = nil, module: String? = nil, branch: String? = nil
-    ) -> TestManagementTestsInfo? {
+    ) throws(LibraryConfigurationCommunicationError) -> TestManagementTestsInfo {
         let testsPayload = TestsRequest(repositoryURL: repositoryURL, sha: sha, commitMessage: commitMessage, module: module, branch: branch)
+        let payloadString = testsPayload.jsonString
 
-        guard let jsonData = testsPayload.jsonData,
-              let response = testsUploader.uploadWithResponse(data: jsonData)
-        else {
-            Log.debug("Test Management Tests Request payload: \(testsPayload.jsonString)")
-            Log.debug("Test Management Tests Request no response")
-            return nil
+        guard let jsonData = testsPayload.jsonData else {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "Test Management Tests Request",
+                payload: payloadString,
+                reason: .payloadEncodingFailed
+            )
         }
 
-        guard let settings = try? JSONDecoder().decode(TestsResponse.self, from: response) else {
-            Log.debug("Test Management Tests Request invalid response: \(String(decoding: response, as: UTF8.self))")
-            return nil
+        let response: Data
+        switch testsUploader.uploadWithResult(data: jsonData) {
+        case .success(let data):
+            response = data
+        case .failure(let error):
+            throw LibraryConfigurationCommunicationError(
+                requestName: "Test Management Tests Request",
+                payload: payloadString,
+                reason: error.isUnauthorized ? .unauthorized : .communicationFailed(error)
+            )
+        }
+
+        let settings: TestsResponse
+        do {
+            settings = try JSONDecoder().decode(TestsResponse.self, from: response)
+        } catch {
+            throw LibraryConfigurationCommunicationError(
+                requestName: "Test Management Tests Request",
+                payload: payloadString,
+                reason: .responseDecodingFailed(body: response, error: error)
+            )
         }
         Log.debug("Test Management Tests Request response: \(String(decoding: response, as: UTF8.self))")
 

--- a/Sources/EventsExporter/Upload/DataUploader.swift
+++ b/Sources/EventsExporter/Upload/DataUploader.swift
@@ -38,9 +38,6 @@ internal final class DataUploader: DataUploaderType {
                 uploadStatus = DataUploadStatus(httpResponse: httpResponse)
             case .failure(let error):
                 uploadStatus = DataUploadStatus(networkError: error)
-                if error.isUnauthorized {
-                    Log.print("Datadog backend rejected the request as unathorized. Please verify that DD_API_KEY is correct.")
-                }
             }
 
             semaphore.signal()
@@ -54,28 +51,26 @@ internal final class DataUploader: DataUploaderType {
     /// Uploads data synchronously (will block current thread) and returns the response data
     /// Uses timeout configured for `HTTPClient`.
     func uploadWithResponse(data: Data) -> Data? {
+        try? uploadWithResult(data: data).get()
+    }
+
+    /// Uploads data synchronously and returns the response data on success
+    /// or the underlying transport/HTTP error so callers can distinguish a
+    /// communication failure from an empty/invalid response.
+    func uploadWithResult(data: Data) -> Result<Data, HTTPClient.RequestError> {
         let request = createRequest(with: data)
-        var returnData: Data?
+        var result: Result<Data, HTTPClient.RequestError>?
 
         let semaphore = DispatchSemaphore(value: 0)
 
-        httpClient.sendWithResult(request: request) { result in
-            switch result {
-            case .success(let data):
-                returnData = data
-            case .failure(let error):
-                if error.isUnauthorized {
-                    Log.print("Datadog backend rejected the request as unathorized. Please verify that DD_API_KEY is correct.")
-                }
-                returnData = nil
-            }
-
+        httpClient.sendWithResult(request: request) { httpResult in
+            result = httpResult
             semaphore.signal()
         }
 
         _ = semaphore.wait(timeout: .distantFuture)
 
-        return returnData
+        return result ?? .failure(.inconsistentSession)
     }
 
     private func createRequest(with data: Data) -> URLRequest {

--- a/Sources/EventsExporter/Upload/HTTPClient.swift
+++ b/Sources/EventsExporter/Upload/HTTPClient.swift
@@ -11,18 +11,32 @@ internal final class HTTPClient {
     private let session: URLSession
     private let debug: Bool
     
-    enum RequestError: Error {
+    enum RequestError: Error, CustomStringConvertible {
         case http(code: Int, body: Data?)
         case transport(any Error)
         /// An error returned if `URLSession` response state is inconsistent (like no data, no response and no error).
         /// The code execution in `URLSessionTransport` should never reach its initialization.
         case inconsistentSession
-        
+
         var isUnauthorized: Bool {
             switch self {
             case .http(code: 401, body: _), .http(code: 403, body: _):
                 return true
             default: return false
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .http(let code, let body):
+                if let body, !body.isEmpty {
+                    return "HTTP \(code): \(String(decoding: body, as: UTF8.self))"
+                }
+                return "HTTP \(code)"
+            case .transport(let error):
+                return "transport error: \(error.localizedDescription)"
+            case .inconsistentSession:
+                return "inconsistent URLSession response"
             }
         }
     }

--- a/Tests/DatadogSDKTesting/Features/LibraryConfigurationErrorTagsTests.swift
+++ b/Tests/DatadogSDKTesting/Features/LibraryConfigurationErrorTagsTests.swift
@@ -1,0 +1,127 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSDKTesting
+
+// MARK: - Tracker
+
+final class LibraryConfigurationErrorsTrackerTests: XCTestCase {
+    func testFlagsAreFalseByDefault() {
+        let tracker = LibraryConfigurationErrors()
+        for kind in LibraryConfigurationErrors.Kind.allCases {
+            XCTAssertFalse(tracker[kind], "expected \(kind) to be false by default")
+        }
+    }
+
+    func testRecordCommunicationErrorIsSticky() {
+        let tracker = LibraryConfigurationErrors()
+        tracker.recordCommunicationError(.settings)
+        XCTAssertTrue(tracker[.settings])
+
+        // Recording again keeps it true (no toggle).
+        tracker.recordCommunicationError(.settings)
+        XCTAssertTrue(tracker[.settings])
+    }
+
+    func testKindsAreIndependent() {
+        let tracker = LibraryConfigurationErrors()
+        tracker.recordCommunicationError(.knownTests)
+        tracker.recordCommunicationError(.testManagementTests)
+
+        XCTAssertTrue(tracker[.knownTests])
+        XCTAssertTrue(tracker[.testManagementTests])
+        XCTAssertFalse(tracker[.settings])
+        XCTAssertFalse(tracker[.skippableTests])
+        XCTAssertFalse(tracker[.flakyTests])
+    }
+}
+
+// MARK: - Feature
+
+final class LibraryConfigurationErrorTagsFeatureTests: XCTestCase {
+    private let module = "MyModule"
+    private let suite = "MySuite"
+    private let test = "testThing"
+
+    func testAppliesNoTagsWhenNoErrorRecorded() async {
+        let session = await runSession(with: LibraryConfigurationErrors())
+
+        for tag in allErrorTags() {
+            XCTAssertNil(session.tags[tag], "session should not carry \(tag)")
+            XCTAssertNil(session[module]?.tags[tag], "module should not carry \(tag)")
+            XCTAssertNil(session[module]?[suite]?.tags[tag], "suite should not carry \(tag)")
+            XCTAssertNil(session[module]?[suite]?[test]?[0]?.tags[tag],
+                         "test should not carry \(tag)")
+        }
+    }
+
+    func testRecordedKindIsTaggedOnEveryEvent() async {
+        let cases: [(LibraryConfigurationErrors.Kind, String)] = [
+            (.settings, DDLibraryConfigurationErrorTags.settings),
+            (.skippableTests, DDLibraryConfigurationErrorTags.skippableTests),
+            (.flakyTests, DDLibraryConfigurationErrorTags.flakyTests),
+            (.knownTests, DDLibraryConfigurationErrorTags.knownTests),
+            (.testManagementTests, DDLibraryConfigurationErrorTags.testManagementTests)
+        ]
+
+        for (kind, tag) in cases {
+            let tracker = LibraryConfigurationErrors()
+            tracker.recordCommunicationError(kind)
+            let session = await runSession(with: tracker)
+
+            XCTAssertEqual(session.tags[tag], "true", "session missing \(tag) for \(kind)")
+            XCTAssertEqual(session[module]?.tags[tag], "true",
+                           "module missing \(tag) for \(kind)")
+            XCTAssertEqual(session[module]?[suite]?.tags[tag], "true",
+                           "suite missing \(tag) for \(kind)")
+            XCTAssertEqual(session[module]?[suite]?[test]?[0]?.tags[tag], "true",
+                           "test missing \(tag) for \(kind)")
+
+            // Other kinds' tags must not leak in.
+            for otherTag in allErrorTags() where otherTag != tag {
+                XCTAssertNil(session.tags[otherTag],
+                             "session should not carry \(otherTag) when only \(kind) is recorded")
+                XCTAssertNil(session[module]?[suite]?[test]?[0]?.tags[otherTag],
+                             "test should not carry \(otherTag) when only \(kind) is recorded")
+            }
+        }
+    }
+
+    func testMultipleRecordedKindsProduceMultipleTags() async {
+        let tracker = LibraryConfigurationErrors()
+        tracker.recordCommunicationError(.settings)
+        tracker.recordCommunicationError(.knownTests)
+
+        let session = await runSession(with: tracker)
+
+        XCTAssertEqual(session.tags[DDLibraryConfigurationErrorTags.settings], "true")
+        XCTAssertEqual(session.tags[DDLibraryConfigurationErrorTags.knownTests], "true")
+        XCTAssertNil(session.tags[DDLibraryConfigurationErrorTags.skippableTests])
+        XCTAssertNil(session.tags[DDLibraryConfigurationErrorTags.flakyTests])
+        XCTAssertNil(session.tags[DDLibraryConfigurationErrorTags.testManagementTests])
+    }
+
+    // MARK: helpers
+
+    private func runSession(with tracker: LibraryConfigurationErrors) async -> Mocks.Session {
+        let feature: TestHooksFeature = LibraryConfigurationErrorTags(errors: tracker)
+        let testsToRun: Mocks.Runner.Tests = [module: [
+            suite: [test: .pass()]
+        ]]
+        return await Mocks.Runner(features: [feature], tests: testsToRun).run()
+    }
+
+    private func allErrorTags() -> [String] {
+        [
+            DDLibraryConfigurationErrorTags.settings,
+            DDLibraryConfigurationErrorTags.skippableTests,
+            DDLibraryConfigurationErrorTags.flakyTests,
+            DDLibraryConfigurationErrorTags.knownTests,
+            DDLibraryConfigurationErrorTags.testManagementTests
+        ]
+    }
+}

--- a/Tests/EventsExporter/LibraryConfigurationErrorsTests.swift
+++ b/Tests/EventsExporter/LibraryConfigurationErrorsTests.swift
@@ -1,0 +1,316 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+@testable import EventsExporter
+import XCTest
+import TestUtils
+
+private struct DummyError: Error, CustomStringConvertible {
+    let message: String
+    var description: String { message }
+}
+
+// MARK: - LibraryConfigurationCommunicationError.description
+
+final class LibraryConfigurationCommunicationErrorTests: XCTestCase {
+    func testDescription_unauthorized_mentionsApiKey() {
+        let error = makeError(reason: .unauthorized)
+        let text = error.description
+
+        XCTAssertTrue(text.contains("Req"), "description should include the request name")
+        XCTAssertTrue(text.contains("DD_API_KEY"),
+                      "unauthorized description should ask the user to verify DD_API_KEY")
+        XCTAssertTrue(text.contains("Payload: {\"k\":1}"),
+                      "description should include the payload")
+    }
+
+    func testDescription_communicationFailed_includesUnderlyingError() {
+        let underlying = DummyError(message: "transport boom")
+        let error = makeError(reason: .communicationFailed(underlying))
+
+        let text = error.description
+        XCTAssertTrue(text.contains("no response from backend"))
+        XCTAssertTrue(text.contains("transport boom"))
+        XCTAssertTrue(text.contains("Payload: {\"k\":1}"))
+    }
+
+    func testDescription_responseDecodingFailed_includesBodyAndUnderlyingError() {
+        let underlying = DummyError(message: "decode boom")
+        let body = Data("<html>nope</html>".utf8)
+        let error = makeError(reason: .responseDecodingFailed(body: body, error: underlying))
+
+        let text = error.description
+        XCTAssertTrue(text.contains("invalid response body"))
+        XCTAssertTrue(text.contains("decode boom"))
+        XCTAssertTrue(text.contains("Response: <html>nope</html>"))
+        XCTAssertTrue(text.contains("Payload: {\"k\":1}"))
+    }
+
+    func testDescription_payloadEncodingFailed_includesPayload() {
+        let error = makeError(reason: .payloadEncodingFailed)
+        let text = error.description
+        XCTAssertTrue(text.contains("payload could not be encoded"))
+        XCTAssertTrue(text.contains("Payload: {\"k\":1}"))
+    }
+
+    private func makeError(reason: LibraryConfigurationCommunicationError.Reason)
+        -> LibraryConfigurationCommunicationError
+    {
+        LibraryConfigurationCommunicationError(requestName: "Req", payload: "{\"k\":1}", reason: reason)
+    }
+}
+
+// MARK: - HTTPClient.RequestError.description
+
+final class HTTPClientRequestErrorDescriptionTests: XCTestCase {
+    func testHTTPWithBody() {
+        let body = Data("server says no".utf8)
+        let error: HTTPClient.RequestError = .http(code: 500, body: body)
+        XCTAssertEqual("\(error)", "HTTP 500: server says no")
+    }
+
+    func testHTTPWithoutBody() {
+        XCTAssertEqual("\(HTTPClient.RequestError.http(code: 401, body: nil))", "HTTP 401")
+        XCTAssertEqual("\(HTTPClient.RequestError.http(code: 403, body: Data()))", "HTTP 403")
+    }
+
+    func testTransportWrapsLocalizedDescription() {
+        let underlying = NSError(domain: "DDTest", code: -1,
+                                 userInfo: [NSLocalizedDescriptionKey: "no internet"])
+        XCTAssertEqual("\(HTTPClient.RequestError.transport(underlying))",
+                       "transport error: no internet")
+    }
+
+    func testInconsistentSession() {
+        XCTAssertEqual("\(HTTPClient.RequestError.inconsistentSession)",
+                       "inconsistent URLSession response")
+    }
+}
+
+// MARK: - Service throw paths
+
+final class LibraryConfigurationServiceThrowTests: XCTestCase {
+    private var server: HttpTestServer!
+
+    override func tearDown() {
+        server?.stop()
+        server = nil
+        super.tearDown()
+    }
+
+    // MARK: - SettingsService
+
+    func testSettingsService_throwsUnauthorizedOn401() throws {
+        let baseURL = try startServer(replyingWith: status(401, reason: "Unauthorized"))
+        let service = try SettingsService(config: makeConfig(baseURL: baseURL))
+
+        let error = expectError {
+            _ = try service.settings(service: "service", env: "env",
+                                     repositoryURL: "repo", branch: "main", sha: "abc",
+                                     testLevel: ITRTestLevel.test,
+                                     configurations: [:], customConfigurations: [:])
+        }
+        XCTAssertEqual(error?.requestName, "SettingsRequest")
+        if case .unauthorized = error?.reason {} else {
+            XCTFail("Expected .unauthorized, got \(error?.reason as Any)")
+        }
+    }
+
+    func testSettingsService_throwsCommunicationFailedOn500() throws {
+        let baseURL = try startServer(replyingWith: status(500, reason: "Internal Server Error"))
+        let service = try SettingsService(config: makeConfig(baseURL: baseURL))
+
+        let error = expectError {
+            _ = try service.settings(service: "service", env: "env",
+                                     repositoryURL: "repo", branch: "main", sha: "abc",
+                                     testLevel: ITRTestLevel.test,
+                                     configurations: [:], customConfigurations: [:])
+        }
+        XCTAssertEqual(error?.requestName, "SettingsRequest")
+        guard case .communicationFailed(let underlying)? = error?.reason else {
+            XCTFail("Expected .communicationFailed, got \(error?.reason as Any)")
+            return
+        }
+        XCTAssertTrue("\(underlying)".contains("HTTP 500"),
+                      "communicationFailed should carry the underlying HTTP error")
+    }
+
+    func testSettingsService_throwsResponseDecodingFailedOnGarbageBody() throws {
+        let body = Data("<not-json>".utf8)
+        let baseURL = try startServer(replyingWith: status(200, reason: "OK"), body: body)
+        let service = try SettingsService(config: makeConfig(baseURL: baseURL))
+
+        let error = expectError {
+            _ = try service.settings(service: "service", env: "env",
+                                     repositoryURL: "repo", branch: "main", sha: "abc",
+                                     testLevel: ITRTestLevel.test,
+                                     configurations: [:], customConfigurations: [:])
+        }
+        XCTAssertEqual(error?.requestName, "SettingsRequest")
+        guard case .responseDecodingFailed(let receivedBody, _)? = error?.reason else {
+            XCTFail("Expected .responseDecodingFailed, got \(error?.reason as Any)")
+            return
+        }
+        XCTAssertEqual(receivedBody, body)
+    }
+
+    func testSettingsService_succeedsOnValidResponse() throws {
+        let baseURL = try startServer(replyingWith: status(200, reason: "OK"),
+                                      body: validSettingsBody())
+        let service = try SettingsService(config: makeConfig(baseURL: baseURL))
+
+        let settings = try service.settings(service: "service", env: "env",
+                                            repositoryURL: "repo", branch: "main", sha: "abc",
+                                            testLevel: ITRTestLevel.test,
+                                            configurations: [:], customConfigurations: [:])
+        XCTAssertTrue(settings.flakyTestRetriesEnabled)
+        XCTAssertTrue(settings.knownTestsEnabled)
+        XCTAssertTrue(settings.itr.itrEnabled)
+    }
+
+    // MARK: - Other services (one throw scenario each)
+
+    func testSkippableTestsService_throwsUnauthorizedOn403() throws {
+        let baseURL = try startServer(replyingWith: status(403, reason: "Forbidden"))
+        let service = try ITRService(config: makeConfig(baseURL: baseURL))
+
+        let error = expectError {
+            _ = try service.skippableTests(repositoryURL: "repo", sha: "abc",
+                                           testLevel: ITRTestLevel.test,
+                                           configurations: [:], customConfigurations: [:])
+        }
+        XCTAssertEqual(error?.requestName, "SkipTestsRequest")
+        if case .unauthorized = error?.reason {} else {
+            XCTFail("Expected .unauthorized, got \(error?.reason as Any)")
+        }
+    }
+
+    func testKnownTestsService_throwsCommunicationFailedOn500() throws {
+        let baseURL = try startServer(replyingWith: status(500, reason: "Internal Server Error"))
+        let service = try KnownTestsService(config: makeConfig(baseURL: baseURL))
+
+        let error = expectError {
+            _ = try service.tests(service: "service", env: "env", repositoryURL: "repo",
+                                  configurations: [:], customConfigurations: [:])
+        }
+        XCTAssertEqual(error?.requestName, "Known Tests Request")
+        if case .communicationFailed = error?.reason {} else {
+            XCTFail("Expected .communicationFailed, got \(error?.reason as Any)")
+        }
+    }
+
+    func testTestManagementService_throwsResponseDecodingFailedOnBadBody() throws {
+        let body = Data("not-json".utf8)
+        let baseURL = try startServer(replyingWith: status(200, reason: "OK"), body: body)
+        let service = try TestManagementService(config: makeConfig(baseURL: baseURL))
+
+        let error = expectError {
+            _ = try service.tests(repositoryURL: "repo",
+                                  sha: String?.none,
+                                  commitMessage: String?.none,
+                                  module: String?.none,
+                                  branch: String?.none)
+        }
+        XCTAssertEqual(error?.requestName, "Test Management Tests Request")
+        guard case .responseDecodingFailed(let receivedBody, _)? = error?.reason else {
+            XCTFail("Expected .responseDecodingFailed, got \(error?.reason as Any)")
+            return
+        }
+        XCTAssertEqual(receivedBody, body)
+    }
+
+    func testSearchExistingCommits_throwsUnauthorizedOn401() throws {
+        let baseURL = try startServer(replyingWith: status(401, reason: "Unauthorized"))
+        let service = try ITRService(config: makeConfig(baseURL: baseURL))
+
+        let error = expectError {
+            _ = try service.searchExistingCommits(repositoryURL: "repo", commits: ["abc"])
+        }
+        XCTAssertEqual(error?.requestName, "SearchCommitsRequest")
+        if case .unauthorized = error?.reason {} else {
+            XCTFail("Expected .unauthorized, got \(error?.reason as Any)")
+        }
+    }
+
+    // MARK: - helpers
+
+    private func startServer(replyingWith status: HTTPTestResponseSender.Status,
+                             body: Data = Data("{}".utf8)) throws -> URL
+    {
+        let captured = (status, body)
+        server = HttpTestServer { _, response in
+            response.sendResponse(status: captured.0,
+                                  contentType: "application/json",
+                                  body: captured.1)
+        }
+        try server.start()
+        return server.baseURL
+    }
+
+    private func status(_ code: UInt16, reason: String) -> HTTPTestResponseSender.Status {
+        HTTPTestResponseSender.Status(code: code, reason: reason)
+    }
+
+    private func makeConfig(baseURL: URL) -> ExporterConfiguration {
+        ExporterConfiguration(
+            serviceName: "service",
+            applicationName: "app",
+            applicationVersion: "1.0",
+            environment: "test",
+            hostname: "host",
+            apiKey: "fakeToken",
+            endpoint: .other(testsBaseURL: baseURL, logsBaseURL: baseURL),
+            metadata: .init(),
+            performancePreset: .readAllFiles,
+            exporterId: "exporterId",
+            logger: Log(isDebug: false)
+        )
+    }
+
+    private func expectError(_ block: () throws -> Void,
+                             file: StaticString = #file, line: UInt = #line)
+        -> LibraryConfigurationCommunicationError?
+    {
+        do {
+            try block()
+            XCTFail("Expected throw", file: file, line: line)
+            return nil
+        } catch let error as LibraryConfigurationCommunicationError {
+            return error
+        } catch {
+            XCTFail("Expected LibraryConfigurationCommunicationError, got \(type(of: error))",
+                    file: file, line: line)
+            return nil
+        }
+    }
+
+    private func validSettingsBody() -> Data {
+        let payload: [String: Any] = [
+            "data": [
+                "id": "1",
+                "type": "ci_app_tracers_test_service_settings",
+                "attributes": [
+                    "itr_enabled": true,
+                    "code_coverage": false,
+                    "tests_skipping": false,
+                    "known_tests_enabled": true,
+                    "require_git": false,
+                    "flaky_test_retries_enabled": true,
+                    "early_flake_detection": [
+                        "enabled": false,
+                        "slow_test_retries": [String: Int](),
+                        "faulty_session_threshold": 0
+                    ] as [String: Any],
+                    "test_management": [
+                        "enabled": false,
+                        "attempt_to_fix_retries": 0
+                    ] as [String: Any]
+                ] as [String: Any]
+            ] as [String: Any]
+        ]
+        return (try? JSONSerialization.data(withJSONObject: payload)) ?? Data()
+    }
+}


### PR DESCRIPTION
### What and why?

We need a way to understand that features were not working because communication with backend failed. Added hidden tags for that.

### How?

Updated tracer to send the hidden tags under _dd.ci.library_configuration_error in every event of a test session (tests, suites, modules, and sessions) when a communication error occurs with the backend during library configuration requests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
