### PR TITLE
[SDTEST-807] Added parameter to disable git unshallow

### DIFF
--- a/Sources/DatadogSDKTesting/Config.swift
+++ b/Sources/DatadogSDKTesting/Config.swift
@@ -44,6 +44,7 @@ final class Config {
     
     /// TIA  related environment
     var gitUploadEnabled: Bool = true
+    var gitUnshallowEnabled: Bool = true
     var tiaEnabled: Bool = true
     var tiaSwiftTestingEnabled: Bool? = nil
     var codeCoverageEnabled: Bool = true
@@ -131,6 +132,7 @@ final class Config {
         
         /// Intelligent test runner related configuration
         gitUploadEnabled = env[.enableCiVisibilityGitUpload] ?? gitUploadEnabled
+        gitUnshallowEnabled = env[.enableCiVisibilityGitUnshallow] ?? gitUnshallowEnabled
         tiaEnabled = env[.enableTIA] ?? env[.enableCiVisibilityITR] ?? tiaEnabled
         tiaSwiftTestingEnabled = env[.enableSwiftTestingTIA]
         excludedBranches = env[.ciVisibilityExcludedBranches] ?? excludedBranches
@@ -231,6 +233,7 @@ extension Config: CustomDebugStringConvertible {
         Disable NTP Clock: \(disableNTPClock)
         Disable Git Information: \(disableGitInformation)
         Git Upload Enabled: \(gitUploadEnabled)
+        Git Unshallow Enabled: \(gitUnshallowEnabled)
         Coverage Enabled: \(codeCoverageEnabled)
         Test Impact Analysis Enabled: \(tiaEnabled)
         Test Impact Analysis for Swift Testing Enabled: \(tiaSwiftTestingEnabled.map(String.init) ?? "auto-detect")

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -225,7 +225,8 @@ internal class DDTestMonitor {
                 }
                 DDTestMonitor.instance?.gitUploader = GitUploader(
                     log: Log.instance, exporter: exporter, gitDirectory: gitDirectory,
-                    commitFolder: try? DDTestMonitor.cacheManager?.commit(feature: "git")
+                    commitFolder: try? DDTestMonitor.cacheManager?.commit(feature: "git"),
+                    unshallowEnabled: DDTestMonitor.config.gitUnshallowEnabled
                 )
             } else {
                 Log.debug("Git Upload Disabled")

--- a/Sources/DatadogSDKTesting/Environment/EnvironmentKeys.swift
+++ b/Sources/DatadogSDKTesting/Environment/EnvironmentKeys.swift
@@ -39,6 +39,7 @@ internal enum EnvironmentKey: String, CaseIterable {
     case disableNTPClock = "DD_DISABLE_NTPCLOCK"
     case enableCiVisibilityLogs = "DD_CIVISIBILITY_LOGS_ENABLED"
     case enableCiVisibilityGitUpload = "DD_CIVISIBILITY_GIT_UPLOAD_ENABLED"
+    case enableCiVisibilityGitUnshallow = "DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED"
     case enableCiVisibilityCodeCoverage = "DD_CIVISIBILITY_CODE_COVERAGE_ENABLED"
     case ciVisibilityCodeCoveragePriority = "DD_CIVISIBILITY_CODE_COVERAGE_PRIORITY"
     case enableCiVisibilityITR = "DD_CIVISIBILITY_ITR_ENABLED"

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/GitUploader.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/GitUploader.swift
@@ -14,11 +14,14 @@ final class GitUploader {
     private let gitDirectory: String
     private let log: Logger
     private let exporter: EventsExporterProtocol
+    private let unshallowEnabled: Bool
 
     private let commitFolder: Directory
     private let packFilesDirectory: Directory
 
-    init?(log: Logger, exporter: EventsExporterProtocol, gitDirectory: String, commitFolder: Directory?) {
+    init?(log: Logger, exporter: EventsExporterProtocol, gitDirectory: String,
+          commitFolder: Directory?, unshallowEnabled: Bool = true)
+    {
         guard !gitDirectory.isEmpty,
               let commitFolder = commitFolder,
               let packFilesDir = try? commitFolder.createSubdirectory(path: Self.packFilesLocation)
@@ -28,6 +31,7 @@ final class GitUploader {
         }
         self.gitDirectory = gitDirectory
         self.exporter = exporter
+        self.unshallowEnabled = unshallowEnabled
         
         guard !commitFolder.hasFile(named: Self.uploadedCommitFile) else {
             log.debug("GitUploader: git information alredy uploaded")
@@ -71,7 +75,8 @@ final class GitUploader {
         }
         
         /// Check if the repository is a shallow clone, if so fetch more info and calculate one more time
-        if isShallowRepository {
+        switch (isShallowRepository, unshallowEnabled) {
+        case (true, true):
             let unshallowed = log.measure(name: "handleShallowClone") {
                 handleShallowClone()
             }
@@ -88,6 +93,9 @@ final class GitUploader {
                 }
                 newCommits = newCommitsUnshallow
             }
+        case (true, false):
+            log.debug("Shallow repository detected but unshallow is disabled. Proceeding with available commits.")
+        default: break
         }
         
         // Generate pack files for the new commits


### PR DESCRIPTION
### What and why?

Customer is worried that git unshallow will make it so that ITR does not actually save time. 

### How?

Added `DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED` env var to allow disabling of git unshallow

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
