### PR TITLE
Fix attempt-to-fix failure suppression

### DIFF
--- a/Sources/DatadogSDKTesting/TestManagement.swift
+++ b/Sources/DatadogSDKTesting/TestManagement.swift
@@ -77,9 +77,8 @@ final class TestManagement: TestHooksFeature {
             // Check that all executions passed
             let atfPassed = info.executions.failed == 0 && status != .fail
             test.set(tag: DDTestManagementTags.testAttemptToFixPassed, value: atfPassed)
-            let finalStatus: TestStatus = atfPassed ? .pass : .fail
             // mark test with final status
-            test.set(tag: DDTestTags.testFinalStatus, value: finalStatus)
+            test.set(tag: DDTestTags.testFinalStatus, value: atfPassed ? TestStatus.pass : .fail)
         }
     }
     
@@ -89,13 +88,6 @@ final class TestManagement: TestHooksFeature {
     {
         guard let testInfo = module.suites[test.suite.name]?.tests[test.name] else {
             return retryStatus.next()
-        }
-
-        let errors: RetryStatus.ErrorsStatus?
-        switch (testInfo.disabled, testInfo.quarantined) {
-        case (true, _): errors = .suppressed(reason: DDTagValues.failureSuppressionReasonDisabled)
-        case (false, true): errors = .suppressed(reason: DDTagValues.failureSuppressionReasonQuarantine)
-        case (false, false): errors = nil
         }
 
         if testInfo.attemptToFix {
@@ -108,6 +100,13 @@ final class TestManagement: TestHooksFeature {
             }
             // end retries (test failed or all retries succeeded)
             return retryStatus.end(errors: nil)
+        }
+        
+        let errors: RetryStatus.ErrorsStatus?
+        switch (testInfo.disabled, testInfo.quarantined) {
+        case (true, _): errors = .suppressed(reason: DDTagValues.failureSuppressionReasonDisabled)
+        case (false, true): errors = .suppressed(reason: DDTagValues.failureSuppressionReasonQuarantine)
+        case (false, false): errors = nil
         }
         return testInfo.disabled
             ? retryStatus.end(errors: errors)

--- a/Sources/DatadogSDKTesting/TestManagement.swift
+++ b/Sources/DatadogSDKTesting/TestManagement.swift
@@ -29,9 +29,7 @@ final class TestManagement: TestHooksFeature {
             return configuration.next()
         }
         if testInfo.attemptToFix {
-            let strategy: RetryGroupSuccessStrategy = testInfo.disabled || testInfo.quarantined ?
-                .alwaysSucceeded : .allSucceeded
-            return configuration.retry(strategy: strategy)
+            return configuration.retry(strategy: .allSucceeded)
         }
         if testInfo.disabled {
             return configuration.skip(reason: "Flaky test is disabled by Datadog",
@@ -79,9 +77,7 @@ final class TestManagement: TestHooksFeature {
             // Check that all executions passed
             let atfPassed = info.executions.failed == 0 && status != .fail
             test.set(tag: DDTestManagementTags.testAttemptToFixPassed, value: atfPassed)
-            // Quarantine and Disable will disable errors, so we should pass.
-            // Otherwise it depends on ATF results
-            let finalStatus: TestStatus = info.retry.status.ignoreErrors ? .pass : (atfPassed ? .pass : .fail)
+            let finalStatus: TestStatus = atfPassed ? .pass : .fail
             // mark test with final status
             test.set(tag: DDTestTags.testFinalStatus, value: finalStatus)
         }
@@ -108,10 +104,10 @@ final class TestManagement: TestHooksFeature {
             // if test isn't failed retry till max retries
             if status != .fail, info.executions.total < attemptToFixRetries - 1 {
                 return retryStatus.retry(reason: DDTagValues.retryReasonAttemptToFix,
-                                         errors: errors)
+                                         errors: nil)
             }
             // end retries (test failed or all retries succeeded)
-            return retryStatus.end(errors: errors)
+            return retryStatus.end(errors: nil)
         }
         return testInfo.disabled
             ? retryStatus.end(errors: errors)
@@ -130,11 +126,14 @@ final class TestManagement: TestHooksFeature {
         guard let testInfo = module.suites[test.suite.name]?.tests[test.name] else {
             return false
         }
+        if testInfo.attemptToFix {
+            // ATF suppression is skipped for non-retriable tests
+            guard info.tags.get(tag: .retriable) ?? true else { return false }
+            return info.executions.total < attemptToFixRetries
+        }
         // Disabled/quarantined always suppress errors regardless of retriable tag
         if testInfo.disabled || testInfo.quarantined { return true }
-        // ATF suppression is skipped for non-retriable tests
-        guard info.tags.get(tag: .retriable) ?? true else { return false }
-        return testInfo.attemptToFix && info.executions.total < attemptToFixRetries
+        return false
     }
 
     func stop() {}

--- a/Tests/DatadogSDKTesting/Features/TestManagementSwiftTestingTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestManagementSwiftTestingTests.swift
@@ -188,6 +188,48 @@ final class TestManagementSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
     }
 
+    func testTMAttemptToFixPassesForDisabledTestWhenAllAttemptsPass() async throws {
+        let runner = tmAndAtrRunner(fix: ["atfTest"], disabled: ["atfTest"],
+                                    tests: ["atfTest": .pass()])
+        let tests = try extractTests(try await runner.run())
+        XCTAssertNotNil(tests["atfTest"])
+        XCTAssertEqual(tests["atfTest"]?.runs.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .pass }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDEfdTags.testIsRetry] == "true" }.count, 19)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDEfdTags.testRetryReason] == DDTagValues.retryReasonAttemptToFix }.count, 19)
+        XCTAssertNil(tests["atfTest"]?.runs.last?.tags[DDTestTags.testHasFailedAllRetries])
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestManagementTags.testAttemptToFixPassed], "true")
+        XCTAssertEqual(tests["atfTest"]?.runs.filter {
+            $0.tags[DDTestTags.testFailureSuppressionReason] == nil
+        }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.isSucceeded, true)
+        XCTAssertEqual(tests["atfTest"]?.isSkipped, false)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+    }
+
+    func testTMAttemptToFixPassesForQuarantinedTestWhenAllAttemptsPass() async throws {
+        let runner = tmAndAtrRunner(fix: ["atfTest"], quarantined: ["atfTest"],
+                                    tests: ["atfTest": .pass()])
+        let tests = try extractTests(try await runner.run())
+        XCTAssertNotNil(tests["atfTest"])
+        XCTAssertEqual(tests["atfTest"]?.runs.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .pass }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDEfdTags.testIsRetry] == "true" }.count, 19)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDEfdTags.testRetryReason] == DDTagValues.retryReasonAttemptToFix }.count, 19)
+        XCTAssertNil(tests["atfTest"]?.runs.last?.tags[DDTestTags.testHasFailedAllRetries])
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestManagementTags.testAttemptToFixPassed], "true")
+        XCTAssertEqual(tests["atfTest"]?.runs.filter {
+            $0.tags[DDTestTags.testFailureSuppressionReason] == nil
+        }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.isSucceeded, true)
+        XCTAssertEqual(tests["atfTest"]?.isSkipped, false)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+    }
+
     func testTMAttemptToFixFailsForFailedTest() async throws {
         let runner = tmAndAtrRunner(fix: ["atfTest"],
                                     tests: ["someTest": .fail("Always fails"),
@@ -229,7 +271,7 @@ final class TestManagementSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
     }
 
-    func testTMAttemptToFixDoesntFailForDisabledTest() async throws {
+    func testTMAttemptToFixFailsForDisabledTest() async throws {
         let runner = tmAndAtrRunner(fix: ["atfTest"], disabled: ["atfTest"],
                                     tests: ["someTest": .fail("Always fails"),
                                             "atfTest": .fail(first: 3)])
@@ -238,19 +280,19 @@ final class TestManagementSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["atfTest"]?.runs.count, 1)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .fail }.count, 1)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .pass }.count, 0)
-        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .fail }.count, 0)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .fail }.count, 1)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 0)
         XCTAssertNil(tests["atfTest"]?.runs.first?.tags[DDEfdTags.testIsRetry])
         XCTAssertNil(tests["atfTest"]?.runs.first?.tags[DDEfdTags.testRetryReason])
         XCTAssertNil(tests["atfTest"]?.runs.last?.tags[DDTestTags.testHasFailedAllRetries])
         XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestManagementTags.testAttemptToFixPassed], "false")
         XCTAssertEqual(tests["atfTest"]?.runs.filter {
-            $0.tags[DDTestTags.testFailureSuppressionReason] == DDTagValues.failureSuppressionReasonDisabled
+            $0.tags[DDTestTags.testFailureSuppressionReason] == nil
         }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.isSucceeded, true)
