### PR TITLE
[CHORE] Fix integration test runner timeout & isolate inner DerivedData

### DIFF
--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -43,3 +43,25 @@ jobs:
       with:
         name: ${{ matrix.xcode }}-${{ matrix.platform }}-integration-log
         path: "logs-integration/*.log"
+    - name: Collect xcresult bundles
+      if: failure()
+      run: |
+        set -euo pipefail
+        mkdir -p xcresults-integration
+        # Grab every xcresult produced during this job (outer test bundle
+        # and any inner build-for-testing/test-without-building runs) and
+        # zip each one to keep the artifact upload fast — xcresult is a
+        # bundle of thousands of small files otherwise.
+        derived_data="$HOME/Library/Developer/Xcode/DerivedData"
+        find "$derived_data" -type d -name '*.xcresult' -print0 \
+          | while IFS= read -r -d '' bundle; do
+              name=$(basename "$bundle" .xcresult)
+              (cd "$(dirname "$bundle")" && zip -qry "$GITHUB_WORKSPACE/xcresults-integration/$name.zip" "$(basename "$bundle")")
+            done
+    - name: Attach xcresult bundles
+      if: failure()
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ matrix.xcode }}-${{ matrix.platform }}-integration-xcresult
+        path: "xcresults-integration/*.zip"
+        if-no-files-found: ignore

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -48,16 +48,22 @@ jobs:
       run: |
         set -euo pipefail
         mkdir -p xcresults-integration
-        # Grab every xcresult produced during this job (outer test bundle
-        # and any inner build-for-testing/test-without-building runs) and
-        # zip each one to keep the artifact upload fast — xcresult is a
-        # bundle of thousands of small files otherwise.
-        derived_data="$HOME/Library/Developer/Xcode/DerivedData"
-        find "$derived_data" -type d -name '*.xcresult' -print0 \
-          | while IFS= read -r -d '' bundle; do
-              name=$(basename "$bundle" .xcresult)
-              (cd "$(dirname "$bundle")" && zip -qry "$GITHUB_WORKSPACE/xcresults-integration/$name.zip" "$(basename "$bundle")")
-            done
+        # Grab every xcresult produced during this job and zip each one to
+        # keep the artifact upload fast (xcresult is a bundle of thousands
+        # of small files otherwise). Two source locations:
+        #   - default DerivedData under $HOME: outer `xcodebuild test` bundle.
+        #   - $GITHUB_WORKSPACE/build/integration-DerivedData: inner
+        #     `xcodebuild test-without-building` bundles spawned by the
+        #     runner. Inner builds use an isolated DerivedData so the
+        #     outer SWBBuildService can't evict their cache.
+        for root in "$HOME/Library/Developer/Xcode/DerivedData" "$GITHUB_WORKSPACE/build/integration-DerivedData"; do
+          [ -d "$root" ] || continue
+          find "$root" -type d -name '*.xcresult' -print0 \
+            | while IFS= read -r -d '' bundle; do
+                name=$(basename "$bundle" .xcresult)
+                (cd "$(dirname "$bundle")" && zip -qry "$GITHUB_WORKSPACE/xcresults-integration/$name.zip" "$(basename "$bundle")")
+              done
+        done
     - name: Attach xcresult bundles
       if: failure()
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/IntegrationTests/Runner/Runner.swift
+++ b/IntegrationTests/Runner/Runner.swift
@@ -148,6 +148,13 @@ struct XcodeTestRunner: Sendable {
             if shouldCloseStdOut { try? stdOut.close() }
         }
         
+        // Isolate inner xcodebuild DerivedData from the outer test bundle's.
+        // When both share `~/Library/Developer/Xcode/DerivedData` the inner
+        // SWBBuildService evicts cached build descriptions out from under
+        // the outer process and prints duplicate-blueprint warnings; this
+        // has caused random mid-build failures and aborted test sessions.
+        let derivedDataPath = "\(workdir)/build/integration-DerivedData"
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env", isDirectory: false)
         process.standardOutput = stdOut
@@ -159,7 +166,8 @@ struct XcodeTestRunner: Sendable {
             "xcodebuild",
             "-scheme", module,
             "-sdk", sdk,
-            "-destination", platform
+            "-destination", platform,
+            "-derivedDataPath", derivedDataPath,
         ] + action
         
         try process.run()
@@ -263,14 +271,22 @@ struct BuildProvider: SuiteTrait, TestScoping {
         self.testBundle = testBundle ?? module
     }
 
+    // Only boot the simulator in `prepare`. The actual `xcodebuild
+    // build-for-testing` is deferred to `provideScope` because xcodebuild
+    // gates the test-runner "ready to run" handshake on trait preparation
+    // finishing within a short window (~5 minutes on Xcode 26). Inner
+    // builds can run several minutes, so doing them here trips the
+    // "test runner timed out while preparing to run tests" failure.
     func prepare(for test: Testing.Test) async throws {
-        try await XcodeTestRunner(module: module, testBundle: testBundle).build()
+        try await XcodeTestRunner(module: module, testBundle: testBundle).bootSimulator()
     }
 
     func provideScope(for test: Testing.Test, testCase: Testing.Test.Case?,
                       performing function: @concurrent @Sendable () async throws -> Void) async throws
     {
-        try await Self.$testRunner.withValue(XcodeTestRunner(module: module, testBundle: testBundle), operation: function)
+        let runner = XcodeTestRunner(module: module, testBundle: testBundle)
+        try await runner.build()
+        try await Self.$testRunner.withValue(runner, operation: function)
     }
 
     @TaskLocal static var testRunner: XcodeTestRunner?


### PR DESCRIPTION
## Summary

- Defer the inner `xcodebuild build-for-testing` out of Swift Testing's `prepare(for:)` and into `provideScope(for:performing:)`. xcodebuild gates the xctest "ready to run" handshake on trait preparation finishing within a multi-minute cap; the inner build is well over that on cold checkouts and trips _"The test runner timed out while preparing to run tests"_ (confirmed via xcresult on a failing visionOS run). Simulator boot stays in `prepare(for:)` because it's cheap.
- Inner `xcodebuild` invocations now use an isolated `-derivedDataPath $SRCROOT/build/integration-DerivedData` so the inner SWBBuildService can't evict the outer test bundle's cached build descriptions mid-run. This matches the duplicate-blueprint warnings and mid-build aborts seen in the original CI logs.
- On `failure()`, the workflow now zips and uploads every `*.xcresult` from both DerivedData roots as a separate artifact, so future failures don't truncate the way the original logs did.

## Test plan

- [x] Re-run **Integration Tests** workflow on this branch via `workflow_dispatch` across the full matrix (Xcode 26.2 / 26.4 × macOS / iOSsim / tvOSsim / watchOSsim / visionOSsim).
- [x] Confirm no job hits "test runner timed out while preparing to run tests".
- [x] If a job does fail, verify the new `*-integration-xcresult` artifact is attached and openable with `xcrun xcresulttool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)