### PR TITLE
[SDTEST-3702] Added error propagation for the packfile upload

### DIFF
--- a/Sources/EventsExporter/EventsExporter.swift
+++ b/Sources/EventsExporter/EventsExporter.swift
@@ -8,8 +8,10 @@ import Foundation
 import OpenTelemetrySdk
 import CodeCoverageParser
 
-/// Thrown by `EventsExporterProtocol` library configuration requests
-/// (`tracerSettings`, `skippableTests`, `knownTests`, `testManagementTests`).
+/// Thrown by `EventsExporterProtocol` requests that need to surface a
+/// backend communication failure to the caller — library configuration
+/// (`tracerSettings`, `skippableTests`, `knownTests`, `testManagementTests`)
+/// as well as the git-upload pair (`searchCommits`, `uploadPackFiles`).
 /// Carries enough context (request name, payload, and the failure reason) for
 /// the caller to log a meaningful diagnostic. `.unauthorized` and
 /// `.communicationFailed` count as communication failures with the backend;

--- a/Sources/EventsExporter/IntelligentTestRunner/ITRService.swift
+++ b/Sources/EventsExporter/IntelligentTestRunner/ITRService.swift
@@ -126,15 +126,26 @@ internal class ITRService {
 
     func uploadPackFiles(packFilesDirectory: Directory, commit: String, repository: String) throws {
         Log.debug("Uploading packfiles from: \(packFilesDirectory) for commit: \(commit) in repo: \(repository)")
-        try packFilesDirectory.files()
-            .filter { $0.name.hasSuffix(".pack") }
-            .forEach {
-                packFileRequestBuilder.addFieldsCallback = { request, data in
-                    request.addDataField(named: "packfile", data: data, mimeType: .applicationOctetStream)
-                    request.addDataField(named: "pushedSha", data: PushedSHA(id: commit, repoURL: repository).bytes!, mimeType: .applicationJSON)
-                }
-                _ = packFileUploader.upload(data: try $0.read())
+        let files = try packFilesDirectory.files().filter { $0.name.hasSuffix(".pack") }
+        
+        let pushedSha = PushedSHA(id: commit, repoURL: repository).bytes!
+        packFileRequestBuilder.addFieldsCallback = { request, data in
+            request.addDataField(named: "packfile", data: data, mimeType: .applicationOctetStream)
+            request.addDataField(named: "pushedSha", data: pushedSha, mimeType: .applicationJSON)
+        }
+        
+        for file in files {
+            switch packFileUploader.uploadWithResult(data: try file.read()) {
+            case .success:
+                continue
+            case .failure(let error):
+                throw LibraryConfigurationCommunicationError(
+                    requestName: "PackFileRequest",
+                    payload: file.name,
+                    reason: error.isUnauthorized ? .unauthorized : .communicationFailed(error)
+                )
             }
+        }
     }
 
     func skippableTests(repositoryURL: String, sha: String, testLevel: ITRTestLevel,


### PR DESCRIPTION
### What and why?

We should propagate errors from packfile upload and handle them properly.

### How?

Added proper error throw on packfile upload process.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
