### PR TITLE
[SDTEST-3769] Telemetry API wrapper (metrics, logs, batches, app lifecycle)

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -13,8 +13,10 @@
 		3B086A157E782A8DCA702976 /* LogsApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = D969899DDA68AF3C690F7FF8 /* LogsApi.swift */; };
 		476CBA69A1DF07E74A0E7311 /* KnownTestsApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1531A96019132E3E9E96A3A7 /* KnownTestsApi.swift */; };
 		4B08F62941D9EB26E5DF3837 /* TestImpactAnalysisApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */; };
+		56B58A2FC91F21D1ABB0155E /* TelemetryApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EB970146040DD4967C7411 /* TelemetryApi.swift */; };
 		821FA0CC8B62245A4949FDBB /* APITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85241CF97F1B6DAA49ECA23 /* APITypes.swift */; };
 		8EF6F88255506A4CEE6D36B6 /* GitUploadApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */; };
+		98D8D496CC4210A0D1D07F93 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12536CCE14EC1D3DAAC8DB81 /* Synced.swift */; };
 		A70B91132DF0AE19003F284F /* AutoTestRetriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70B91122DF0AE11003F284F /* AutoTestRetriesTests.swift */; };
 		A7183A782E9030630093C831 /* CodeCoverageParser in Frameworks */ = {isa = PBXBuildFile; productRef = A7183A772E9030630093C831 /* CodeCoverageParser */; };
 		A718EC2D2CBD5DCE00C5F0D9 /* EarlyFlakeDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A718EC2C2CBD5DCE00C5F0D9 /* EarlyFlakeDetection.swift */; };
@@ -126,7 +128,6 @@
 		A7E2332D2BC81B5D0087D8F8 /* AutoLoad.c in Sources */ = {isa = PBXBuildFile; fileRef = A7E233002BC6EF220087D8F8 /* AutoLoad.c */; };
 		A7E2332E2BC81B680087D8F8 /* AutoLoad.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E233202BC819A70087D8F8 /* AutoLoad.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7E233312BC82CD10087D8F8 /* Kronos in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, maccatalyst, macos, tvos, xros, ); productRef = A7E233302BC82CD10087D8F8 /* Kronos */; };
-		A7E233332BC93D100087D8F8 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E233322BC93D100087D8F8 /* Synced.swift */; };
 		A7E233352BCD39E30087D8F8 /* Swift+C.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E233342BCD39E30087D8F8 /* Swift+C.swift */; };
 		A7E233372BCD6A000087D8F8 /* SubprocessSpawn.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E233362BCD6A000087D8F8 /* SubprocessSpawn.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7E233392BCD6B240087D8F8 /* SubprocessSpawn.c in Sources */ = {isa = PBXBuildFile; fileRef = A7E233382BCD6B240087D8F8 /* SubprocessSpawn.c */; };
@@ -406,7 +407,9 @@
 
 /* Begin PBXFileReference section */
 		0083E7241E320B00198C0D71 /* TestManagementApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestManagementApi.swift; sourceTree = "<group>"; };
+		01EB970146040DD4967C7411 /* TelemetryApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryApi.swift; sourceTree = "<group>"; };
 		0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisSwiftTestingTests.swift; sourceTree = "<group>"; };
+		12536CCE14EC1D3DAAC8DB81 /* Synced.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Synced.swift; sourceTree = "<group>"; };
 		1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisApi.swift; sourceTree = "<group>"; };
 		1531A96019132E3E9E96A3A7 /* KnownTestsApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KnownTestsApi.swift; sourceTree = "<group>"; };
 		31F8747157604DB48FE692EB /* AutoTestRetriesSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTestRetriesSwiftTestingTests.swift; sourceTree = "<group>"; };
@@ -520,7 +523,6 @@
 		A7E233002BC6EF220087D8F8 /* AutoLoad.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = AutoLoad.c; sourceTree = "<group>"; };
 		A7E233162BC7FA590087D8F8 /* CDatadogSDKTesting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDatadogSDKTesting.h; sourceTree = "<group>"; };
 		A7E233202BC819A70087D8F8 /* AutoLoad.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoLoad.h; sourceTree = "<group>"; };
-		A7E233322BC93D100087D8F8 /* Synced.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Synced.swift; sourceTree = "<group>"; };
 		A7E233342BCD39E30087D8F8 /* Swift+C.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Swift+C.swift"; sourceTree = "<group>"; };
 		A7E233362BCD6A000087D8F8 /* SubprocessSpawn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SubprocessSpawn.h; sourceTree = "<group>"; };
 		A7E233382BCD6B240087D8F8 /* SubprocessSpawn.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = SubprocessSpawn.c; sourceTree = "<group>"; };
@@ -938,7 +940,6 @@
 			isa = PBXGroup;
 			children = (
 				A7B012162F364D00000270A4 /* NoopSpanExporter.swift */,
-				A7E233322BC93D100087D8F8 /* Synced.swift */,
 				E1293F8828DB515F00D31DD6 /* SanitizerHelper.swift */,
 				E1AD07A8252F5CB8003705C1 /* InternalError.swift */,
 				E1D476A525DD369F00832592 /* BinaryParser.swift */,
@@ -1123,6 +1124,7 @@
 				A7AB7C0F2F11AA1100000002 /* RunLoopWaiter.swift */,
 				A7E233342BCD39E30087D8F8 /* Swift+C.swift */,
 				6F3EB9ACD93007FC43F039EE /* Async.swift */,
