### PR TITLE
[SDTEST-3761] Propagate TIA tests skipping tag

### DIFF
--- a/Sources/DatadogSDKTesting/DDTest.swift
+++ b/Sources/DatadogSDKTesting/DDTest.swift
@@ -119,7 +119,7 @@ extension Test: TestRun {
     }
     
     func set(tag name: String, value: SpanAttributeConvertible) {
-        setTag(key: name, value: value)
+        span.setAttribute(key: name, value: value.spanAttribute)
     }
     
     func set(metric name: String, value: Double) {

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
@@ -89,6 +89,10 @@ final class TestImpactAnalysis: TestHooksFeature {
             module.session.set(metric: DDTestSessionTags.testCoverageLines, value: linesCovered)
         }
     }
+
+    func testSuiteWillEnd(suite: any TestSuite) {
+        suite.set(tag: DDTestSessionTags.testSkippingEnabled, value: isSkippingEnabled)
+    }
     
     func testGroupConfiguration(for test: String, tags: any TestTags,
                                 in suite: any TestSuite,
@@ -117,6 +121,7 @@ final class TestImpactAnalysis: TestHooksFeature {
         guard !test.suite.isSwiftTesting || swiftTestingEnabled else {
             return
         }
+        test.set(tag: DDTestSessionTags.testSkippingEnabled, value: isSkippingEnabled)
         if let correlationId = correlationId {
             test.set(tag: DDItrTags.itrCorrelationId, value: correlationId)
         }

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
@@ -91,6 +91,9 @@ final class TestImpactAnalysis: TestHooksFeature {
     }
 
     func testSuiteWillEnd(suite: any TestSuite) {
+        guard !suite.isSwiftTesting || swiftTestingEnabled else {
+            return
+        }
         suite.set(tag: DDTestSessionTags.testSkippingEnabled, value: isSkippingEnabled)
     }
     

--- a/Tests/DatadogSDKTesting/DDXCTestObserverTests.swift
+++ b/Tests/DatadogSDKTesting/DDXCTestObserverTests.swift
@@ -85,6 +85,27 @@ internal class DDXCTestObserverTests: XCTestCase {
         XCTAssertEqual(spanData.attributes[DDHostTags.hostVCPUCount]?.description, String(Double(PlatformUtils.getCpuCount())))
     }
 
+    func testWhenTestRunSetTagGetsBoolValue_tagIsSetAsStringAttribute() async {
+        let group = DDXCTestRetryGroup(for: self, observer: testObserver)
+        testObserver.testBundleWillStart(Bundle.main)
+        testObserver.testSuiteWillStart(theSuite)
+        testObserver.testRetryGroupWillStart(group)
+
+        let spanData = group.context.suite.withActiveTest(named: self.testId.test) { test in
+            test.set(tag: "test.bool_tag", value: true)
+
+            let span = OpenTelemetry.instance.contextProvider.activeSpan as! SpanSdk
+            return span.toSpanData()
+        }
+
+        testObserver.testRetryGroupDidFinish(group)
+        testObserver.testSuiteDidFinish(theSuite)
+        testObserver.testBundleDidFinish(Bundle.main)
+        await destroyObserver()
+
+        XCTAssertEqual(spanData.attributes["test.bool_tag"], AttributeValue.string("true"))
+    }
+
     func testWhenTestCaseDidFinishIsCalled_testStatusIsSet() async {
         let group = DDXCTestRetryGroup(for: self, observer: testObserver)
         testObserver.testBundleWillStart(Bundle.main)

--- a/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSwiftTestingTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSwiftTestingTests.swift
@@ -63,6 +63,15 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["skipTest"]?.runs.first?.tags[DDTestSessionTags.testSkippingEnabled], "true")
     }
 
+    func testTestsSkippingEnabledTagNotSetOnSuite_whenSwiftTestingDisabled() async throws {
+        let (runner, _, _) = tiaSwiftTestingDisabledRunner(skip: [],
+                                                           tests: ["someTest": .pass()])
+        let session = try await runner.run()
+        let suite = try extractSuite(session)
+
+        XCTAssertNil(suite.tags[DDTestSessionTags.testSkippingEnabled])
+    }
+
     // TIA + EFD
     func testTestImpactAnalysisSkipsEFDKnownTest() async throws {
         let (runner, tia, collector) = tiaAndEfdRunner(skip: ["skipTest"], known: ["skipTest"],
@@ -251,6 +260,16 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
                                                         configuration: ["test.bundle": "TIAModule"]) })
         let collector = Mocks.CoverageCollector()
         let tia = TestImpactAnalysis(tests: skipped, coverage: collector, swiftTestingEnabled: true)