+        XCTAssertEqual(tests["atfTest"]?.isSucceeded, false)
         XCTAssertEqual(tests["atfTest"]?.isSkipped, false)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
 
         XCTAssertNotNil(tests["someTest"])
         XCTAssertEqual(tests["someTest"]?.runs.count, 6)
@@ -270,7 +312,7 @@ final class TestManagementSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
     }
 
-    func testTMAttemptToFixDoesntFailForQuarantinedTest() async throws {
+    func testTMAttemptToFixFailsForQuarantinedTest() async throws {
         let runner = tmAndAtrRunner(fix: ["atfTest"], quarantined: ["atfTest"],
                                     tests: ["someTest": .fail("Always fails"),
                                             "atfTest": .fail(after: 4)])
@@ -279,19 +321,19 @@ final class TestManagementSwiftTestingTests: XCTestCase {
         XCTAssertEqual(tests["atfTest"]?.runs.count, 5)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .fail }.count, 1)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .pass }.count, 4)
-        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 5)
-        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .fail }.count, 0)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 4)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .fail }.count, 1)
         XCTAssertNil(tests["atfTest"]?.runs.first?.tags[DDEfdTags.testIsRetry])
         XCTAssertNil(tests["atfTest"]?.runs.first?.tags[DDEfdTags.testRetryReason])
         XCTAssertNil(tests["atfTest"]?.runs.last?.tags[DDTestTags.testHasFailedAllRetries])
         XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestManagementTags.testAttemptToFixPassed], "false")
         XCTAssertEqual(tests["atfTest"]?.runs.filter {
-            $0.tags[DDTestTags.testFailureSuppressionReason] == DDTagValues.failureSuppressionReasonQuarantine
-        }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.isSucceeded, true)
+            $0.tags[DDTestTags.testFailureSuppressionReason] == nil
+        }.count, 5)
+        XCTAssertEqual(tests["atfTest"]?.isSucceeded, false)
         XCTAssertEqual(tests["atfTest"]?.isSkipped, false)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
 
         XCTAssertNotNil(tests["someTest"])
         XCTAssertEqual(tests["someTest"]?.runs.count, 6)