+				12536CCE14EC1D3DAAC8DB81 /* Synced.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1414,6 +1416,7 @@
 				1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */,
 				0083E7241E320B00198C0D71 /* TestManagementApi.swift */,
 				E0B522400A21CABC6BB4F1CA /* TestOptimizationApi.swift */,
+				01EB970146040DD4967C7411 /* TelemetryApi.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1949,7 +1952,6 @@
 				A7FC25B42BA1EADF00067E26 /* DDXCTestObserver.swift in Sources */,
 				A7FC260D2BA1EC0500067E26 /* SignalUtils.swift in Sources */,
 				A7B012152F364C37000270A4 /* URLSessionLogger.swift in Sources */,
-				A7E233332BC93D100087D8F8 /* Synced.swift in Sources */,
 				A7FC25D42BA1EB3400067E26 /* BinaryImages.swift in Sources */,
 				A7FC25B62BA1EADF00067E26 /* DDTestModule.swift in Sources */,
 				A7B012132F364C04000270A4 /* URLSessionInstrumentationConfiguration.swift in Sources */,
@@ -2098,6 +2100,8 @@
 				1FB416017E14C140B15E1D97 /* Async.swift in Sources */,
 				3B086A157E782A8DCA702976 /* LogsApi.swift in Sources */,
 				CD1E9CDE6FE677BC07E66905 /* SpansApi.swift in Sources */,
