### PR TITLE
[SDTEST-2373] Added suite-level codeowners

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		A77C12392D8DD2A9009C2BA1 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C12382D8DD2A9009C2BA1 /* Feature.swift */; };
 		A77C123C2D9425C7009C2BA1 /* KnownTestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */; };
 		A7EE000000020000000000A2 /* LibraryConfigurationErrorTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */; };
+		A7EE000000020000000000A4 /* AdditionalTagsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000020000000000A3 /* AdditionalTagsFeatureTests.swift */; };
 		A77C123E2D9474E6009C2BA1 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C123D2D9474E6009C2BA1 /* Models.swift */; };
 		A794A8FF2E7990D20044FE3C /* TestManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */; };
 		A79DA5B42F928F87004BCA8C /* SwiftTestingSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79DA5B32F928F87004BCA8C /* SwiftTestingSmokeTests.swift */; };
@@ -466,6 +467,7 @@
 		A77C12382D8DD2A9009C2BA1 /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownTestsTests.swift; sourceTree = "<group>"; };
 		A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationErrorTagsTests.swift; sourceTree = "<group>"; };
+		A7EE000000020000000000A3 /* AdditionalTagsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalTagsFeatureTests.swift; sourceTree = "<group>"; };
 		A77C123D2D9474E6009C2BA1 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestManagementTests.swift; sourceTree = "<group>"; };
 		A79DA5B22F928F71004BCA8C /* IntegrationTests-UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "IntegrationTests-UnitTests.xctestplan"; sourceTree = "<group>"; };
@@ -844,6 +846,7 @@
 				CC931D86ADB841B6969C7A7A /* EarlyFlakeDetectionSwiftTestingTests.swift */,
 				A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */,
 				A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */,
+				A7EE000000020000000000A3 /* AdditionalTagsFeatureTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -2014,6 +2017,7 @@
 				A7675D722F6CA00000A05B5F /* SwiftTestRunParametersParserTests.swift in Sources */,
 				A77C123C2D9425C7009C2BA1 /* KnownTestsTests.swift in Sources */,
 				A7EE000000020000000000A2 /* LibraryConfigurationErrorTagsTests.swift in Sources */,
+				A7EE000000020000000000A4 /* AdditionalTagsFeatureTests.swift in Sources */,
 				A7FC266E2BA1F70200067E26 /* DDXCTestObserverTests.swift in Sources */,
 				A7675D742F6CA00000A05B5F /* SessionManagerTests.swift in Sources */,
 				A7FC266C2BA1F70200067E26 /* FrameworkLoadHandlerTests.swift in Sources */,