--- a/Tests/DatadogSDKTesting/Features/TestManagementTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TestManagementTests.swift
@@ -187,6 +187,48 @@ class TestManagementTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
     }
+
+    func testTMAttemptToFixPassesForDisabledTestWhenAllAttemptsPass() async throws {
+        let runner = tmAndAtrRunner(fix: ["atfTest"], disabled: ["atfTest"],
+                                    tests: ["atfTest": .pass()])
+        let tests = try await extractTests(runner.run())
+        XCTAssertNotNil(tests["atfTest"])
+        XCTAssertEqual(tests["atfTest"]?.runs.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .pass }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDEfdTags.testIsRetry] == "true" }.count, 19)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDEfdTags.testRetryReason] == DDTagValues.retryReasonAttemptToFix }.count, 19)
+        XCTAssertNil(tests["atfTest"]?.runs.last?.tags[DDTestTags.testHasFailedAllRetries])
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestManagementTags.testAttemptToFixPassed], "true")
+        XCTAssertEqual(tests["atfTest"]?.runs.filter {
+            $0.tags[DDTestTags.testFailureSuppressionReason] == nil
+        }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.isSucceeded, true)
+        XCTAssertEqual(tests["atfTest"]?.isSkipped, false)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+    }
+
+    func testTMAttemptToFixPassesForQuarantinedTestWhenAllAttemptsPass() async throws {
+        let runner = tmAndAtrRunner(fix: ["atfTest"], quarantined: ["atfTest"],
+                                    tests: ["atfTest": .pass()])
+        let tests = try await extractTests(runner.run())
+        XCTAssertNotNil(tests["atfTest"])
+        XCTAssertEqual(tests["atfTest"]?.runs.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .pass }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDEfdTags.testIsRetry] == "true" }.count, 19)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDEfdTags.testRetryReason] == DDTagValues.retryReasonAttemptToFix }.count, 19)
+        XCTAssertNil(tests["atfTest"]?.runs.last?.tags[DDTestTags.testHasFailedAllRetries])
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestManagementTags.testAttemptToFixPassed], "true")
+        XCTAssertEqual(tests["atfTest"]?.runs.filter {
+            $0.tags[DDTestTags.testFailureSuppressionReason] == nil
+        }.count, 20)
+        XCTAssertEqual(tests["atfTest"]?.isSucceeded, true)
+        XCTAssertEqual(tests["atfTest"]?.isSkipped, false)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+    }
     
     func testTMAttemptToFixFailsForFailedTest() async throws {
         let runner = tmAndAtrRunner(fix: ["atfTest"],
@@ -229,7 +271,7 @@ class TestManagementTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
     }
     
-    func testTMAttemptToFixDoesntFailForDisabledTest() async throws {
+    func testTMAttemptToFixFailsForDisabledTest() async throws {
         let runner = tmAndAtrRunner(fix: ["atfTest"], disabled: ["atfTest"],
                                     tests: ["someTest": .fail("Always fails"),
                                             "atfTest": .fail(first: 3)])
@@ -238,19 +280,19 @@ class TestManagementTests: XCTestCase {
         XCTAssertEqual(tests["atfTest"]?.runs.count, 1)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .fail }.count, 1)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .pass }.count, 0)
