### PR TITLE
[CHORE] Fix race condition in SwiftTestingTraitTests mock SessionManager

### DIFF
--- a/Tests/DatadogSDKTesting/MockTestTypes.swift
+++ b/Tests/DatadogSDKTesting/MockTestTypes.swift
@@ -639,6 +639,7 @@ enum Mocks {
                                        config: SessionConfig)
 
         private var _session: Task<SessionWithConfig, any Error>?
+        private var _stopped: Bool = false
         let provider: any TestSessionProvider
         let _config: SessionConfig
         let _observer: (any TestSessionManagerObserver & TestModuleManagerObserver)?
@@ -671,13 +672,16 @@ enum Mocks {
         }
 
         func stop() async {
-            guard let sc = try? await _session?.value else {
-                return
-            }
+            guard !_stopped else { return }
+            _stopped = true
+            guard let sc = try? await _session?.value else { return }
             await _observer?.willFinish(session: sc.session, with: sc.config)
-            _session = nil
             sc.session.end()
             await _observer?.didFinish(session: sc.session, with: sc.config)
+            // Keep _session set so concurrent readers calling sessionAndConfig
+            // after stop() see the same (now-ended) session instead of bootstrapping
+            // a fresh empty one — that would race with parallel verification blocks
+            // inspecting session.modules.
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes intermittent `Expectation failed: session.modules[test.ddModule]?.suites[test.ddSuite] → nil` in `SwiftTestingTraitTests`.
- The trait's `provideScope` verification blocks run concurrently across the file's top-level scopes (2 suites + 3 free `@Test` funcs). When the scope ending the module called `stop()`, `Mocks.SessionManager` nilled `_session`. A slower verifier awaiting `suiteProvider.session.session` after that point would re-enter `sessionAndConfig` and bootstrap a **brand-new empty session** via `provider.startSession`, so the subsequent `session.modules[...]?.suites[...]` lookup returned nil.
- Keep `_session` set after `stop()` and gate the observer notifications with a `_stopped` flag so willFinish/didFinish/end still fire exactly once. Concurrent readers post-stop now observe the same (now-ended) session instead of a fresh one.

## Test plan
- [x] `xcodebuild test-without-building` for `SwiftTestingTraitTests`, `SwiftTestingTaggedSuiteTests`, `testFuncRetryErrorShouldFail`, `testFuncRegistration`, `zzzzFuncCancel` — 10 consecutive runs all pass, no `session.modules → nil` failures.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)