--- a/Sources/DatadogSDKTesting/AdditionalTagsFeature.swift
+++ b/Sources/DatadogSDKTesting/AdditionalTagsFeature.swift
@@ -40,6 +40,8 @@ final class AdditionalTags: TestHooksFeature {
     let codeOwners: CodeOwners?
     let workspacePath: String?
 
+    private let suiteOwners = Synced<[ObjectIdentifier: [String]]>([:])
+
     init(codeCoverage: Bool = false, bundleFunctions: FunctionMap = [:], codeOwners: CodeOwners? = nil, workspacePath: String? = nil) {
         self.codeCoverage = codeCoverage
         self.bundleFunctions = bundleFunctions
@@ -66,25 +68,48 @@ final class AdditionalTags: TestHooksFeature {
         }
     }
 
+    func testSuiteWillEnd(suite: any TestSuite) {
+        let owners = suiteOwners.update { $0.removeValue(forKey: ObjectIdentifier(suite)) }
+        if let owners, !owners.isEmpty {
+            suite.set(tag: DDTestTags.testCodeowners, value: CodeOwners.format(owners))
+        }
+    }
+
     func testWillStart(test: any TestRun, info: TestRunInfoStart) {
         if let functionInfo = bundleFunctions["\(test.suite.name).\(test.name)"] {
-            var filePath = functionInfo.file
-            if let workspacePath,
-               let workspaceRange = filePath.range(of: workspacePath + "/")
-            {
-                filePath.removeSubrange(workspaceRange)
-            }
+            let filePath = stripWorkspace(from: functionInfo.file)
             test.set(tag: DDTestTags.testSourceFile, value: filePath)
             test.set(tag: DDTestTags.testSourceStartLine, value: functionInfo.startLine)
             test.set(tag: DDTestTags.testSourceEndLine, value: functionInfo.endLine)
-            if let owners = codeOwners?.ownersForPath(filePath) {
-                test.set(tag: DDTestTags.testCodeowners, value: owners)
+            if let owners = codeOwners?.owners(forPath: filePath) {
+                test.set(tag: DDTestTags.testCodeowners, value: CodeOwners.format(owners))
+                accumulate(owners: owners, in: test.suite)
             }
         }
         if let retry = info.retry {
             test.set(tag: DDEfdTags.testIsRetry, value: "true")
             test.set(tag: DDEfdTags.testRetryReason, value: retry.reason)
         }
+    }
+
+    private func accumulate(owners: [String], in suite: any TestSuite) {
+        let key = ObjectIdentifier(suite)
+        suiteOwners.update { state in
+            var existing = state[key] ?? []
+            for owner in owners where !existing.contains(owner) {
+                existing.append(owner)
+            }
+            state[key] = existing
+        }
+    }
+
+    private func stripWorkspace(from path: String) -> String {
+        guard let workspacePath,
+              let range = path.range(of: workspacePath + "/")
+        else { return path }
+        var result = path
+        result.removeSubrange(range)
+        return result
     }
 
     func testWillFinish(test: any TestRun, duration: TimeInterval,

--- a/Sources/DatadogSDKTesting/AdditionalTagsFeature.swift
+++ b/Sources/DatadogSDKTesting/AdditionalTagsFeature.swift
@@ -39,14 +39,31 @@ final class AdditionalTags: TestHooksFeature {
     let bundleFunctions: FunctionMap
     let codeOwners: CodeOwners?
     let workspacePath: String?
+    
+    struct SuiteOwners {
+        private var _owners: [String: Int] = [:]
+        
+        var owners: [String] {
+            _owners.sorted { $0.value < $1.value }.map { $0.key }
+        }
+        
+        var isEmpty: Bool { _owners.isEmpty }
+        
+        mutating func add(owners: [String]) {
+            for owner in owners where _owners[owner] == nil {
+                _owners[owner] = _owners.count
+            }
+        }
+    }
 
-    private let suiteOwners = Synced<[ObjectIdentifier: [String]]>([:])
+    private let suiteOwners: Synced<[ObjectIdentifier: SuiteOwners]>
 
     init(codeCoverage: Bool = false, bundleFunctions: FunctionMap = [:], codeOwners: CodeOwners? = nil, workspacePath: String? = nil) {
         self.codeCoverage = codeCoverage
         self.bundleFunctions = bundleFunctions
         self.codeOwners = codeOwners
         self.workspacePath = workspacePath
+        self.suiteOwners = .init([:])
     }
 
     func testSessionWillEnd(session: any TestSession) {
@@ -71,7 +88,7 @@ final class AdditionalTags: TestHooksFeature {
     func testSuiteWillEnd(suite: any TestSuite) {
         let owners = suiteOwners.update { $0.removeValue(forKey: ObjectIdentifier(suite)) }
         if let owners, !owners.isEmpty {
-            suite.set(tag: DDTestTags.testCodeowners, value: CodeOwners.format(owners))
+            suite.set(tag: DDTestTags.testCodeowners, value: CodeOwners.format(owners.owners))
         }
     }
 
@@ -83,33 +100,15 @@ final class AdditionalTags: TestHooksFeature {
             test.set(tag: DDTestTags.testSourceEndLine, value: functionInfo.endLine)
             if let owners = codeOwners?.owners(forPath: filePath) {
                 test.set(tag: DDTestTags.testCodeowners, value: CodeOwners.format(owners))
-                accumulate(owners: owners, in: test.suite)
+                suiteOwners.update { state in
+                    state[ObjectIdentifier(test.suite), default: .init()].add(owners: owners)
+                }
             }
         }
         if let retry = info.retry {
             test.set(tag: DDEfdTags.testIsRetry, value: "true")
             test.set(tag: DDEfdTags.testRetryReason, value: retry.reason)
         }
-    }
-
-    private func accumulate(owners: [String], in suite: any TestSuite) {
-        let key = ObjectIdentifier(suite)
-        suiteOwners.update { state in
-            var existing = state[key] ?? []
-            for owner in owners where !existing.contains(owner) {
-                existing.append(owner)
-            }
-            state[key] = existing
-        }
-    }
-
-    private func stripWorkspace(from path: String) -> String {
-        guard let workspacePath,
-              let range = path.range(of: workspacePath + "/")
-        else { return path }
-        var result = path
-        result.removeSubrange(range)
-        return result
     }
 
     func testWillFinish(test: any TestRun, duration: TimeInterval,
@@ -139,6 +138,15 @@ final class AdditionalTags: TestHooksFeature {
     }
 
     func stop() {}
+    
+    private func stripWorkspace(from path: String) -> String {
+        guard let workspacePath,
+              let range = path.range(of: workspacePath + "/")
+        else { return path }
+        var result = path
+        result.removeSubrange(range)
+        return result
+    }
 }
 
 /// Adds `_dd.ci.library_configuration_error.*` hidden tags to every test,

--- a/Sources/DatadogSDKTesting/Utils/CodeOwners.swift
+++ b/Sources/DatadogSDKTesting/Utils/CodeOwners.swift
@@ -79,7 +79,7 @@ struct CodeOwners {
         self.init(sections: sectionsOrder.map { ($0, sections[$0]!) })
     }
     
-    func ownersForPath(_ path: String) -> String? {
+    func owners(forPath path: String) -> [String]? {
         let fullPath = path.first == "/" ? path : "/" + path
         let fullPathRange = NSRange(location: 0, length: fullPath.utf16.count)
         // Last matching rule wins (inside one section).
@@ -103,8 +103,15 @@ struct CodeOwners {
                 codeowners.append(contentsOf: lastMatch)
             }
         }
-        guard !codeowners.isEmpty else { return nil }
-        return "[\"" + codeowners.joined(separator: "\",\"") + "\"]"
+        return codeowners.isEmpty ? nil : codeowners
+    }
+
+    func ownersForPath(_ path: String) -> String? {
+        owners(forPath: path).map(Self.format)
+    }
+
+    static func format(_ owners: [String]) -> String {
+        #"[""# + owners.joined(separator: #"",""#) + #""]"#
     }
 }
 

--- a/Tests/DatadogSDKTesting/Features/AdditionalTagsFeatureTests.swift
+++ b/Tests/DatadogSDKTesting/Features/AdditionalTagsFeatureTests.swift
@@ -1,0 +1,139 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSDKTesting
+
+final class AdditionalTagsSuiteCodeownersTests: XCTestCase {
+    private let module = "MyModule"
+
+    private let codeOwnersContent = """
+    *               @global
+    /Sources/Foo/   @foo-team
+    /Sources/Bar/   @bar-team
+    /Sources/Baz/   @baz-team
+    """
+
+    func testSuiteTagIsSetWhenAllTestsShareOneFile() async throws {
+        let codeOwners = try CodeOwners(parsing: codeOwnersContent)
+        let bundleFunctions: FunctionMap = [
+            "MySuite.testA": .init(file: "/Sources/Foo/A.swift", startLine: 1, endLine: 5),
+            "MySuite.testB": .init(file: "/Sources/Foo/A.swift", startLine: 7, endLine: 9),
+        ]
+
+        let session = await runSession(bundleFunctions: bundleFunctions, codeOwners: codeOwners,
+                                       tests: [module: ["MySuite": ["testA": .pass(), "testB": .pass()]]])
+
+        XCTAssertEqual(session[module]?["MySuite"]?.tags[DDTestTags.testCodeowners],
+                       "[\"@foo-team\"]")
+    }
+
+    func testSuiteTagAggregatesOwnersAcrossFiles() async throws {
+        let codeOwners = try CodeOwners(parsing: codeOwnersContent)
+        let bundleFunctions: FunctionMap = [
+            "MySuite.testA": .init(file: "/Sources/Foo/A.swift", startLine: 1, endLine: 5),
+            "MySuite.testB": .init(file: "/Sources/Bar/B.swift", startLine: 1, endLine: 5),
+        ]
+
+        let session = await runSession(bundleFunctions: bundleFunctions, codeOwners: codeOwners,
+                                       tests: [module: ["MySuite": ["testA": .pass(), "testB": .pass()]]])
+
+        // Owners are accumulated in test-execution order, deduped.
+        XCTAssertEqual(session[module]?["MySuite"]?.tags[DDTestTags.testCodeowners],
+                       "[\"@foo-team\",\"@bar-team\"]")
+    }
+
+    func testSuiteTagDedupesRepeatedOwners() async throws {
+        let codeOwners = try CodeOwners(parsing: codeOwnersContent)
+        let bundleFunctions: FunctionMap = [
+            "MySuite.testA": .init(file: "/Sources/Foo/A.swift", startLine: 1, endLine: 5),
+            "MySuite.testB": .init(file: "/Sources/Foo/B.swift", startLine: 1, endLine: 5),
+            "MySuite.testC": .init(file: "/Sources/Foo/C.swift", startLine: 1, endLine: 5),
+        ]
+
+        let session = await runSession(bundleFunctions: bundleFunctions, codeOwners: codeOwners,
+                                       tests: [module: ["MySuite": [
+                                           "testA": .pass(),
+                                           "testB": .pass(),
+                                           "testC": .pass(),
+                                       ]]])
+
+        XCTAssertEqual(session[module]?["MySuite"]?.tags[DDTestTags.testCodeowners],
+                       "[\"@foo-team\"]")
+    }
+
+    func testSuiteTagIgnoresTestsWithoutFileInfo() async throws {
+        let codeOwners = try CodeOwners(parsing: codeOwnersContent)
+        // Only the middle test has file info — the suite tag reflects only that file.
+        let bundleFunctions: FunctionMap = [
+            "MySuite.testB": .init(file: "/Sources/Bar/B.swift", startLine: 1, endLine: 5),
+        ]
+
+        let session = await runSession(bundleFunctions: bundleFunctions, codeOwners: codeOwners,
+                                       tests: [module: ["MySuite": [
+                                           "testA": .pass(),
+                                           "testB": .pass(),
+                                           "testC": .pass(),
+                                       ]]])
+
+        XCTAssertEqual(session[module]?["MySuite"]?.tags[DDTestTags.testCodeowners],
+                       "[\"@bar-team\"]")
+    }
+
+    func testSuiteTagIsNilWhenNoBundleFunctions() async throws {
+        let codeOwners = try CodeOwners(parsing: codeOwnersContent)
+
+        let session = await runSession(bundleFunctions: [:], codeOwners: codeOwners,
+                                       tests: [module: ["MySuite": ["testA": .pass()]]])
+
+        XCTAssertNil(session[module]?["MySuite"]?.tags[DDTestTags.testCodeowners])
+    }
+
+    func testSuiteTagIsNilWhenCodeOwnersIsNil() async throws {
+        let bundleFunctions: FunctionMap = [
+            "MySuite.testA": .init(file: "/Sources/Foo/A.swift", startLine: 1, endLine: 5),
+        ]
+
+        let session = await runSession(bundleFunctions: bundleFunctions, codeOwners: nil,
+                                       tests: [module: ["MySuite": ["testA": .pass()]]])
+
+        XCTAssertNil(session[module]?["MySuite"]?.tags[DDTestTags.testCodeowners])
+    }
+
+    func testOwnersAreScopedPerSuite() async throws {
+        let codeOwners = try CodeOwners(parsing: codeOwnersContent)
+        let bundleFunctions: FunctionMap = [
+            "FooSuite.testA": .init(file: "/Sources/Foo/A.swift", startLine: 1, endLine: 5),
+            "BarSuite.testB": .init(file: "/Sources/Bar/B.swift", startLine: 1, endLine: 5),
+            "BazSuite.testC": .init(file: "/Sources/Baz/C.swift", startLine: 1, endLine: 5),
+        ]
+
+        let session = await runSession(bundleFunctions: bundleFunctions, codeOwners: codeOwners,
+                                       tests: [module: [
+                                           "FooSuite": ["testA": .pass()],
+                                           "BarSuite": ["testB": .pass()],
+                                           "BazSuite": ["testC": .pass()],
+                                       ]])
+
+        XCTAssertEqual(session[module]?["FooSuite"]?.tags[DDTestTags.testCodeowners], "[\"@foo-team\"]")
+        XCTAssertEqual(session[module]?["BarSuite"]?.tags[DDTestTags.testCodeowners], "[\"@bar-team\"]")
+        XCTAssertEqual(session[module]?["BazSuite"]?.tags[DDTestTags.testCodeowners], "[\"@baz-team\"]")
+    }
+
+    // MARK: helpers
+
+    private func runSession(
+        bundleFunctions: FunctionMap,
+        codeOwners: CodeOwners?,
+        tests: Mocks.Runner.Tests
+    ) async -> Mocks.Session {
+        let feature: TestHooksFeature = AdditionalTags(
+            bundleFunctions: bundleFunctions,
+            codeOwners: codeOwners
+        )
+        return await Mocks.Runner(features: [feature], tests: tests).run()
+    }
+}


### PR DESCRIPTION
### What and why?

Added suite-level codeowners.

### How?

Collect codeowners for all tests in the suite and add them to the suite on the testSuiteWillEnd event.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
