### PR TITLE
[CHORE] Parallelize release tests and clarify CI job names

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -1,0 +1,53 @@
+name: Setup Xcode
+description: Select an Xcode version and resolve the matching simulator names.
+
+inputs:
+  version:
+    description: Xcode app name without the `.app` suffix (e.g. `Xcode_26.1`).
+    required: true
+
+outputs:
+  ios-simulator:
+    description: iOS simulator destination name.
+    value: ${{ steps.simulators.outputs.ios }}
+  tvos-simulator:
+    description: tvOS simulator destination name.
+    value: ${{ steps.simulators.outputs.tvos }}
+  watchos-simulator:
+    description: watchOS simulator destination name.
+    value: ${{ steps.simulators.outputs.watchos }}
+  visionos-simulator:
+    description: visionOS simulator destination name.
+    value: ${{ steps.simulators.outputs.visionos }}
+
+runs:
+  using: composite
+  steps:
+    - name: Select ${{ inputs.version }}
+      shell: bash
+      run: sudo xcode-select --switch "/Applications/${{ inputs.version }}.app"
+
+    - name: Resolve simulators for ${{ inputs.version }}
+      id: simulators
+      shell: bash
+      env:
+        XCODE_VERSION: ${{ inputs.version }}
+      run: |
+        case "$XCODE_VERSION" in
+          Xcode_26.1 | Xcode_26.2 | Xcode_26.4)
+            ios="iPhone 17"
+            tvos="Apple TV"
+            watchos="Apple Watch Series 11 (46mm)"
+            visionos="Apple Vision Pro"
+            ;;
+          *)
+            echo "::error::Unknown Xcode version '$XCODE_VERSION' — add it to .github/actions/setup-xcode/action.yml" >&2
+            exit 1
+            ;;
+        esac
+        {
+          echo "ios=$ios"
+          echo "tvos=$tvos"
+          echo "watchos=$watchos"
+          echo "visionos=$visionos"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -11,22 +11,38 @@ on:
 permissions:
   contents: read
 
+env:
+  XCODE_VERSION: Xcode_26.1
+
 jobs:
   test:
-    name: Run Tests
+    name: ${{ env.XCODE_VERSION }} / ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ["macOS", "iOSsim", "tvOSsim", "watchOSsim", "visionOSsim"]
     runs-on: macos-26
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Select Xcode 26.1
-      run: sudo xcode-select --switch /Applications/Xcode_26.1.app
+    - name: Setup ${{ env.XCODE_VERSION }}
+      id: xcode
+      uses: ./.github/actions/setup-xcode
+      with:
+        version: ${{ env.XCODE_VERSION }}
     - name: Test
-      run: make XC_LOG=tests IOS_SIMULATOR="iPhone 17" TVOS_SIMULATOR="Apple TV" WATCHOS_SIMULATOR="Apple Watch Series 11 (46mm)" VISIONOS_SIMULATOR="Apple Vision Pro" tests
+      run: >-
+        make XC_LOG=tests
+        IOS_SIMULATOR="${{ steps.xcode.outputs.ios-simulator }}"
+        TVOS_SIMULATOR="${{ steps.xcode.outputs.tvos-simulator }}"
+        WATCHOS_SIMULATOR="${{ steps.xcode.outputs.watchos-simulator }}"
+        VISIONOS_SIMULATOR="${{ steps.xcode.outputs.visionos-simulator }}"
+        tests/unit/${{ matrix.platform }}
     - name: Attach Xcode logs
       if: '!cancelled()'
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: xcode-tests-logs
+        name: ${{ env.XCODE_VERSION }}-${{ matrix.platform }}-tests-logs
         path: "*-tests.log"
 
   release:
@@ -46,8 +62,10 @@ jobs:
       with:
         scope: DataDog/dd-sdk-swift-testing
         policy: self.github.create-release.workflow-dispatch
-    - name: Select Xcode 26.1
-      run: sudo xcode-select --switch /Applications/Xcode_26.1.app
+    - name: Setup ${{ env.XCODE_VERSION }}
+      uses: ./.github/actions/setup-xcode
+      with:
+        version: ${{ env.XCODE_VERSION }}
     - name: Fix git repo url with obtained token
       env:
         GH_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   test:
-    name: ${{ env.XCODE_VERSION }} / ${{ matrix.platform }}
+    name: Test / ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +80,7 @@ jobs:
       with:
         name: xcode-archive-logs
         path: "*-archive.log"
-  
+
   publish-pod:
     name: Publish Pod
     needs: [release]

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -11,38 +11,29 @@ jobs:
     uses: ./.github/workflows/unitTests.yml
 
   integration:
-    name: Run Integration Tests
+    name: ${{ matrix.xcode }} / ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
-        env:
-          - xcode: "Xcode_26.1"
-            os: "macos-26"
-            iossim: "iPhone 17"
-            tvossim: "Apple TV"
-            watchossim: "Apple Watch Series 11 (46mm)"
-            visionossim: "Apple Vision Pro"
-          - xcode: "Xcode_26.2"
-            os: "macos-26"
-            iossim: "iPhone 17"
-            tvossim: "Apple TV"
-            watchossim: "Apple Watch Series 11 (46mm)"
-            visionossim: "Apple Vision Pro"
-          - xcode: "Xcode_26.4"
-            os: "macos-26"
-            iossim: "iPhone 17"
-            tvossim: "Apple TV"
-            watchossim: "Apple Watch Series 11 (46mm)"
-            visionossim: "Apple Vision Pro"
+        xcode: ["Xcode_26.1", "Xcode_26.2", "Xcode_26.4"]
         platform: ["macOS", "iOSsim", "tvOSsim", "watchOSsim", "visionOSsim"]
-    runs-on: ${{ matrix.env.os }}
+    runs-on: macos-26
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Select ${{ matrix.env.xcode }}
-      run: sudo xcode-select --switch /Applications/${{ matrix.env.xcode }}.app
+    - name: Setup ${{ matrix.xcode }}
+      id: xcode
+      uses: ./.github/actions/setup-xcode
+      with:
+        version: ${{ matrix.xcode }}
     - name: Run tests for ${{ matrix.platform }}
-      run: make XC_LOG=integration IOS_SIMULATOR="${{ matrix.env.iossim }}" TVOS_SIMULATOR="${{ matrix.env.tvossim }}" WATCHOS_SIMULATOR="${{ matrix.env.watchossim }}" VISIONOS_SIMULATOR="${{ matrix.env.visionossim }}" tests/integration/${{ matrix.platform }}
+      run: >-
+        make XC_LOG=integration
+        IOS_SIMULATOR="${{ steps.xcode.outputs.ios-simulator }}"
+        TVOS_SIMULATOR="${{ steps.xcode.outputs.tvos-simulator }}"
+        WATCHOS_SIMULATOR="${{ steps.xcode.outputs.watchos-simulator }}"
+        VISIONOS_SIMULATOR="${{ steps.xcode.outputs.visionos-simulator }}"
+        tests/integration/${{ matrix.platform }}
       env:
         DD_API_KEY: '${{ secrets.DD_API_KEY }}'
         DD_TEST_RUNNER: 1
@@ -50,5 +41,5 @@ jobs:
       if: '!cancelled()'
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: ${{ matrix.env.xcode }}-${{ matrix.platform }}-integration-log
+        name: ${{ matrix.xcode }}-${{ matrix.platform }}-integration-log
         path: "logs-integration/*.log"

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -10,47 +10,32 @@ on:
 
 jobs:
   unit:
-    name: ${{ matrix.env.xcode }} / ${{ matrix.platform }}
+    name: ${{ matrix.xcode }} / ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
-        env:
-          - xcode: "Xcode_26.1"
-            os: "macos-26"
-            iossim: "iPhone 17"
-            tvossim: "Apple TV"
-            watchossim: "Apple Watch Series 11 (46mm)"
-            visionossim: "Apple Vision Pro"
-          - xcode: "Xcode_26.2"
-            os: "macos-26"
-            iossim: "iPhone 17"
-            tvossim: "Apple TV"
-            watchossim: "Apple Watch Series 11 (46mm)"
-            visionossim: "Apple Vision Pro"
-          - xcode: "Xcode_26.4"
-            os: "macos-26"
-            iossim: "iPhone 17"
-            tvossim: "Apple TV"
-            watchossim: "Apple Watch Series 11 (46mm)"
-            visionossim: "Apple Vision Pro"
+        xcode: ["Xcode_26.1", "Xcode_26.2", "Xcode_26.4"]
         platform: ["macOS", "iOSsim", "tvOSsim", "watchOSsim", "visionOSsim"]
-    runs-on: ${{ matrix.env.os }}
+    runs-on: macos-26
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Select ${{ matrix.env.xcode }}
-      run: sudo xcode-select --switch /Applications/${{ matrix.env.xcode }}.app
+    - name: Setup ${{ matrix.xcode }}
+      id: xcode
+      uses: ./.github/actions/setup-xcode
+      with:
+        version: ${{ matrix.xcode }}
     - name: Unit tests
       run: >-
         make XC_LOG=unit
-        IOS_SIMULATOR="${{ matrix.env.iossim }}"
-        TVOS_SIMULATOR="${{ matrix.env.tvossim }}"
-        WATCHOS_SIMULATOR="${{ matrix.env.watchossim }}"
-        VISIONOS_SIMULATOR="${{ matrix.env.visionossim }}"
+        IOS_SIMULATOR="${{ steps.xcode.outputs.ios-simulator }}"
+        TVOS_SIMULATOR="${{ steps.xcode.outputs.tvos-simulator }}"
+        WATCHOS_SIMULATOR="${{ steps.xcode.outputs.watchos-simulator }}"
+        VISIONOS_SIMULATOR="${{ steps.xcode.outputs.visionos-simulator }}"
         tests/unit/${{ matrix.platform }}
     - name: Attach Xcode logs
       if: '!cancelled()'
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: ${{ matrix.env.xcode }}-${{ matrix.platform }}-unit-logs
+        name: ${{ matrix.xcode }}-${{ matrix.platform }}-unit-logs
         path: "*-unit.log"


### PR DESCRIPTION
## Summary
- Release workflow now runs unit tests in parallel by platform (matrix), matching `unitTests.yml`.
- Job names in `unitTests.yml` and `integrationTests.yml` now show `Xcode_X.Y / platform`, including when `unitTests.yml` is called as a reusable workflow from `integrationTests.yml` (previously the Xcode version was dropped because the matrix used a nested `env` object — switched to scalar `xcode` / `platform` keys).
- Added `.github/actions/setup-xcode` composite action that selects an Xcode version and emits the matching simulator names as outputs, so the version→simulator mapping lives in a single file instead of being duplicated across each workflow.
- `createRelease.yml` hoists the Xcode version into a workflow-level `XCODE_VERSION` env var so it can be bumped once.

## Test plan
- [x] Open a PR (unit tests run) and confirm each unit job appears as `Xcode_26.X / <platform>` in checks.
- [x] Manually dispatch `Integration Tests` and confirm the `unit / Xcode_26.X / <platform>` and `integration / Xcode_26.X / <platform>` jobs show the Xcode version in their names.
- [ ] Manually dispatch `Create new release` against a throwaway version and confirm the `test` job fans out into five platform-specific jobs.
- [ ] Confirm the composite action fails with a clear message if given an unknown Xcode version (e.g. by temporarily passing `Xcode_99.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)