### PR TITLE
[SDTEST-3795] Fix nested Swift Testing @Suite crash

### DIFF
--- a/IntegrationTests/Runner/UnitTests+SwiftTestingSmoke.swift
+++ b/IntegrationTests/Runner/UnitTests+SwiftTestingSmoke.swift
@@ -115,6 +115,15 @@ struct UnitTestsSwiftTestingSmoke: IntergationTestSuite {
             #expect(meta[DDTestTags.testSuite] == "STNestedSuite.Inner")
             #expect(meta[DDTestTags.testType] == "test")
 
+            // Source location was resolved for the nested test: function-lines
+            // lookup keys are `<ddSuite>.<ddName>`, which the FileLocator's
+            // last-dot split produces from the dsym symbol
+            // `STNestedSuite.Inner.nestedPass()`.
+            let sourceFile = meta[DDTestTags.testSourceFile] ?? ""
+            #expect(sourceFile.hasSuffix("SwiftTestingSmokeTests.swift"))
+            #expect((meta[DDTestTags.testSourceStartLine] ?? "0") != "0")
+            #expect((meta[DDTestTags.testSourceEndLine] ?? "0") != "0")
+
             // Only the leaf suite that actually owns the test should emit a
             // `test_suite_end` event. The outer `STNestedSuite` container
             // should not produce one of its own.

--- a/IntegrationTests/Runner/UnitTests+SwiftTestingSmoke.swift
+++ b/IntegrationTests/Runner/UnitTests+SwiftTestingSmoke.swift
@@ -102,6 +102,32 @@ struct UnitTestsSwiftTestingSmoke: IntergationTestSuite {
         }
     }
 