+        return (Mocks.STRunner(features: [tia, AdditionalTags()], tests: ["TIAModule": ["TIASuite": .init(tests: tests)]]), tia, collector)
+    }
+
+    func tiaSwiftTestingDisabledRunner(skip: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.STRunner, TestImpactAnalysis, Mocks.CoverageCollector) {
+        let skipped = SkipTests(correlationId: "abacaba",
+                                tests: skip.map { .init(name: $0,
+                                                        suite: "TIASuite",
+                                                        configuration: ["test.bundle": "TIAModule"]) })
+        let collector = Mocks.CoverageCollector()
+        let tia = TestImpactAnalysis(tests: skipped, coverage: collector, swiftTestingEnabled: false)
         return (Mocks.STRunner(features: [tia, AdditionalTags()], tests: ["TIAModule": ["TIASuite": .init(tests: tests)]]), tia, collector)
     }
 

--- a/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSwiftTestingTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestImpactAnalysisSwiftTestingTests.swift
@@ -43,6 +43,26 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
         XCTAssertEqual(collector.tests.count, 1) // someTest ran once; skipTest was skipped
     }
 
+    func testTestsSkippingEnabledTagOnSuite_whenSkippingEnabled() async throws {
+        let (runner, _, _) = tiaRunner(skip: ["skipTest"],
+                                       tests: ["someTest": .pass(),
+                                               "skipTest": .fail("Always fails")])
+        let session = try await runner.run()
+        let suite = try extractSuite(session)
+
+        XCTAssertEqual(suite.tags[DDTestSessionTags.testSkippingEnabled], "true")
+    }
+
+    func testTestsSkippingEnabledTagOnTest_whenSkippingEnabled() async throws {
+        let (runner, _, _) = tiaRunner(skip: ["skipTest"],
+                                       tests: ["someTest": .pass(),
+                                               "skipTest": .fail("Always fails")])
+        let tests = try extractTests(try await runner.run())
+
+        XCTAssertEqual(tests["someTest"]?.runs.first?.tags[DDTestSessionTags.testSkippingEnabled], "true")
+        XCTAssertEqual(tests["skipTest"]?.runs.first?.tags[DDTestSessionTags.testSkippingEnabled], "true")
+    }
+
     // TIA + EFD
     func testTestImpactAnalysisSkipsEFDKnownTest() async throws {
         let (runner, tia, collector) = tiaAndEfdRunner(skip: ["skipTest"], known: ["skipTest"],
@@ -266,6 +286,13 @@ final class TestImpactAnalysisSwiftTestingTests: XCTestCase {
         features.insert(atr, at: features.count - 2)
         runner.0.features = features
         return runner
+    }
+
+    func extractSuite(_ session: Mocks.Session) throws -> Mocks.Suite {
+        guard let suite = session["TIAModule"]?["TIASuite"] else {
+            throw InternalError(description: "Can't get TIAModule and TIASuite")
+        }
+        return suite
     }
 
     func extractTests(_ session: Mocks.Session) throws -> [String: Mocks.Group] {

--- a/Tests/DatadogSDKTesting/Features/TestImpactAnalysisTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestImpactAnalysisTests.swift
@@ -43,6 +43,53 @@ class TestImpactAnalysisTests: XCTestCase {
         XCTAssertEqual(collector.tests.count, 1) // someTest ran once; skipTest was skipped
     }
 
+    func testTestsSkippingEnabledTagOnSuite_whenSkippingEnabled() async throws {
+        let (runner, _, _) = tiaRunner(skip: ["skipTest"],
+                                       tests: ["someTest": .pass(),
+                                               "skipTest": .fail("Always fails")])
+        let session = await runner.run()
+        let suite = try extractSuite(session)
+
+        XCTAssertEqual(suite.tags[DDTestSessionTags.testSkippingEnabled], "true")
+    }
+
+    func testTestsSkippingEnabledTagOnSuite_whenSkippingDisabled() async throws {
+        let (runner, _) = tiaDisabledRunner(tests: ["someTest": .pass()])
+        let session = await runner.run()
+        let suite = try extractSuite(session)
+
+        XCTAssertEqual(suite.tags[DDTestSessionTags.testSkippingEnabled], "false")
+    }
+
+    func testTestsSkippingEnabledTagOnTest_whenSkippingEnabled() async throws {
+        let (runner, _, _) = tiaRunner(skip: ["skipTest"],
+                                       tests: ["someTest": .pass(),
+                                               "skipTest": .fail("Always fails")])
+        let tests = try await extractTests(runner.run())
+
+        XCTAssertEqual(tests["someTest"]?.runs.first?.tags[DDTestSessionTags.testSkippingEnabled], "true")
+        XCTAssertEqual(tests["skipTest"]?.runs.first?.tags[DDTestSessionTags.testSkippingEnabled], "true")
+    }
+
+    func testTestsSkippingEnabledTagOnTest_whenSkippingDisabled() async throws {
+        let (runner, _) = tiaDisabledRunner(tests: ["someTest": .pass()])
+        let tests = try await extractTests(runner.run())
+
+        XCTAssertEqual(tests["someTest"]?.runs.first?.tags[DDTestSessionTags.testSkippingEnabled], "false")
+    }
+
+    func testTestsSkippingEnabledTagPropagatedAcrossRetries() async throws {
+        let (runner, _, _) = tiaAndAtrRunner(skip: [],
+                                             tests: ["someTest": .fail(first: 3)])
+        let tests = try await extractTests(runner.run())
+        let runs = try XCTUnwrap(tests["someTest"]?.runs)
+
+        XCTAssertEqual(runs.count, 4)
+        for run in runs {
+            XCTAssertEqual(run.tags[DDTestSessionTags.testSkippingEnabled], "true")
+        }
+    }
+
     func testTestImpactAnalysisDoesntSkipUnskippable() async throws {
         let (runner, tia, collector) = tiaRunner(skip: ["skipTest"],
                                          tests: ["someTest": .fail("Always fails"),
@@ -345,6 +392,11 @@ class TestImpactAnalysisTests: XCTestCase {
         let tia = TestImpactAnalysis(tests: skipped, coverage: collector, swiftTestingEnabled: false)
         return (Mocks.Runner(features: [tia, AdditionalTags()], tests: ["TIAModule": ["TIASuite": .init(tests: tests)]]), tia, collector)
     }
+
+    func tiaDisabledRunner(tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.Runner, TestImpactAnalysis) {
+        let tia = TestImpactAnalysis(tests: nil, coverage: nil, swiftTestingEnabled: false)
+        return (Mocks.Runner(features: [tia, AdditionalTags()], tests: ["TIAModule": ["TIASuite": .init(tests: tests)]]), tia)
+    }
     
     func tiaAndEfdRunner(skip: [String], known: [String], tests: KeyValuePairs<String, Mocks.Runner.TestMethod>) -> (Mocks.Runner, TestImpactAnalysis, Mocks.CoverageCollector) {
         let runner = tiaRunner(skip: skip, tests: tests)
@@ -378,6 +430,13 @@ class TestImpactAnalysisTests: XCTestCase {
         features.insert(atr, at: features.count - 2)
         runner.0.features = features
         return runner
+    }
+
+    func extractSuite(_ session: Mocks.Session) throws -> Mocks.Suite {
+        guard let suite = session["TIAModule"]?["TIASuite"] else {
+            throw InternalError(description: "Can't get TIAModule and TIASuite")
+        }
+        return suite
     }
     
     func extractTests(_ session: Mocks.Session) throws -> [String: Mocks.Group] {


### PR DESCRIPTION
Summary:
- Propagate test.itr.tests_skipping.enabled to suite and test spans.
- Add XCTest coverage for enabled, disabled, and retry propagation.
- Add swift-testing coverage for enabled suite and test propagation.

Tests:
- xcodebuild test -project DatadogSDKTesting.xcodeproj -scheme DatadogSDKTesting -destination platform=macOS -derivedDataPath /private/tmp/dd-sdk-swift-testing-DerivedData-fresh