+				56B58A2FC91F21D1ABB0155E /* TelemetryApi.swift in Sources */,
+				98D8D496CC4210A0D1D07F93 /* Synced.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/DatadogSDKTesting/AdditionalTagsFeature.swift
+++ b/Sources/DatadogSDKTesting/AdditionalTagsFeature.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+internal import EventsExporter
 
 /// Tracks communication errors that occurred while fetching library
 /// configuration data from the backend (settings, skippable tests, flaky tests,

--- a/Sources/DatadogSDKTesting/DDTest.swift
+++ b/Sources/DatadogSDKTesting/DDTest.swift
@@ -8,6 +8,7 @@ import Foundation
 @preconcurrency internal import OpenTelemetryApi
 @preconcurrency internal import OpenTelemetrySdk
 internal import SigmaSwiftStatistics
+internal import EventsExporter
 
 @objc(DDTest)
 public final class Test: NSObject {

--- a/Sources/DatadogSDKTesting/DDTestModule.swift
+++ b/Sources/DatadogSDKTesting/DDTestModule.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 @preconcurrency internal import OpenTelemetryApi
+internal import EventsExporter
 
 @objc(DDTestModule)
 public final class Module: NSObject, Encodable {

--- a/Sources/DatadogSDKTesting/DDTestSuite.swift
+++ b/Sources/DatadogSDKTesting/DDTestSuite.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 @preconcurrency internal import OpenTelemetryApi
+internal import EventsExporter
 
 @objc(DDTestSuite)
 public final class Suite: NSObject, Encodable {

--- a/Sources/DatadogSDKTesting/Utils/Clock.swift
+++ b/Sources/DatadogSDKTesting/Utils/Clock.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+internal import EventsExporter
 #if !os(watchOS)
 internal import Kronos
 #endif

--- a/Sources/EventsExporter/API/APITypes.swift
+++ b/Sources/EventsExporter/API/APITypes.swift
@@ -254,6 +254,8 @@ internal enum APICallError: Error {
 }
 
 internal struct APIServiceConfig {
+    let serviceName: String
+    let environment: String
     let applicationName: String
     let version: String
     let device: Device
@@ -289,10 +291,13 @@ internal struct APIServiceConfig {
             (hostname != nil ? [.hostnameHeader(hostname: hostname!)] : [])
     }
 
-    init(applicationName: String, version: String,
+    init(serviceName: String, environment: String,
+         applicationName: String, version: String,
          device: Device, hostname: String?, apiKey: String,
          endpoint: Endpoint, clientId: String, payloadCompression: Bool)
     {
+        self.serviceName = serviceName
+        self.environment = environment
         self.applicationName = applicationName
         self.version = version
         self.device = device

--- a/Sources/EventsExporter/API/GitUploadApi.swift
+++ b/Sources/EventsExporter/API/GitUploadApi.swift
@@ -43,8 +43,19 @@ extension GitUploadApi {
         } catch {
             throw APICallError.fileSystem(error)
         }
-        for file in files {
-            try await uploadPackFile(file: file, commit: commit, repositoryURL: repositoryURL)
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for file in files {
+                    group.addTask {
+                        try await uploadPackFile(file: file, commit: commit, repositoryURL: repositoryURL)
+                    }
+                }
+                return try await group.next()
+            }
+        } catch let err as APICallError {
+            throw err
+        } catch {
+            throw .unknownError(error)
         }
     }
 }

--- a/Sources/EventsExporter/API/TelemetryApi.swift
+++ b/Sources/EventsExporter/API/TelemetryApi.swift
@@ -1,0 +1,718 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+// MARK: - Public domain types
+
+/// A single telemetry metric series for `generate-metrics`.
+public struct TelemetryMetric {
+    /// Per-tracer metric namespace (`dd.instrumentation_telemetry_data.{namespace}.*`).
+    public enum Namespace: String, Codable {
+        case tracers, general, telemetry, iast, appsec
+    }
+
+    /// The metric kind. The intake defaults to `.gauge` when omitted.
+    public enum MetricType: String, Codable {
+        case gauge, count, rate
+    }
+
+    /// A single `[timestamp, value]` sample. Encoded as a JSON pair, per spec.
+    public struct Point: Codable {
+        public var timestamp: TimeInterval
+        public var value: Double
+
+        public init(timestamp: TimeInterval, value: Double) {
+            self.timestamp = timestamp
+            self.value = value
+        }
+
+        public init(from decoder: any Decoder) throws {
+            var container = try decoder.unkeyedContainer()
+            self.timestamp = try container.decode(TimeInterval.self)
+            self.value = try container.decode(Double.self)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.unkeyedContainer()
+            try container.encode(timestamp)
+            try container.encode(value)
+        }
+    }
+
+    /// A metric series with one or more sampled points.
+    public struct Series: Codable {
+        public var metric: String
+        public var points: [Point]
+        public var interval: Double?
+        public var type: MetricType?
+        public var tags: [String]?
+        public var common: Bool?
+        /// Per-series override for the payload-level namespace.
+        public var namespace: Namespace?
+
+        public init(metric: String,
+                    points: [Point],
+                    interval: Double? = nil,
+                    type: MetricType? = nil,
+                    tags: [String]? = nil,
+                    common: Bool? = nil,
+                    namespace: Namespace? = nil)
+        {
+            self.metric = metric
+            self.points = points
+            self.interval = interval
+            self.type = type
+            self.tags = tags
+            self.common = common
+            self.namespace = namespace
+        }
+    }
+}
+
+/// A single telemetry log message for the `logs` request type.
+///
+/// The telemetry intake's `log_message` schema is intentionally minimal — it
+/// does *not* duplicate the service / env / host / version identity that the
+/// outer envelope carries. This type is purpose-built for that endpoint and
+/// is unrelated to `DDLog` (the `/api/v2/logs` body).
+public struct TelemetryLog: Codable {
+    public enum Level: String, Codable {
+        case error = "ERROR"
+        case warn = "WARN"
+        case debug = "DEBUG"
+    }
+
+    public var message: String
+    public var level: Level
+    /// Deduplicated occurrence count. Optional per spec.
+    public var count: Int?
+    /// Comma-separated tag string in the form `"k:v,k:v"`. Optional.
+    public var tags: String?
+    public var stackTrace: String?
+    /// Per-log unix-seconds timestamp. When `nil`, the envelope's `tracer_time` is used.
+    public var tracerTime: Int64?
+
+    public init(message: String,
+                level: Level,
+                count: Int? = nil,
+                tags: String? = nil,
+                stackTrace: String? = nil,
+                tracerTime: Int64? = nil)
+    {
+        self.message = message
+        self.level = level
+        self.count = count
+        self.tags = tags
+        self.stackTrace = stackTrace
+        self.tracerTime = tracerTime
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case message, level, count, tags
+        case stackTrace = "stack_trace"
+        case tracerTime = "tracer_time"
+    }
+}
+
+// MARK: - App-lifecycle types
+
+/// Lightweight error envelope used inside `app-started` (both at the payload
+/// level and per-configuration-item).
+public struct TelemetryError: Codable {
+    public var code: Int
+    public var message: String
+
+    public init(code: Int, message: String) {
+        self.code = code
+        self.message = message
+    }
+}
+
+/// Per-product status reported in `app-started`. All fields optional.
+public struct TelemetryProductInfo: Codable {
+    public var version: String?
+    public var enabled: Bool?
+    public var error: TelemetryError?
+
+    public init(version: String? = nil,
+                enabled: Bool? = nil,
+                error: TelemetryError? = nil)
+    {
+        self.version = version
+        self.enabled = enabled
+        self.error = error
+    }
+}
+
+/// Product-status payload inside `app-started`.
+public struct TelemetryProducts: Codable {
+    public var appsec: TelemetryProductInfo?
+    public var profiler: TelemetryProductInfo?
+    public var dynamicInstrumentation: TelemetryProductInfo?
+    public var mlobs: TelemetryProductInfo?
+
+    public init(appsec: TelemetryProductInfo? = nil,
+                profiler: TelemetryProductInfo? = nil,
+                dynamicInstrumentation: TelemetryProductInfo? = nil,
+                mlobs: TelemetryProductInfo? = nil)
+    {
+        self.appsec = appsec
+        self.profiler = profiler
+        self.dynamicInstrumentation = dynamicInstrumentation
+        self.mlobs = mlobs
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case appsec, profiler, mlobs
+        case dynamicInstrumentation = "dynamic_instrumentation"
+    }
+}
+
+/// Source of a `TelemetryConfigItem` value, per spec.
+public enum TelemetryConfigOrigin: String, Codable {
+    case envVar = "env_var"
+    case jvmProp = "jvm_prop"
+    case code
+    case ddConfig = "dd_config"
+    case remoteConfig = "remote_config"
+    case appConfig = "app.config"
+    case `default`
+    case unknown
+}
+
+/// One entry in the `configuration` array of `app-started`.
+/// `value` accepts string / number / boolean (per spec); use `JSONGeneric`
+/// to model that union.
+public struct TelemetryConfigItem: Codable {
+    public var name: String
+    public var value: JSONGeneric
+    public var origin: TelemetryConfigOrigin
+    public var error: TelemetryError?
+    /// Optional monotonic counter the caller maintains per-config-key (or
+    /// globally) to track the active set of values over time.
+    public var seqId: UInt64?
+
+    public init(name: String,
+                value: JSONGeneric,
+                origin: TelemetryConfigOrigin,
+                error: TelemetryError? = nil,
+                seqId: UInt64? = nil)
+    {
+        self.name = name
+        self.value = value
+        self.origin = origin
+        self.error = error
+        self.seqId = seqId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name, value, origin, error
+        case seqId = "seq_id"
+    }
+}
+
+/// `install_signature` block of `app-started`. Each field maps directly to
+/// a `DD_INSTRUMENTATION_INSTALL_*` env-var per the spec.
+public struct TelemetryInstallSignature: Codable {
+    public var installId: String?
+    public var installType: String?
+    public var installTime: String?
+
+    public init(installId: String? = nil,
+                installType: String? = nil,
+                installTime: String? = nil)
+    {
+        self.installId = installId
+        self.installType = installType
+        self.installTime = installTime
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case installId = "install_id"
+        case installType = "install_type"
+        case installTime = "install_time"
+    }
+}
+
+/// A single entry inside a `message-batch` telemetry payload.
+///
+/// Each entry is one of the concrete telemetry request types that this SDK
+/// supports today. Adding a new variant here is the only change needed to
+/// let it ride in a batch.
+public enum TelemetryBatchItem {
+    case metrics(series: [TelemetryMetric.Series], namespace: TelemetryMetric.Namespace?)
+    case logs([TelemetryLog])
+    case appStarted(products: TelemetryProducts? = nil,
+                    configuration: [TelemetryConfigItem]? = nil,
+                    error: TelemetryError? = nil,
+                    installSignature: TelemetryInstallSignature? = nil)
+    case appHeartbeat
+    case appClosing
+}
+
+// MARK: - Protocol
+
+internal protocol TelemetryApi: APIService {
+    /// Send the one-time `app-started` event. Per spec this should be sent
+    /// exactly once per tracer lifecycle, after init. All payload fields are
+    /// optional and `nil` ones are omitted from the wire payload.
+    func sendAppStarted(products: TelemetryProducts?,
+                        configuration: [TelemetryConfigItem]?,
+                        error: TelemetryError?,
+                        installSignature: TelemetryInstallSignature?) async throws(HTTPClient.RequestError)
+
+    /// Send an `app-heartbeat` event. Per spec callers should schedule this
+    /// once per minute after `sendAppStarted` for as long as the app is alive,
+    /// even if other telemetry events were sent in the same window.
+    func sendAppHeartbeat() async throws(HTTPClient.RequestError)
+
+    /// Send the `app-closing` event when the app is about to terminate.
+    /// Should use a short timeout so it doesn't delay shutdown.
+    func sendAppClosing() async throws(HTTPClient.RequestError)
+
+    /// Send a batch of metric series via the `generate-metrics` request type.
+    func sendMetrics(_ series: [TelemetryMetric.Series],
+                     namespace: TelemetryMetric.Namespace?) async throws(HTTPClient.RequestError)
+
+    /// Send a batch of log messages via the `logs` request type.
+    func sendLogs(_ logs: [TelemetryLog]) async throws(HTTPClient.RequestError)
+
+    /// Send a mixed batch of telemetry items via the `message-batch` request
+    /// type. Items keep their original request_type tag inside the batch and
+    /// share the outer envelope's `application`/`host`/`runtime_id`/`seq_id`.
+    /// An empty `items` array is a no-op and does not hit the network.
+    func send(batch items: [TelemetryBatchItem]) async throws(HTTPClient.RequestError)
+
+    /// Send a pre-built `message-batch` HTTP body from a file. The file must
+    /// hold a complete telemetry envelope (`api_version` / `request_type` /
+    /// `runtime_id` / `seq_id` / `tracer_time` / `application` / `host` /
+    /// `payload`) — bytes are POSTed verbatim. Use this when replaying a
+    /// telemetry payload that was queued to disk upstream. Note that any
+    /// timestamp / sequence-id fields baked into the file are used as-is.
+    func send(batch url: URL) async throws(APICallError)
+
+    /// Send pre-built `message-batch` HTTP body bytes directly. Same
+    /// semantics as the URL variant — `data` is POSTed as the body verbatim.
+    func send(batch data: Data) async throws(HTTPClient.RequestError)
+}
+
+extension TelemetryApi {
+    func send(batch url: URL) async throws(APICallError) {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        } catch {
+            throw .fileSystem(error)
+        }
+        do {
+            try await send(batch: data)
+        } catch {
+            throw APICallError(from: error)
+        }
+    }
+}
+
+// MARK: - Service
+
+internal struct TelemetryApiService: TelemetryApi {
+    var endpoint: Endpoint
+    var headers: [HTTPHeader]
+    var encoder: JSONEncoder
+    var decoder: JSONDecoder
+    let httpClient: HTTPClient
+    let log: Logger
+
+    /// Stable identifier for this tracer session. Reused as the telemetry
+    /// `runtime_id` so backend can correlate telemetry with traces.
+    private let runtimeId: String
+    private let application: TelemetryApplication
+    private let host: TelemetryHost
+    /// Strictly monotonic `seq_id` counter. The intake uses gaps in this
+    /// sequence to detect dropped messages, so it must increase across all
+    /// telemetry requests within a runtime.
+    private let seq: Synced<UInt64>
+
+    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+        self.endpoint = config.endpoint
+        self.httpClient = httpClient
+        self.log = log
+        // The telemetry intake does NOT accept the trace-style headers — strip
+        // them. Keep the auth / user-agent / hostname additions.
+        self.headers = config.defaultHeaders.filter { header in
+            switch header.field {
+            case .traceIDHeaderField, .parentSpanIDHeaderField, .samplingPriorityHeaderField:
+                return false
+            default:
+                return true
+            }
+        }
+        self.encoder = config.encoder
+        self.decoder = config.decoder
+        self.runtimeId = config.clientId
+        self.application = TelemetryApplication(config: config)
+        self.host = TelemetryHost(config: config)
+        self.seq = Synced<UInt64>(0)
+    }
+
+    private func nextSeqId() -> UInt64 {
+        seq.update { value in
+            value &+= 1
+            return value
+        }
+    }
+
+    func sendAppStarted(products: TelemetryProducts?,
+                        configuration: [TelemetryConfigItem]?,
+                        error: TelemetryError?,
+                        installSignature: TelemetryInstallSignature?) async throws(HTTPClient.RequestError)
+    {
+        let payload = TelemetryAppStartedPayload(products: products,
+                                                 configuration: configuration,
+                                                 error: error,
+                                                 installSignature: installSignature)
+        try await send(requestType: .appStarted, payload: payload)
+    }
+
+    func sendAppHeartbeat() async throws(HTTPClient.RequestError) {
+        try await send(requestType: .appHeartbeat, payload: TelemetryEmptyPayload())
+    }
+
+    func sendAppClosing() async throws(HTTPClient.RequestError) {
+        try await send(requestType: .appClosing, payload: TelemetryEmptyPayload())
+    }
+
+    func sendMetrics(_ series: [TelemetryMetric.Series],
+                     namespace: TelemetryMetric.Namespace?) async throws(HTTPClient.RequestError)
+    {
+        let payload = TelemetryMetricsPayload(namespace: namespace, series: series)
+        try await send(requestType: .generateMetrics, payload: payload)
+    }
+
+    func sendLogs(_ logs: [TelemetryLog]) async throws(HTTPClient.RequestError) {
+        let payload = TelemetryLogsPayload(logs: logs)
+        try await send(requestType: .logs, payload: payload)
+    }
+
+    func send(batch items: [TelemetryBatchItem]) async throws(HTTPClient.RequestError) {
+        guard !items.isEmpty else { return }
+        try await send(requestType: .messageBatch,
+                       payload: items.map(TelemetryBatchEntry.init(item:)))
+    }
+
+    func send(batch data: Data) async throws(HTTPClient.RequestError) {
+        try await send(requestType: .messageBatch, body: data)
+    }
+
+    var endpointURLs: Set<URL> { [endpoint.telemetryURL] }
+
+    private func send<Payload: Encodable>(
+        requestType: TelemetryRequestType,
+        payload: Payload
+    ) async throws(HTTPClient.RequestError) {
+        let envelope = TelemetryEnvelope(
+            requestType: requestType,
+            tracerTime: Int64(Date().timeIntervalSince1970),
+            runtimeId: runtimeId,
+            seqId: nextSeqId(),
+            application: application,
+            host: host,
+            payload: payload
+        )
+        let data: Data
+        do {
+            data = try encoder.encode(envelope)
+        } catch {
+            // The intake never produces a decoding error, but if our own
+            // encoding fails we surface it through `.transport` since the
+            // wire protocol is throws(HTTPClient.RequestError).
+            throw .transport(error)
+        }
+        try await send(requestType: requestType, body: data)
+    }
+
+    private func send(requestType: TelemetryRequestType,
+                      body: Data) async throws(HTTPClient.RequestError)
+    {
+        var request = URLRequest(url: endpoint.telemetryURL)
+        request.httpMethod = "POST"
+        request.httpHeaders = headers
+        request.setHTTPHeader(.contentTypeHeader(contentType: .applicationJSON))
+        request.setValue(.constant(TelemetryHeaders.apiVersion),
+                         forHTTPHeader: .ddTelemetryApiVersion)
+        request.setValue(.constant(requestType.rawValue),
+                         forHTTPHeader: .ddTelemetryRequestType)
+        request.setValue(.constant(TelemetryHeaders.libraryLanguage),
+                         forHTTPHeader: .ddClientLibraryLanguage)
+        request.setValue(.constant(application.tracerVersion),
+                         forHTTPHeader: .ddClientLibraryVersion)
+        request.httpBody = body
+
+        let log = self.log
+        log.debug("Telemetry \(requestType.rawValue) sending \(body.count) bytes...")
+        let _ = try await httpClient.send(request: request)
+        log.debug("Telemetry \(requestType.rawValue) accepted")
+    }
+}
+
+// MARK: - Wire types
+
+/// The set of telemetry request_types this service implements.
+private enum TelemetryRequestType: String, Encodable {
+    case generateMetrics = "generate-metrics"
+    case logs
+    case messageBatch = "message-batch"
+    case appStarted = "app-started"
+    case appHeartbeat = "app-heartbeat"
+    case appClosing = "app-closing"
+}
+
+/// One entry of a `message-batch` payload. The case itself is the
+/// discriminator: each variant carries its concrete inner payload, and
+/// `encode(to:)` emits the matching `request_type` tag.
+private enum TelemetryBatchEntry: Encodable {
+    case metrics(TelemetryMetricsPayload)
+    case logs(TelemetryLogsPayload)
+    case appStarted(TelemetryAppStartedPayload)
+    case appHeartbeat
+    case appClosing
+
+    init(item: TelemetryBatchItem) {
+        switch item {
+        case .metrics(let series, let namespace):
+            self = .metrics(TelemetryMetricsPayload(namespace: namespace, series: series))
+        case .logs(let logs):
+            self = .logs(TelemetryLogsPayload(logs: logs))
+        case let .appStarted(products, configuration, error, installSignature):
+            self = .appStarted(TelemetryAppStartedPayload(products: products,
+                                                          configuration: configuration,
+                                                          error: error,
+                                                          installSignature: installSignature))
+        case .appHeartbeat:
+            self = .appHeartbeat
+        case .appClosing:
+            self = .appClosing
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestType = "request_type"
+        case payload
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .metrics(let payload):
+            try container.encode(TelemetryRequestType.generateMetrics, forKey: .requestType)
+            try container.encode(payload, forKey: .payload)
+        case .logs(let payload):
+            try container.encode(TelemetryRequestType.logs, forKey: .requestType)
+            try container.encode(payload, forKey: .payload)
+        case .appStarted(let payload):
+            try container.encode(TelemetryRequestType.appStarted, forKey: .requestType)
+            try container.encode(payload, forKey: .payload)
+        case .appHeartbeat:
+            try container.encode(TelemetryRequestType.appHeartbeat, forKey: .requestType)
+            try container.encode(TelemetryEmptyPayload(), forKey: .payload)
+        case .appClosing:
+            try container.encode(TelemetryRequestType.appClosing, forKey: .requestType)
+            try container.encode(TelemetryEmptyPayload(), forKey: .payload)
+        }
+    }
+}
+
+private struct TelemetryEnvelope<Payload: Encodable>: Encodable {
+    let apiVersion: String = TelemetryHeaders.apiVersion
+    let requestType: TelemetryRequestType
+    let tracerTime: Int64
+    let runtimeId: String
+    let seqId: UInt64
+    let application: TelemetryApplication
+    let host: TelemetryHost
+    let payload: Payload
+
+    enum CodingKeys: String, CodingKey {
+        case apiVersion = "api_version"
+        case requestType = "request_type"
+        case tracerTime = "tracer_time"
+        case runtimeId = "runtime_id"
+        case seqId = "seq_id"
+        case application
+        case host
+        case payload
+    }
+}
+
+private struct TelemetryApplication: Encodable {
+    let serviceName: String
+    let env: String
+    let serviceVersion: String
+    let tracerVersion: String
+    let languageName: String
+    let languageVersion: String
+    let runtimeName: String
+    let runtimeVersion: String
+
+    init(config: APIServiceConfig) {
+        self.serviceName = config.serviceName
+        self.env = config.environment
+        self.serviceVersion = config.version
+        self.tracerVersion = config.version
+        self.languageName = TelemetryHeaders.libraryLanguage
+        self.languageVersion = SwiftRuntime.languageVersion
+        self.runtimeName = "swift"
+        self.runtimeVersion = SwiftRuntime.languageVersion
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case serviceName = "service_name"
+        case env
+        case serviceVersion = "service_version"
+        case tracerVersion = "tracer_version"
+        case languageName = "language_name"
+        case languageVersion = "language_version"
+        case runtimeName = "runtime_name"
+        case runtimeVersion = "runtime_version"
+    }
+}
+
+private struct TelemetryHost: Encodable {
+    let hostname: String
+    let os: String
+    let osVersion: String
+    let architecture: String
+    let kernelName: String
+    let kernelRelease: String
+    let kernelVersion: String
+
+    init(config: APIServiceConfig) {
+        let kernel = SwiftRuntime.kernelInfo
+        self.hostname = config.hostname ?? ProcessInfo.processInfo.hostName
+        self.os = config.device.osName
+        self.osVersion = config.device.osVersion
+        self.architecture = kernel.machine
+        self.kernelName = kernel.sysname
+        self.kernelRelease = kernel.release
+        self.kernelVersion = kernel.version
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case hostname, os, architecture
+        case osVersion = "os_version"
+        case kernelName = "kernel_name"
+        case kernelRelease = "kernel_release"
+        case kernelVersion = "kernel_version"
+    }
+}
+
+private struct TelemetryMetricsPayload: Encodable {
+    let namespace: TelemetryMetric.Namespace?
+    let series: [TelemetryMetric.Series]
+}
+
+private struct TelemetryLogsPayload: Encodable {
+    let logs: [TelemetryLog]
+}
+
+/// Wire shape for `app-started` payload. All fields optional; `Encodable`
+/// default behavior skips them when `nil`.
+private struct TelemetryAppStartedPayload: Encodable {
+    let products: TelemetryProducts?
+    let configuration: [TelemetryConfigItem]?
+    let error: TelemetryError?
+    let installSignature: TelemetryInstallSignature?
+
+    enum CodingKeys: String, CodingKey {
+        case products, configuration, error
+        case installSignature = "install_signature"
+    }
+}
+
+/// Empty `{}` payload used by `app-heartbeat` and `app-closing`. The schema
+/// description says payload is required even when there's nothing to send;
+/// emitting an empty object satisfies that contract.
+private struct TelemetryEmptyPayload: Encodable {}
+
+// MARK: - Helpers
+
+private enum TelemetryHeaders {
+    static let apiVersion = "v2"
+    static let libraryLanguage = "swift"
+}
+
+extension HTTPHeader.Field {
+    static let ddTelemetryApiVersion: Self = "DD-Telemetry-API-Version"
+    static let ddTelemetryRequestType: Self = "DD-Telemetry-Request-Type"
+    static let ddClientLibraryLanguage: Self = "DD-Client-Library-Language"
+    static let ddClientLibraryVersion: Self = "DD-Client-Library-Version"
+}
+
+private enum SwiftRuntime {
+    struct KernelInfo {
+        let sysname: String
+        let release: String
+        let version: String
+        let machine: String
+    }
+
+    /// Cached result of `uname(3)` for the host this process runs on.
+    /// Populated lazily; safe to read concurrently because the closure body
+    /// runs at most once and the resulting struct is value-typed.
+    static let kernelInfo: KernelInfo = {
+        var info = utsname()
+        guard uname(&info) == 0 else {
+            return KernelInfo(sysname: "", release: "", version: "", machine: "")
+        }
+        return KernelInfo(sysname: cString(&info.sysname),
+                          release: cString(&info.release),
+                          version: cString(&info.version),
+                          machine: cString(&info.machine))
+    }()
+
+    static let languageVersion: String = {
+        #if swift(>=6.2)
+        return "6.2"
+        #elseif swift(>=6.1)
+        return "6.1"
+        #elseif swift(>=6.0)
+        return "6.0"
+        #elseif swift(>=5.10)
+        return "5.10"
+        #elseif swift(>=5.9)
+        return "5.9"
+        #else
+        return ""
+        #endif
+    }()
+
+    /// Read a C `char[N]` tuple (which is how `utsname` fields surface to
+    /// Swift) as a null-terminated `String`.
+    private static func cString<T>(_ pointer: UnsafePointer<T>) -> String {
+        pointer.withMemoryRebound(to: CChar.self, capacity: MemoryLayout<T>.size) {
+            String(cString: $0)
+        }
+    }
+}
+
+// MARK: - Endpoint URL
+
+private extension Endpoint {
+    var telemetryURL: URL {
+        let endpoint = "/api/v2/apmtelemetry"
+        switch self {
+        case let .other(testsBaseURL: url, logsBaseURL: _):
+            return url.appendingPathComponent(endpoint)
+        default:
+            return URL(string: "https://instrumentation-telemetry-intake.\(site!)\(endpoint)")!
+        }
+    }
+}

--- a/Sources/EventsExporter/API/TestOptimizationApi.swift
+++ b/Sources/EventsExporter/API/TestOptimizationApi.swift
@@ -14,6 +14,7 @@ internal protocol TestOptimizationApi: APIService {
     var testManagement: TestManagementApi { get }
     var spans: SpansApi { get }
     var logs: LogsApi { get }
+    var telemetry: TelemetryApi { get }
 }
 
 internal struct TestOptimizationApiService: TestOptimizationApi {
@@ -27,6 +28,7 @@ internal struct TestOptimizationApiService: TestOptimizationApi {
             testManagement.endpoint = newValue
             spans.endpoint = newValue
             logs.endpoint = newValue
+            telemetry.endpoint = newValue
         }
     }
     var headers: [HTTPHeader] {
@@ -39,6 +41,7 @@ internal struct TestOptimizationApiService: TestOptimizationApi {
             testManagement.headers = newValue
             spans.headers = newValue
             logs.headers = newValue
+            telemetry.headers = newValue
         }
     }
 
@@ -52,6 +55,7 @@ internal struct TestOptimizationApiService: TestOptimizationApi {
             testManagement.encoder = newValue
             spans.encoder = newValue
             logs.encoder = newValue
+            telemetry.encoder = newValue
         }
     }
 
@@ -65,6 +69,7 @@ internal struct TestOptimizationApiService: TestOptimizationApi {
             testManagement.decoder = newValue
             spans.decoder = newValue
             logs.decoder = newValue
+            telemetry.decoder = newValue
         }
     }
 
@@ -75,6 +80,7 @@ internal struct TestOptimizationApiService: TestOptimizationApi {
     var testManagement: TestManagementApi
     var spans: SpansApi
     var logs: LogsApi
+    var telemetry: TelemetryApi
 
     init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
         settings = SettingsApiService(config: config, httpClient: httpClient, log: log)
@@ -84,6 +90,7 @@ internal struct TestOptimizationApiService: TestOptimizationApi {
         testManagement = TestManagementApiService(config: config, httpClient: httpClient, log: log)
         spans = SpansApiService(config: config, httpClient: httpClient, log: log)
         logs = LogsApiService(config: config, httpClient: httpClient, log: log)
+        telemetry = TelemetryApiService(config: config, httpClient: httpClient, log: log)
     }
 
     var endpointURLs: Set<URL> {
@@ -94,5 +101,6 @@ internal struct TestOptimizationApiService: TestOptimizationApi {
             .union(testManagement.endpointURLs)
             .union(spans.endpointURLs)
             .union(logs.endpointURLs)
+            .union(telemetry.endpointURLs)
     }
 }

--- a/Sources/EventsExporter/EventsExporter.swift
+++ b/Sources/EventsExporter/EventsExporter.swift
@@ -130,6 +130,8 @@ public final class EventsExporter: EventsExporterProtocol {
         coverageExporter = try CoverageExporter(config: configuration)
 
         let apiConfig = APIServiceConfig(
+            serviceName: config.serviceName,
+            environment: config.environment,
             applicationName: config.applicationName,
             version: config.version,
             device: .current,

--- a/Sources/EventsExporter/Utils/Synced.swift
+++ b/Sources/EventsExporter/Utils/Synced.swift
@@ -6,59 +6,59 @@
 
 import Foundation
 
-final class UnfairLock: Sendable {
+public final class UnfairLock: Sendable {
     nonisolated(unsafe) private let _lock: os_unfair_lock_t
-    
-    init() {
+
+    public init() {
         _lock = .allocate(capacity: 1)
         _lock.initialize(to: .init())
     }
-    
+
     deinit {
         _lock.deinitialize(count: 1)
         _lock.deallocate()
     }
-    
-    func lock() {
+
+    public func lock() {
         os_unfair_lock_lock(_lock)
     }
-    
-    func unlock() {
+
+    public func unlock() {
         os_unfair_lock_unlock(_lock)
     }
-    
-    func whileLocked<T>(_ action: () throws -> T) rethrows -> T {
+
+    public func whileLocked<T>(_ action: () throws -> T) rethrows -> T {
         os_unfair_lock_lock(_lock)
         defer { os_unfair_lock_unlock(_lock) }
         return try action()
     }
 }
 
-final class Synced<V>: Sendable {
+public final class Synced<V>: Sendable {
     nonisolated(unsafe) private var _value: V
     private let lock = UnfairLock()
-    
-    init(_ value: V) {
+
+    public init(_ value: V) {
         _value = value
     }
-    
-    var value: V { lock.whileLocked { _value } }
-    
-    func use<R>(_ action: (V) throws -> R) rethrows -> R {
+
+    public var value: V { lock.whileLocked { _value } }
+
+    public func use<R>(_ action: (V) throws -> R) rethrows -> R {
         try lock.whileLocked { try action(_value) }
     }
-    
-    func update<R>(_ action: (inout V) throws -> R) rethrows -> R {
+
+    public func update<R>(_ action: (inout V) throws -> R) rethrows -> R {
         try lock.whileLocked { try action(&_value) }
     }
 }
 
-struct LazySynced<V>: Sendable {
+public struct LazySynced<V>: Sendable {
     private enum State {
         case constructor(() throws -> V)
         case value(V)
         case error(any Error)
-        
+
         mutating func get() throws -> V {
             switch self {
             case .value(let v): return v
@@ -75,22 +75,22 @@ struct LazySynced<V>: Sendable {
             }
         }
     }
-    
+
     private let state: Synced<State>
-    
-    init(_ constructor: @escaping () throws -> V) {
+
+    public init(_ constructor: @escaping () throws -> V) {
         state = .init(.constructor(constructor))
     }
-    
-    func value() throws -> V {
+
+    public func value() throws -> V {
         try state.update { try $0.get() }
     }
-    
-    func use<R>(_ action: (V) throws -> R) throws -> R {
+
+    public func use<R>(_ action: (V) throws -> R) throws -> R {
         try state.update { try action($0.get()) }
     }
-    
-    func update<R>(_ action: (inout V) throws -> R) throws -> R {
+
+    public func update<R>(_ action: (inout V) throws -> R) throws -> R {
         try state.update { state in
             var value = try state.get()
             let result = try action(&value)

--- a/Tests/DatadogSDKTesting/MockSwiftTesting.swift
+++ b/Tests/DatadogSDKTesting/MockSwiftTesting.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 @testable import DatadogSDKTesting
+@testable import EventsExporter
 
 extension Mocks {
     struct STTestActions: DatadogSwiftTestingTestActions {

--- a/Tests/DatadogSDKTesting/MockTestTypes.swift
+++ b/Tests/DatadogSDKTesting/MockTestTypes.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 @testable import DatadogSDKTesting
+@testable import EventsExporter
 @preconcurrency import OpenTelemetryApi
 
 protocol MockTestModuleInfo {

--- a/Tests/DatadogSDKTesting/SessionManagerTests.swift
+++ b/Tests/DatadogSDKTesting/SessionManagerTests.swift
@@ -5,6 +5,7 @@
  */
 
 @testable import DatadogSDKTesting