+    @Test func nestedSuitePass() async throws {
+        try await run(test: "STNestedSuite/Inner/nestedPass()") { backend, success in
+            let spans = backend.allTestSpans
+            let suiteEnds = backend.allSuiteEnds
+            #expect(success == true)
+            #expect(spans.count == 1)
+            let meta = try #require(spans.last?.meta)
+            #expect(meta[DDTestTags.testStatus] == DDTagValues.statusPass)
+            #expect(meta[DDGenericTags.resource] == "STNestedSuite.Inner.nestedPass")
+            #expect(meta[DDTestTags.testName] == "nestedPass")
+            #expect(meta[DDTestTags.testSuite] == "STNestedSuite.Inner")
+            #expect(meta[DDTestTags.testType] == "test")
+
+            // Only the leaf suite that actually owns the test should emit a
+            // `test_suite_end` event. The outer `STNestedSuite` container
+            // should not produce one of its own.
+            let emittedSuites = suiteEnds.map(\.resource).sorted()
+            #expect(emittedSuites == ["STNestedSuite.Inner"])
+
+            // Exactly one module_end and one session_end should be emitted
+            // for a single-test run, regardless of suite nesting.
+            #expect(backend.allModuleEnds.count == 1)
+            #expect(backend.allSessionEnds.count == 1)
+        }
+    }
+
     @Test func networkIntegration() async throws {
         try await run(test: "STNetworkIntegration/networkIntegration()") { backend, success in
             let testSpans = backend.allTestSpans

--- a/IntegrationTests/UnitTests/SwiftTestingSmokeTests.swift
+++ b/IntegrationTests/UnitTests/SwiftTestingSmokeTests.swift
@@ -71,6 +71,14 @@ import DatadogSDKTesting
 }
 
 
+@Suite(.datadogTesting) struct STNestedSuite {
+    struct Inner {
+        @Test func nestedPass() {
+            #expect(Bool(true))
+        }
+    }
+}
+
 @Suite(.datadogTesting) struct STCrash {
     @Test func crash() {
         let array: [Int] = [1]

--- a/Sources/DatadogSDKTesting/DDTest.swift
+++ b/Sources/DatadogSDKTesting/DDTest.swift
@@ -143,6 +143,7 @@ extension Test {
                                _ action: @Sendable (Test) async throws -> T) async rethrows -> T
     {
         let testStartTime = start ?? suite.configuration.clock.now
+        suite.recordTestStarted()
         return try await DDTestMonitor.tracer.withActiveSpan(name: "\(suite.testFramework.name).test",
                                                              attributes: attributes(test: name, in: suite),
                                                              startTime: testStartTime) { span in
@@ -154,11 +155,12 @@ extension Test {
             return result
         }
     }
-    
+
     static func withActiveTest<T>(named name: String, in suite: Suite, at start: Date? = nil,
                                _ action: (Test) throws -> T) rethrows -> T
     {
         let testStartTime = start ?? suite.configuration.clock.now
+        suite.recordTestStarted()
         return try DDTestMonitor.tracer.withActiveSpan(name: "\(suite.testFramework.name).test",
                                                        attributes: attributes(test: name, in: suite),
                                                        startTime: testStartTime) { span in

--- a/Sources/DatadogSDKTesting/DDTestModule.swift
+++ b/Sources/DatadogSDKTesting/DDTestModule.swift
@@ -79,7 +79,7 @@ public final class Module: NSObject, Encodable {
         DDTestMonitor.tracer.eventsExporter?.exportEvent(event: ModuleEnvelope(self))
         configuration.log.debug("Exported module_end event moduleId: \(self.id)")
     }
-    
+
     func addFramework(_ name: String) {
         let _ = _state.update { $0.testFrameworks.insert(name) }
         _session.addFramework(name)

--- a/Sources/DatadogSDKTesting/DDTestSuite.swift
+++ b/Sources/DatadogSDKTesting/DDTestSuite.swift
@@ -215,7 +215,7 @@ extension Suite {
             try container.encode(state.meta, forKey: .meta)
             try container.encode(state.metrics, forKey: .metrics)
             try container.encode(state.status == .fail ? 1 : 0, forKey: .error)
-            try container.encode("\(testFramework).suite", forKey: .name)
+            try container.encode("\(testFramework.name).suite", forKey: .name)
             try container.encode(name, forKey: .resource)
             try container.encode(configuration.service, forKey: .service)
         }

--- a/Sources/DatadogSDKTesting/DDTestSuite.swift
+++ b/Sources/DatadogSDKTesting/DDTestSuite.swift
@@ -14,6 +14,7 @@ public final class Suite: NSObject, Encodable {
         var meta: [String: String] = [:]
         var metrics: [String: Double] = [:]
         var status: TestStatus = .pass
+        var testsStarted: Int = 0
     }
     
     public let name: String
@@ -75,12 +76,24 @@ public final class Suite: NSObject, Encodable {
 
     private func internalEnd(endTime: Date? = nil) {
         let duration = (endTime ?? configuration.clock.now).timeIntervalSince(startTime).toNanoseconds
-        _state.update { state in
+        let shouldExport: Bool = _state.update { state in
             state.duration = duration
             state.meta[DDTestTags.testStatus] = state.status.spanAttribute
+            return state.testsStarted > 0
+        }
+        // Don't emit a `test_suite_end` event for suites in which no tests
+        // actually ran. This happens for container types that only enclose
+        // nested @Suite types, and for XCTest's empty wrapper suites.
+        guard shouldExport else {
+            Log.debug("Skipped suite_end event for empty suite \(name) (id: \(self.id))")
+            return
         }
         DDTestMonitor.tracer.eventsExporter?.exportEvent(event: SuiteEnvelope(self))
         Log.debug("Exported suite_end event suiteId: \(self.id)")
+    }
+
+    func recordTestStarted() {
+        _state.update { $0.testsStarted += 1 }
     }
 
     /// Ends the test suite 

--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTrait.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTrait.swift
@@ -227,8 +227,16 @@ extension DatadogSwiftTestingScopeProvider {
 }
 
 extension Testing.Test {
-    var ddModule: String { id.moduleName }
-    
+    /// Module identifier used by the registry, module manager, and span tags.
+    /// Underscores are normalized to hyphens so that Swift Testing's
+    /// `id.moduleName` (e.g. `"My_Tests"`) and XCTest's `Bundle.name` (e.g.
+    /// `"My-Tests"`) collapse to the same canonical name. Without this both
+    /// framework paths produce two `Module` instances for the same bundle.
+    var ddModule: String {
+        id.moduleName.replacingOccurrences(of: "_", with: "-")
+    }
+
+
     var ddHasSuite: Bool {
         let components = id.nameComponents
         return components.count > 1 || components.first?.last != ")"
@@ -242,12 +250,18 @@ extension Testing.Test {
     }
     
     var ddSuite: String {
-        guard !isSuite else { return name }
-        if ddHasSuite {
-            return id.nameComponents.first!
-        } else {
+        let components = id.nameComponents
+        // For test functions, the trailing component is the function signature
+        // (ends with ")"). Drop it to obtain the enclosing type chain. For
+        // suite Tests every component is a type name and is kept. Nested
+        // types produce a dotted chain like "Outer.Inner".
+        let typeChain = isSuite || components.last?.last != ")"
+            ? components
+            : Array(components.dropLast())
+        guard !typeChain.isEmpty else {
             return "[\(sourceLocation.fileName.replacingOccurrences(of: ".swift", with: ""))]"
         }
+        return typeChain.joined(separator: ".")
     }
 }
 

--- a/Sources/DatadogSDKTesting/XCTest/DDXCTestObserver.swift
+++ b/Sources/DatadogSDKTesting/XCTest/DDXCTestObserver.swift
@@ -44,8 +44,13 @@ final class DDXCTestObserver: NSObject, XCTestObservation, DDXCTestRetryDelegate
             return
         }
         
-        let bundleName = testBundle.name
-        
+        // Normalize underscores to hyphens so this matches Swift Testing's
+        // `ddModule` (which derives from the Swift module name where any `-`
+        // in the original product name became `_`). Both paths must converge
+        // on the same identifier or `StatefulManager.module(named:)` creates
+        // two `Module` instances for the same bundle.
+        let bundleName = testBundle.name.replacingOccurrences(of: "_", with: "-")
+
         do {
             let session = try waitForAsync { try await manager.sessionAndConfig }
             let module = session.session.module(named: bundleName)
@@ -65,8 +70,9 @@ final class DDXCTestObserver: NSObject, XCTestObservation, DDXCTestRetryDelegate
             return
         }
         state = .stopping
-        guard module.name == testBundle.name else {
-            log.print("testBundleDidFinish: Bad module: \(testBundle.name), expected: \(module.name)")
+        let bundleName = testBundle.name.replacingOccurrences(of: "_", with: "-")
+        guard module.name == bundleName else {
+            log.print("testBundleDidFinish: Bad module: \(bundleName), expected: \(module.name)")
             return
         }
         context.session.end(module: module)

--- a/Tests/DatadogSDKTesting/SwiftTestingTraitTests.swift
+++ b/Tests/DatadogSDKTesting/SwiftTestingTraitTests.swift
@@ -15,14 +15,14 @@ import Testing
 struct SwiftTestingTraitTests {
     enum TestError: Error {
         case test(String)
-        
+
         var name: String {
             switch self {
             case .test(let name): return name
             }
         }
     }
-    
+
     @Test
     func scopingTraitIsApplied() async throws {
         #expect(Testing.Test.current?.ddSuite == "\(type(of: self))")
@@ -31,52 +31,52 @@ struct SwiftTestingTraitTests {
         #expect(framework.name == "Testing")
         #expect(framework.version == PlatformUtils.getSwiftTestingVersion())
     }
-    
+
     @Test
     func testSkip() async throws {
-        #expect(1 == 0, Comment(rawValue: Testing.Test.current!.ddName))
+        #expect(1 == 0, Comment(rawValue: Testing.Test.current!.ddFullName))
     }
-    
+
     @Test()
     func testRetryIgnore() async throws {
-        #expect(1 == 0, Comment(rawValue: Testing.Test.current!.ddName))
+        #expect(1 == 0, Comment(rawValue: Testing.Test.current!.ddFullName))
     }
-    
+
     @Test
     func testRetryShouldFail() async throws {
-        #expect(1 == 0, Comment(rawValue: Testing.Test.current!.ddName))
+        #expect(1 == 0, Comment(rawValue: Testing.Test.current!.ddFullName))
     }
-    
+
     @Test
     func testRetryErrorIgnore() async throws {
-        throw TestError.test(Testing.Test.current!.ddName)
+        throw TestError.test(Testing.Test.current!.ddFullName)
     }
-    
+
     @Test
     func testRetryErrorShouldFail() async throws {
-        throw TestError.test(Testing.Test.current!.ddName)
+        throw TestError.test(Testing.Test.current!.ddFullName)
     }
-    
+
     @Test
     func testPass() async throws {
-        #expect(1 == 1, Comment(rawValue: Testing.Test.current!.ddName))
+        #expect(1 == 1, Comment(rawValue: Testing.Test.current!.ddFullName))
     }
-    
+
     @Test
     func testShouldFail() async throws {
-        #expect(1 == 0, Comment(rawValue: Testing.Test.current!.ddName))
+        #expect(1 == 0, Comment(rawValue: Testing.Test.current!.ddFullName))
     }
-    
+
     @Test
     func testError() async throws {
-        throw TestError.test(Testing.Test.current!.ddName)
+        throw TestError.test(Testing.Test.current!.ddFullName)
     }
-    
+
     @Test
     func testErrorIgnore() async throws {
-        throw TestError.test(Testing.Test.current!.ddName)
+        throw TestError.test(Testing.Test.current!.ddFullName)
     }
-    
+
     @Test(arguments: zip([1, 2, 3], ["1", "2", "3"]))
     func testParameterized(p1: Int, p2: String) async throws {
         #expect("\(p1)" == p2)
@@ -113,7 +113,7 @@ struct SwiftTestingTaggedSuiteTests {
 
 @Test(.observerTester, .datadogTesting)
 func testFuncRetryErrorShouldFail() async throws {
-    throw SwiftTestingTraitTests.TestError.test(Testing.Test.current!.ddName)
+    throw SwiftTestingTraitTests.TestError.test(Testing.Test.current!.ddFullName)
 }
 
 @Test(.observerTester, .datadogTesting)
@@ -124,9 +124,39 @@ func testFuncRegistration() async throws {
 #if compiler(>=6.3)
 @Test(.observerTester, .datadogTesting)
 func zzzzFuncCancel() async throws {
-    try Testing.Test.cancel(Comment(rawValue: Testing.Test.current!.ddName))
+    try Testing.Test.cancel(Comment(rawValue: Testing.Test.current!.ddFullName))
 }
 #endif
+
+private extension Testing.Test {
+    /// Suite-qualified test identifier (e.g. `"SwiftTestingTraitTests.testPass"`)
+    /// used as the unique key in `ObserverTesterTrait`'s expected map and the
+    /// payload carried by issues raised inside tests.
+    var ddFullName: String { "\(ddSuite).\(ddName)" }
+}
+
+
+/// Verifies that `ddSuite` joins the full enclosing-type chain into a dotted
+/// path (e.g. `"Outer.Inner"`) so nested `@Suite` types don't collide on the
+/// outermost type name in the registry and function-lines lookup.
+@Suite(.observerTester, .datadogTesting)
+struct DDSuiteNamingTests {
+    @Test func topLevelSuiteName() async throws {
+        #expect(Testing.Test.current?.ddSuite == "DDSuiteNamingTests")
+    }
+
+    struct NestedSuite {
+        @Test func nestedSuiteName() async throws {
+            #expect(Testing.Test.current?.ddSuite == "DDSuiteNamingTests.NestedSuite")
+        }
+
+        struct DoublyNestedSuite {
+            @Test func doublyNestedSuiteName() async throws {
+                #expect(Testing.Test.current?.ddSuite == "DDSuiteNamingTests.NestedSuite.DoublyNestedSuite")
+            }
+        }
+    }
+}
 
 private final class MockSwiftTestingObserver: SwiftTestingObserverType {
     func willStart(suite: borrowing SwiftTestingSuiteContext) async {}
@@ -312,36 +342,44 @@ private struct ObserverTesterTrait: SuiteTrait, TestTrait, TestScoping {
         let errors = issues.value
         let cancels = cancelled.value
         
+        // Keyed by the suite-qualified test name (`"<ddSuite>.<ddName>"`) so
+        // tests that share a function name across nested suites don't collide.
         let expected: [String: (status: [TestStatus], errors: Int?, cancelled: Bool?)] = [
-            "scopingTraitIsApplied": ([.pass], nil, nil),
-            "testSkip": ([.skip], nil, nil),
-            "testRetryIgnore": (Array(repeating: .fail, count: 5), nil, nil),
-            "testRetryShouldFail": (Array(repeating: .fail, count: 5), 1, nil),
-            "testRetryErrorIgnore": (Array(repeating: .fail, count: 5), nil, nil),
-            "testRetryErrorShouldFail": (Array(repeating: .fail, count: 5), 1, nil),
-            "testPass": ([.pass], nil, nil),
-            "testShouldFail": ([.fail], 1, nil),
-            "testError": ([.fail], 1, nil),
-            "testErrorIgnore": ([.fail], nil, nil),
-            "testFuncRetryErrorShouldFail": (Array(repeating: .fail, count: 5), 1, nil),
-            "testFuncRegistration": ([.pass], nil, nil),
-            "testParameterized(p1:p2:)": (Array(repeating: .pass, count: 3), nil, nil),
-            "testRetriableTagObtainedFromSwiftTestingTags": ([.pass], nil, nil),
-            "testTiaSkippableTagObtainedFromSwiftTestingTags": ([.pass], nil, nil),
-            "testRetriableTagOverridesSuiteNonretriableTag": ([.pass], nil, nil),
-            "testSkippableTagOverridesSuiteUnskippableTag": ([.pass], nil, nil),
-            "zzzzFuncCancel": ([.skip], nil, true)
+            "SwiftTestingTraitTests.scopingTraitIsApplied": ([.pass], nil, nil),
+            "SwiftTestingTraitTests.testSkip": ([.skip], nil, nil),
+            "SwiftTestingTraitTests.testRetryIgnore": (Array(repeating: .fail, count: 5), nil, nil),
+            "SwiftTestingTraitTests.testRetryShouldFail": (Array(repeating: .fail, count: 5), 1, nil),
+            "SwiftTestingTraitTests.testRetryErrorIgnore": (Array(repeating: .fail, count: 5), nil, nil),
+            "SwiftTestingTraitTests.testRetryErrorShouldFail": (Array(repeating: .fail, count: 5), 1, nil),
+            "SwiftTestingTraitTests.testPass": ([.pass], nil, nil),
+            "SwiftTestingTraitTests.testShouldFail": ([.fail], 1, nil),
+            "SwiftTestingTraitTests.testError": ([.fail], 1, nil),
+            "SwiftTestingTraitTests.testErrorIgnore": ([.fail], nil, nil),
+            "SwiftTestingTraitTests.testParameterized(p1:p2:)": (Array(repeating: .pass, count: 3), nil, nil),
+            "SwiftTestingTaggedSuiteTests.testRetriableTagObtainedFromSwiftTestingTags": ([.pass], nil, nil),
+            "SwiftTestingTaggedSuiteTests.testTiaSkippableTagObtainedFromSwiftTestingTags": ([.pass], nil, nil),
+            "SwiftTestingTaggedSuiteTests.testRetriableTagOverridesSuiteNonretriableTag": ([.pass], nil, nil),
+            "SwiftTestingTaggedSuiteTests.testSkippableTagOverridesSuiteUnskippableTag": ([.pass], nil, nil),
+            "DDSuiteNamingTests.topLevelSuiteName": ([.pass], nil, nil),
+            "DDSuiteNamingTests.NestedSuite.nestedSuiteName": ([.pass], nil, nil),
+            "DDSuiteNamingTests.NestedSuite.DoublyNestedSuite.doublyNestedSuiteName": ([.pass], nil, nil),
+            "[SwiftTestingTraitTests].testFuncRetryErrorShouldFail": (Array(repeating: .fail, count: 5), 1, nil),
+            "[SwiftTestingTraitTests].testFuncRegistration": ([.pass], nil, nil),
+            "[SwiftTestingTraitTests].zzzzFuncCancel": ([.skip], nil, true)
         ]
-        
-        // If we have a suite we should check for all tests.
-        // If we have function we need check only for function, scope will be called for each
-        let testsList = test.isSuite ? suite : [test.ddName]
-        for test in testsList {
-            let expect = try #require(expected[test])
-            let status = try #require(statuses[test]).runs.map { $0.status }
+
+        // If we have a suite we should check for all tests it owns.
+        // If we have a function we only check that function; the framework
+        // invokes provideScope separately for each test.
+        let suiteName = test.ddSuite
+        let testNames: [String] = test.isSuite ? Array(suite) : [test.ddName]
+        for testName in testNames {
+            let fullName = "\(suiteName).\(testName)"
+            let expect = try #require(expected[fullName], "missing expectation for \(fullName)")
+            let status = try #require(statuses[testName]).runs.map { $0.status }
             #expect(status == expect.status)
-            #expect(errors[test] == expect.errors)
-            #expect(cancels[test] == expect.cancelled)
+            #expect(errors[fullName] == expect.errors)
+            #expect(cancels[fullName] == expect.cancelled)
         }
         
         let decoder = JSONDecoder()

--- a/Tests/TestUtils/MockBackend.swift
+++ b/Tests/TestUtils/MockBackend.swift
@@ -76,6 +76,12 @@ public final class MockBackend {
         public var allInfoSpans: [Span] { spanEnvelopes.flatMap(\.infoSpans) }
         /// All test-type spans across all received envelopes.
         public var allTestSpans: [Span] { spanEnvelopes.flatMap(\.testSpans) }
+        /// All `test_suite_end` events across all received envelopes.
+        public var allSuiteEnds: [TestSpan] { spanEnvelopes.flatMap(\.suiteEndEvents) }
+        /// All `test_module_end` events across all received envelopes.
+        public var allModuleEnds: [TestSpan] { spanEnvelopes.flatMap(\.moduleEndEvents) }
+        /// All `test_session_end` events across all received envelopes.
+        public var allSessionEnds: [TestSpan] { spanEnvelopes.flatMap(\.sessionEndEvents) }
 
         /// All individual log entries across all batches.
         public var allLogs: [Log] { logs.flatMap { $0 } }
@@ -406,7 +412,13 @@ extension MockBackend {
         /// Only events with type == "test".
         public var testSpans: [Span] { extended.filter { $0.isTest }.compactMap(\.span) }
         /// Only end events
-        public var testEvents: [TestSpan] { extended.filter { $0.isEvent }.compactMap(\.event) }
+        public var allEndEvents: [TestSpan] { extended.filter { $0.isEndEvent }.compactMap(\.event) }
+        /// Only suite_end events
+        public var suiteEndEvents: [TestSpan] { extended.filter { $0.isSuiteEndEvent }.compactMap(\.event) }
+        /// Only module_end events
+        public var moduleEndEvents: [TestSpan] { extended.filter { $0.isModuleEndEvent }.compactMap(\.event) }
+        /// Only session_end events
+        public var sessionEndEvents: [TestSpan] { extended.filter { $0.isSessionEndEvent }.compactMap(\.event) }
     }
     
     public enum SpanEvent: Decodable, Sendable {
@@ -430,9 +442,30 @@ extension MockBackend {
             }
         }
         
-        var isEvent: Bool {
+        var isEndEvent: Bool {
             switch self {
             case .moduleEnd, .suiteEnd, .sessionEnd: return true
+            default: return false
+            }
+        }
+        
+        var isSuiteEndEvent: Bool {
+            switch self {
+            case .suiteEnd: return true
+            default: return false
+            }
+        }
+        
+        var isModuleEndEvent: Bool {
+            switch self {
+            case .moduleEnd: return true
+            default: return false
+            }
+        }
+        
+        var isSessionEndEvent: Bool {
+            switch self {
+            case .sessionEnd: return true
             default: return false
             }
         }


### PR DESCRIPTION
## Summary
- Fixes [SDTEST-3795](https://datadoghq.atlassian.net/browse/SDTEST-3795) / [issue #252](https://github.com/DataDog/dd-sdk-swift-testing/issues/252): nested `@Suite` types crashed when `.datadogTesting` was applied, because the trait keyed tests by the outermost type only while suite registration used the innermost, so the inner suite ran tests it had never been told about.
- `Testing.Test.ddSuite` now joins the full enclosing-type chain (e.g. `Outer.Inner`) so the registry, function-lines lookup, and span tags all agree on one identifier per suite.
- Module name is normalized by replacing `_` with `-` in both the Swift Testing (`ddModule`) and XCTest (`bundleName`) paths, so the same bundle yields a single `Module` instance no matter which framework reaches `module(named:)` first.
- `Suite.internalEnd` skips `test_suite_end` emission when no tests started in that suite — container types that only enclose nested `@Suite`s and the XCTest wrapper-suite no longer generate empty suite events.

## Test plan
- [x] `DDSuiteNamingTests` — new unit tests assert `ddSuite` returns the full dotted chain for top-level, single-nested, and doubly-nested suites.
- [x] `ObserverTesterTrait` now keys its expected dictionary by suite-qualified test name to avoid collisions across nested suites.
- [x] `nestedSuitePass` integration test (`IntegrationTests-UnitTests`) asserts: one `test_suite_end` (`STNestedSuite.Inner`), one `test_module_end`, one `test_session_end`.
- [x] FileLocator fixture coverage already includes dotted-module symbols (`Mocks.TestBase.set(skipped:)`), so nested-type symbol lookup works without further changes.
- [x] Run the full unit + integration suites across all platforms before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDTEST-3795]: https://datadoghq.atlassian.net/browse/SDTEST-3795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