### PR TITLE
[SDTEST-3792] Rename XCTest retries so Xcode reports each as a distinct test

### DIFF
--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTrait.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTrait.swift
@@ -36,7 +36,7 @@ public struct DatadogSwiftTestingTrait: TestTrait, SuiteTrait {
     }
     
     func prepare(test: some SwiftTestingTestInfoType) async throws {
-        try await _activeProvider?.registry.register(test: test)
+        await _activeProvider?.registry.register(test: test)
     }
     
     private var _activeProvider: (any SwiftTestingSuiteProviderType)? {

--- a/Sources/DatadogSDKTesting/Utils/Log.swift
+++ b/Sources/DatadogSDKTesting/Utils/Log.swift
@@ -40,7 +40,8 @@ final class Log: Logger, @unchecked Sendable {
             let startTime = CFAbsoluteTimeGetCurrent()
             defer {
                 let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
-                print(prefix: "[Debug][DatadogSDKTesting] ", message: "Time elapsed for \(name): \(timeElapsed) s.")
+                print(prefix: "[Debug][DatadogSDKTesting] ",
+                      message: "Time elapsed for \(name): \(String(format: "%.5f", timeElapsed))s.")
             }
             return try operation()
         } else {

--- a/Sources/DatadogSDKTesting/XCTest/DDXCTestCase.swift
+++ b/Sources/DatadogSDKTesting/XCTest/DDXCTestCase.swift
@@ -253,6 +253,7 @@ final class DDXCTestRetryGroup: XCTest, DDXCTestRetryGroupType {
     private let _testMethod: Selector
     private var _skipReason: String?
     private var _nextTest: XCTestCase?
+    private var _retryCount: Int = 0
 
     init(for test: XCTestCase, observer: any DDXCTestRetryDelegate) {
         self.currentTest = test
@@ -265,24 +266,41 @@ final class DDXCTestRetryGroup: XCTest, DDXCTestRetryGroupType {
         self.observer = observer
         super.init()
     }
-    
+
     func skip(reason: String) {
         _skipReason = reason
         _nextTest = nil
     }
-    
+
     func retry() {
+        _retryCount += 1
+#if canImport(ObjectiveC)
+        // Xcode dedupes a real retry failure against the prior run's expected
+        // failure when both runs report the same test identity. Initialise
+        // each retry instance with a fresh alias selector (testFoo$2,
+        // testFoo$3, ...) that forwards to the original test body. XCTest's
+        // default -name derives from invocation.selector, so Xcode treats
+        // every retry as a separate test run. The backend still receives the
+        // original test name — see perform(_:) below.
+        let aliasName = "\(NSStringFromSelector(_testMethod))$\(_retryCount + 1)"
+        let aliasSelector = testClass.addAlias(of: _testMethod, named: aliasName)
+        _nextTest = testClass.init(selector: aliasSelector)
+#else
         _nextTest = testClass.init(selector: _testMethod)
+#endif
         _skipReason = nil
     }
-    
+
     override func perform(_ run: XCTestRun) {
         guard let groupRun = run as? DDXCTestRetryGroupRun else {
             fatalError("Wrong XCTestRun class. Expected DDXCTestRetryGroupRun")
         }
         groupRun.start()
         while let xcTest = currentTest {
-            context.suite.withActiveTest(named: xcTest.testId.test) { test in
+            // Use the group's captured original testId so the backend keeps a
+            // stable test name across retries even though xcTest.name has been
+            // suffixed ($2, $3, ...) for Xcode.
+            context.suite.withActiveTest(named: testId.test) { test in
                 let xcTestRun = DDXCTestCaseRetryRun(xcTest: xcTest, test: test, group: self)
                 xcTest.setValue(xcTestRun, forKey: "testRun")
                 groupRun.addTestRun(xcTestRun)

--- a/Sources/DatadogSDKTesting/XCTest/DDXCTestCase.swift
+++ b/Sources/DatadogSDKTesting/XCTest/DDXCTestCase.swift
@@ -282,7 +282,7 @@ final class DDXCTestRetryGroup: XCTest, DDXCTestRetryGroupType {
         // default -name derives from invocation.selector, so Xcode treats
         // every retry as a separate test run. The backend still receives the
         // original test name — see perform(_:) below.
-        let aliasName = "\(NSStringFromSelector(_testMethod))$\(_retryCount + 1)"
+        let aliasName = "\(testId.test)$\(_retryCount + 1)"
         let aliasSelector = testClass.addAlias(of: _testMethod, named: aliasName)
         _nextTest = testClass.init(selector: aliasSelector)
 #else

--- a/Sources/DatadogSDKTesting/XCTest/XCTestExtensions.swift
+++ b/Sources/DatadogSDKTesting/XCTest/XCTestExtensions.swift
@@ -18,6 +18,41 @@ extension XCTestCase {
     private static let _trimmedCharacters: CharacterSet = CharacterSet(charactersIn: "-[]")
 }
 
+#if canImport(ObjectiveC)
+extension XCTestCase {
+    /// Adds a new instance method to this class with selector `newName`. The
+    /// added method shares the original method's IMP and type encoding, so
+    /// invoking the new selector runs the same code as `original` regardless
+    /// of signature (sync, `throws`, `async`, return value).
+    ///
+    /// XCTest identifies a test by its invocation selector — XCTest's default
+    /// `-name` is computed from `[self class]` and `invocation.selector`, and
+    /// Xcode keys retry-failure dedup off that identity. Adding an alias and
+    /// initialising a retry instance with the alias selector makes Xcode
+    /// treat each retry as a separate test run while the original method's
+    /// body still runs.
+    ///
+    /// Idempotent: repeat calls with the same `newName` return the cached
+    /// selector. Returns `original` unchanged if it isn't defined on the
+    /// class.
+    @discardableResult
+    class func addAlias(of original: Selector, named newName: String) -> Selector {
+        let newSelector = NSSelectorFromString(newName)
+        if class_getInstanceMethod(self, newSelector) != nil {
+            return newSelector
+        }
+        guard let originalMethod = class_getInstanceMethod(self, original) else {
+            return original
+        }
+        class_addMethod(self,
+                        newSelector,
+                        method_getImplementation(originalMethod),
+                        method_getTypeEncoding(originalMethod))
+        return newSelector
+    }
+}
+#endif
+
 extension XCTestRun {
     var status: TestStatus {
         if hasBeenSkipped { return .skip }


### PR DESCRIPTION
## Summary

- Xcode dedupes a real retry failure against the prior run's expected failure when both runs share a test identity. That hid genuine failures emitted on the final attempt for tests routed through ATR/EFD.
- `XCTestCase.addAlias(of:named:)` (new, in `XCTestExtensions.swift`) registers an instance method whose IMP and type encoding are copied from the original test method. Works for sync, `throws`, `async`, and methods with return values.
- `DDXCTestRetryGroup.retry()` now allocates each retry instance with an alias selector (`testFoo$2`, `testFoo$3`, ...). XCTest's invocation-derived `-name` makes Xcode treat each attempt as a separate test run.
- `DDXCTestRetryGroup.perform(_:)` uses the group's captured `testId.test` (original) for `withActiveTest(named:)`, so the backend keeps a stable test name across retries.
- Bundles two unrelated drive-by cleanups: drop a stale `try` in `SwiftTestingTrait.prepare(test:)` (the call no longer throws) and format elapsed time in `Log.measure` with `%.5f`.

## Test plan

- [x] `xcodebuild test -only-testing:DatadogSDKTestingTests/DDXCTestObserverTests -only-testing:DatadogSDKTestingTests/SwiftTestingTraitTests` — green locally
- [x] Run an integration test where ATR retries a failing XCTest method; confirm Xcode surfaces every retry's final failure (no dedup against earlier expected failures) and that the backend reports a single test with the original name across attempts
- [x] Sanity-check an `async`/`throws` XCTest retry to confirm the aliased selector dispatches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)