+@testable import EventsExporter
 import XCTest
 
 final class SessionManagerTests: XCTestCase {


### PR DESCRIPTION
## Summary
- New `TelemetryApi` / `TelemetryApiService` in `Sources/EventsExporter/API/TelemetryApi.swift`, posting to the agentless `/api/v2/apmtelemetry` intake on `instrumentation-telemetry-intake.<site>`. Owns a per-runtime `seq_id` counter (overflow-safe with `&+=`) and reuses `APIServiceConfig.clientId` as the telemetry `runtime_id` so the backend can correlate telemetry with traces.
- **Metrics / logs:** `sendMetrics(_:namespace:)` and `sendLogs(_:)`. Public domain types: `TelemetryMetric.{Series, Point, MetricType, Namespace}` and `TelemetryLog` / `TelemetryLog.Level`. `Point` encodes as `[ts, value]` per spec.
- **App lifecycle:** `sendAppStarted(products:configuration:error:installSignature:)`, `sendAppHeartbeat()`, `sendAppClosing()`. Public types: `TelemetryError`, `TelemetryProductInfo`, `TelemetryProducts`, `TelemetryConfigItem`, `TelemetryConfigOrigin`, `TelemetryInstallSignature`. Heartbeat/closing emit `payload: {}` to satisfy the envelope schema.
- **Batching:** `send(batch:)` overloaded for `[TelemetryBatchItem]`, `URL`, and `Data`. The structured variant wraps inner request types as a `message-batch` with a fresh envelope; the URL/Data variants POST a pre-built envelope verbatim, matching the `LogsApi`/`SpansApi` shape. `TelemetryBatchEntry` is a tagged enum (no `AnyEncodable`).
- **Wiring:** `APIServiceConfig` gains `serviceName` and `environment` (used by the telemetry application/host blocks). `TestOptimizationApi`/`Service` exposes `var telemetry: TelemetryApi`.
- **Shared:** `Synced` / `UnfairLock` / `LazySynced` moved from `DatadogSDKTesting/Utils/Synced.swift` → `EventsExporter/Utils/Synced.swift` and made `public` so both modules share them. DatadogSDKTesting source/test files that consume `Synced` import `EventsExporter`.
- **Misc:** `GitUploadApi.uploadPackFiles` now uploads files concurrently via `withThrowingTaskGroup`.

Telemetry is exposed via the API surface but not yet consumed by `EventsExporter` — wiring it into an upload pipeline is follow-up work.

## Test plan
- [x] `xcodebuild test` for `EventsExporter` on macOS arm64 — 95/95 passing
- [x] `xcodebuild build` for `DatadogSDKTesting` on macOS arm64 — clean
- [ ] Manual smoke against a real telemetry intake (Datadog staging) once a consumer is wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)