-        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .fail }.count, 0)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .fail }.count, 1)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 0)
         XCTAssertNil(tests["atfTest"]?.runs.first?.tags[DDEfdTags.testIsRetry])
         XCTAssertNil(tests["atfTest"]?.runs.first?.tags[DDEfdTags.testRetryReason])
         XCTAssertNil(tests["atfTest"]?.runs.last?.tags[DDTestTags.testHasFailedAllRetries])
         XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestManagementTags.testAttemptToFixPassed], "false")
         XCTAssertEqual(tests["atfTest"]?.runs.filter {
-            $0.tags[DDTestTags.testFailureSuppressionReason] == DDTagValues.failureSuppressionReasonDisabled
+            $0.tags[DDTestTags.testFailureSuppressionReason] == nil
         }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.isSucceeded, true)
+        XCTAssertEqual(tests["atfTest"]?.isSucceeded, false)
         XCTAssertEqual(tests["atfTest"]?.isSkipped, false)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
         
         XCTAssertNotNil(tests["someTest"])
         XCTAssertEqual(tests["someTest"]?.runs.count, 6)
@@ -270,7 +312,7 @@ class TestManagementTests: XCTestCase {
         XCTAssertEqual(tests["someTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
     }
     
-    func testTMAttemptToFixDoesntFailForQuarantinedTest() async throws {
+    func testTMAttemptToFixFailsForQuarantinedTest() async throws {
         let runner = tmAndAtrRunner(fix: ["atfTest"], quarantined: ["atfTest"],
                                     tests: ["someTest": .fail("Always fails"),
                                             "atfTest": .fail(first: 3)])
@@ -279,19 +321,19 @@ class TestManagementTests: XCTestCase {
         XCTAssertEqual(tests["atfTest"]?.runs.count, 1)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .fail }.count, 1)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.status == .pass }.count, 0)
-        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .fail }.count, 0)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .fail }.count, 1)
+        XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.xcStatus == .pass }.count, 0)
         XCTAssertNil(tests["atfTest"]?.runs.first?.tags[DDEfdTags.testIsRetry])
         XCTAssertNil(tests["atfTest"]?.runs.first?.tags[DDEfdTags.testRetryReason])
         XCTAssertNil(tests["atfTest"]?.runs.last?.tags[DDTestTags.testHasFailedAllRetries])
         XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestManagementTags.testAttemptToFixPassed], "false")
         XCTAssertEqual(tests["atfTest"]?.runs.filter {
-            $0.tags[DDTestTags.testFailureSuppressionReason] == DDTagValues.failureSuppressionReasonQuarantine
+            $0.tags[DDTestTags.testFailureSuppressionReason] == nil
         }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.isSucceeded, true)
+        XCTAssertEqual(tests["atfTest"]?.isSucceeded, false)
         XCTAssertEqual(tests["atfTest"]?.isSkipped, false)
         XCTAssertEqual(tests["atfTest"]?.runs.filter { $0.tags[DDTestTags.testFinalStatus] != nil }.count, 1)
-        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusPass)
+        XCTAssertEqual(tests["atfTest"]?.runs.last?.tags[DDTestTags.testFinalStatus], DDTagValues.statusFail)
         
         XCTAssertNotNil(tests["someTest"])
         XCTAssertEqual(tests["someTest"]?.runs.count, 6)


### PR DESCRIPTION
## Summary

Test Management attempt-to-fix should take precedence over quarantine and disabled status. This updates Swift Test Management so disabled or quarantined attempt-to-fix tests no longer suppress failures, and final status is based only on attempt-to-fix outcomes.

All-passing attempt-to-fix tests still report `pass`; any failing attempt reports `fail`. Non-attempt-to-fix disabled and quarantined behavior is unchanged.

## Testing

- `git diff --check`
- `swift test --filter TestManagementTests` and `swift test --filter TestManagementSwiftTestingTests` were not able to run in this local checkout because the package is binary-target-only for SwiftPM and the active developer directory is Command Line Tools rather than a full Xcode installation.