### PR TITLE
[CHORE] Rename test model classes with DD prefix and simplify Exporter naming

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -154,13 +154,13 @@
 		A7FC25882BA1E87400067E26 /* EventsExporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7FC25802BA1E87400067E26 /* EventsExporter.framework */; };
 		A7FC25B42BA1EADF00067E26 /* DDXCTestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA07025231F4700ED8AEF /* DDXCTestObserver.swift */; };
 		A7FC25B52BA1EADF00067E26 /* DDInstrumentationControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E158E2DB25471DA000DBCD6C /* DDInstrumentationControl.swift */; };
-		A7FC25B62BA1EADF00067E26 /* DDTestModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10034D92703599D00439C9C /* DDTestModule.swift */; };
-		A7FC25B72BA1EADF00067E26 /* DDTestSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8194A2242940B33100B4B592 /* DDTestSession.swift */; };
+		A7FC25B62BA1EADF00067E26 /* DDModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10034D92703599D00439C9C /* DDModule.swift */; };
+		A7FC25B72BA1EADF00067E26 /* DDSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8194A2242940B33100B4B592 /* DDSession.swift */; };
 		A7FC25B82BA1EADF00067E26 /* DDTracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1798CC52524B9BD008DEBB9 /* DDTracer.swift */; };
 		A7FC25BA2BA1EADF00067E26 /* DDTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA07125231F4700ED8AEF /* DDTags.swift */; };
 		A7FC25BB2BA1EADF00067E26 /* DDTestMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA08A252341EA00ED8AEF /* DDTestMonitor.swift */; };
 		A7FC25BC2BA1EADF00067E26 /* FrameworkLoadHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ABA07225231F4700ED8AEF /* FrameworkLoadHandler.swift */; };
-		A7FC25BD2BA1EADF00067E26 /* DDTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1743F4C283E7D9E006CBFF8 /* DDTestSuite.swift */; };
+		A7FC25BD2BA1EADF00067E26 /* DDSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1743F4C283E7D9E006CBFF8 /* DDSuite.swift */; };
 		A7FC25BE2BA1EADF00067E26 /* DDTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1743F4D283E7DAE006CBFF8 /* DDTest.swift */; };
 		A7FC25BF2BA1EAEB00067E26 /* CodeCoverageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C8DEF4268363EC005B5411 /* CodeCoverageProvider.swift */; };
 		A7FC25C02BA1EAEB00067E26 /* LLVMTotalsCoverageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81EDADB2292698A200279027 /* LLVMTotalsCoverageFormat.swift */; };
@@ -218,12 +218,12 @@
 		A7FC26492BA1ECF800067E26 /* Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CF1727D7790300F4018A /* Directory.swift */; };
 		A7FC264A2BA1ECF800067E26 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CF1827D7790300F4018A /* File.swift */; };
 		A7FC264C2BA1ED0C00067E26 /* ExporterConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CF0C27D7790300F4018A /* ExporterConfiguration.swift */; };
-		A7FC264D2BA1ED1200067E26 /* EventsExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CF1927D7790300F4018A /* EventsExporter.swift */; };
+		A7FC264D2BA1ED1200067E26 /* Exporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CF1927D7790300F4018A /* Exporter.swift */; };
 		A7FC26502BA1F1E600067E26 /* Recording in Frameworks */ = {isa = PBXBuildFile; productRef = A7FC26F82BA87E4000067E26 /* Recording */; };
 		A7FC26512BA1F1E600067E26 /* SigmaSwiftStatistics in Frameworks */ = {isa = PBXBuildFile; productRef = E157A71A256E9D1D00CBCA52 /* SigmaSwiftStatistics */; };
 		A7FC26552BA1F1F900067E26 /* EventsExporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7FC25802BA1E87400067E26 /* EventsExporter.framework */; };
 		A7FC265E2BA1F65200067E26 /* fixtures in Resources */ = {isa = PBXBuildFile; fileRef = A7C292122B9B2B39009C2979 /* fixtures */; };
-		A7FC265F2BA1F66E00067E26 /* DDTestSessionApiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E171DC91270DBCAB00A12B79 /* DDTestSessionApiTests.m */; };
+		A7FC265F2BA1F66E00067E26 /* DDSessionApiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E171DC91270DBCAB00A12B79 /* DDSessionApiTests.m */; };
 		A7FC26602BA1F67800067E26 /* SimpleSpanSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FB4844253891E70083B263 /* SimpleSpanSerializerTests.swift */; };
 		A7FC26612BA1F67800067E26 /* DDSymbolicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15264AE25FA3C16008B8665 /* DDSymbolicatorTests.swift */; };
 		A7FC26622BA1F67F00067E26 /* DDNetworkInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14AA0BF2555A9A1003FA711 /* DDNetworkInstrumentationTests.swift */; };
@@ -426,7 +426,7 @@
 		5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GitUploadApi.swift; sourceTree = "<group>"; };
 		6F3EB9ACD93007FC43F039EE /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
 		81894A4E29B0A28B00108C51 /* Retrying.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Retrying.swift; sourceTree = "<group>"; };
-		8194A2242940B33100B4B592 /* DDTestSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTestSession.swift; sourceTree = "<group>"; };
+		8194A2242940B33100B4B592 /* DDSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSession.swift; sourceTree = "<group>"; };
 		81AA244A2978589600DE8F8A /* DDFileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDFileReader.swift; sourceTree = "<group>"; };
 		81EDADB2292698A200279027 /* LLVMTotalsCoverageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLVMTotalsCoverageFormat.swift; sourceTree = "<group>"; };
 		8EE92A3947C2E5BD2183BB4E /* MultipartFormURLRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MultipartFormURLRequest.swift; sourceTree = "<group>"; };
@@ -572,7 +572,7 @@
 		CC931D86ADB841B6969C7A7A /* EarlyFlakeDetectionSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlyFlakeDetectionSwiftTestingTests.swift; sourceTree = "<group>"; };
 		D969899DDA68AF3C690F7FF8 /* LogsApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogsApi.swift; sourceTree = "<group>"; };
 		E0B522400A21CABC6BB4F1CA /* TestOptimizationApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestOptimizationApi.swift; sourceTree = "<group>"; };
-		E10034D92703599D00439C9C /* DDTestModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTestModule.swift; sourceTree = "<group>"; };
+		E10034D92703599D00439C9C /* DDModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDModule.swift; sourceTree = "<group>"; };
 		E11295BA25F2483D002719E7 /* FileLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLocator.swift; sourceTree = "<group>"; };
 		E116D7DA25248C390022779D /* SwiftExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		E117CFC626307B9A00ACE977 /* SpySpanProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpySpanProcessor.swift; sourceTree = "<group>"; };
@@ -633,7 +633,7 @@
 		E143CF1527D7790300F4018A /* FileReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileReader.swift; sourceTree = "<group>"; };
 		E143CF1727D7790300F4018A /* Directory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Directory.swift; sourceTree = "<group>"; };
 		E143CF1827D7790300F4018A /* File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
-		E143CF1927D7790300F4018A /* EventsExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsExporter.swift; sourceTree = "<group>"; };
+		E143CF1927D7790300F4018A /* Exporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exporter.swift; sourceTree = "<group>"; };
 		E143CF1C27D7790300F4018A /* DataUploader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataUploader.swift; sourceTree = "<group>"; };
 		E143CF1E27D7790300F4018A /* DataUploadWorker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataUploadWorker.swift; sourceTree = "<group>"; };
 		E143CF2027D7790300F4018A /* DataUploadDelay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataUploadDelay.swift; sourceTree = "<group>"; };
@@ -649,8 +649,8 @@
 		E160A11125275CC1003121A5 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		E1665A7225D12D7500BA53CD /* Spawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spawn.swift; sourceTree = "<group>"; };
 		E1665A8025D13BBB00BA53CD /* DDSymbolicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSymbolicator.swift; sourceTree = "<group>"; };
-		E171DC91270DBCAB00A12B79 /* DDTestSessionApiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDTestSessionApiTests.m; sourceTree = "<group>"; };
-		E1743F4C283E7D9E006CBFF8 /* DDTestSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTestSuite.swift; sourceTree = "<group>"; };
+		E171DC91270DBCAB00A12B79 /* DDSessionApiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDSessionApiTests.m; sourceTree = "<group>"; };
+		E1743F4C283E7D9E006CBFF8 /* DDSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSuite.swift; sourceTree = "<group>"; };
 		E1743F4D283E7DAE006CBFF8 /* DDTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTest.swift; sourceTree = "<group>"; };
 		E1743F5628490141006CBFF8 /* CoverageExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverageExporter.swift; sourceTree = "<group>"; };
 		E1798CC52524B9BD008DEBB9 /* DDTracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracer.swift; sourceTree = "<group>"; };
@@ -1123,7 +1123,7 @@
 				E143CF1127D7790300F4018A /* Persistence */,
 				E143CF1627D7790300F4018A /* Files */,
 				E143CF0C27D7790300F4018A /* ExporterConfiguration.swift */,
-				E143CF1927D7790300F4018A /* EventsExporter.swift */,
+				E143CF1927D7790300F4018A /* Exporter.swift */,
 				A7AB7C2026E7EB1100000002 /* OpenTelemetry+Extensions.swift */,
 			);
 			path = EventsExporter;
@@ -1221,7 +1221,7 @@
 		E171DC90270DBC6A00A12B79 /* ObjCApi */ = {
 			isa = PBXGroup;
 			children = (
-				E171DC91270DBCAB00A12B79 /* DDTestSessionApiTests.m */,
+				E171DC91270DBCAB00A12B79 /* DDSessionApiTests.m */,
 			);
 			path = ObjCApi;
 			sourceTree = "<group>";
@@ -1276,9 +1276,9 @@
 				A79FAD9A2F8559530080C3F6 /* AdditionalTagsFeature.swift */,
 				A7EE000000031000000000B0 /* LibraryConfigurationCommunicationError.swift */,
 				E158E2DB25471DA000DBCD6C /* DDInstrumentationControl.swift */,
-				8194A2242940B33100B4B592 /* DDTestSession.swift */,
-				E10034D92703599D00439C9C /* DDTestModule.swift */,
-				E1743F4C283E7D9E006CBFF8 /* DDTestSuite.swift */,
+				8194A2242940B33100B4B592 /* DDSession.swift */,
+				E10034D92703599D00439C9C /* DDModule.swift */,
+				E1743F4C283E7D9E006CBFF8 /* DDSuite.swift */,
 				E1743F4D283E7DAE006CBFF8 /* DDTest.swift */,
 				A7AB7C2026E7EB110000001E /* SpanSdk+TestStatus.swift */,
 				E1ABA07125231F4700ED8AEF /* DDTags.swift */,
@@ -1970,7 +1970,7 @@
 				A7FC26082BA1EC0500067E26 /* FileLocator.swift in Sources */,
 				A7FC26132BA1EC0500067E26 /* CodeOwners.swift in Sources */,
 				A77C12332D8C9798009C2BA1 /* KnownTests.swift in Sources */,
-				A7FC25B72BA1EADF00067E26 /* DDTestSession.swift in Sources */,
+				A7FC25B72BA1EADF00067E26 /* DDSession.swift in Sources */,
 				A77C12352D8C9F5D009C2BA1 /* TestManagement.swift in Sources */,
 				A77C12392D8DD2A9009C2BA1 /* Feature.swift in Sources */,
 				A7B0120F2F364B97000270A4 /* InstrumentationUtils.swift in Sources */,
@@ -1995,7 +1995,7 @@
 				A7FC260D2BA1EC0500067E26 /* SignalUtils.swift in Sources */,
 				A7B012152F364C37000270A4 /* URLSessionLogger.swift in Sources */,
 				A7FC25D42BA1EB3400067E26 /* BinaryImages.swift in Sources */,
-				A7FC25B62BA1EADF00067E26 /* DDTestModule.swift in Sources */,
+				A7FC25B62BA1EADF00067E26 /* DDModule.swift in Sources */,
 				A7B012132F364C04000270A4 /* URLSessionInstrumentationConfiguration.swift in Sources */,
 				A71E646A2BAA0AA100F2ACA5 /* Environment.swift in Sources */,
 				A754BB102F8E7930001613EB /* XCTestTags.swift in Sources */,
@@ -2018,7 +2018,7 @@
 				A71E647C2BAA0AA100F2ACA5 /* EnvironmentKeys.swift in Sources */,
 				A7FC25C02BA1EAEB00067E26 /* LLVMTotalsCoverageFormat.swift in Sources */,
 				A76174BD2CB3E3780098CE99 /* DDXCTestCase.swift in Sources */,
-				A7FC25BD2BA1EADF00067E26 /* DDTestSuite.swift in Sources */,
+				A7FC25BD2BA1EADF00067E26 /* DDSuite.swift in Sources */,
 				A7CC6D882C0F3F83003C13BC /* Tags+ObjC.swift in Sources */,
 				A74C91CA2E67278800B10681 /* DroneCI.swift in Sources */,
 				A7FC25D12BA1EB2900067E26 /* DDCrashes.swift in Sources */,
@@ -2069,7 +2069,7 @@
 				A75DAB9C2DEE18DD00F1B8A7 /* MockTestRunner.swift in Sources */,
 				A718EC352CC7F32A00C5F0D9 /* EarlyFlakeDetectionTests.swift in Sources */,
 				300F42B595C3462AB9656B0C /* EarlyFlakeDetectionSwiftTestingTests.swift in Sources */,
-				A7FC265F2BA1F66E00067E26 /* DDTestSessionApiTests.m in Sources */,
+				A7FC265F2BA1F66E00067E26 /* DDSessionApiTests.m in Sources */,
 				A7FC26602BA1F67800067E26 /* SimpleSpanSerializerTests.swift in Sources */,
 				A7FC26672BA1F6FC00067E26 /* CodeOwnersTests.swift in Sources */,
 				A7FC26622BA1F67F00067E26 /* DDNetworkInstrumentationTests.swift in Sources */,
@@ -2124,7 +2124,7 @@
 				A74EB8E62D0B449300FAD9B8 /* TestCodeCoverage.swift in Sources */,
 				A7FC26192BA1EC5A00067E26 /* DataUploadDelay.swift in Sources */,
 				A7FC264A2BA1ECF800067E26 /* File.swift in Sources */,
-				A7FC264D2BA1ED1200067E26 /* EventsExporter.swift in Sources */,
+				A7FC264D2BA1ED1200067E26 /* Exporter.swift in Sources */,
 				A7FC26302BA1ECBD00067E26 /* CoverageExporter.swift in Sources */,
 				A7AB7C2026E7EB1100000011 /* CoverageData.swift in Sources */,
 				A7AB7C2026E7EB1100000013 /* CoverageProcessor.swift in Sources */,

--- a/IntegrationTests/Runner/UnitTests+SwiftTestingSmoke.swift
+++ b/IntegrationTests/Runner/UnitTests+SwiftTestingSmoke.swift
@@ -187,7 +187,7 @@ struct UnitTestsSwiftTestingSmoke: IntergationTestSuite {
             #expect(failed[DDTags.errorCrashLog + ".00"] != nil)
 
             // save all error tags to our test span so we can inspect them in the DD UI
-            if let test = DatadogSDKTesting.Test.current {
+            if let test = DDTest.current {
                 let tags = [DDTags.errorType, DDTags.errorMessage, DDTags.errorStack,
                             DDTags.errorCrashLog + ".00", DDTags.errorCrashLog + ".01",
                             DDTags.errorCrashLog + ".02", DDTags.errorCrashLog + ".03",

--- a/IntegrationTests/Runner/UnitTests+XCTestSmoke.swift
+++ b/IntegrationTests/Runner/UnitTests+XCTestSmoke.swift
@@ -158,7 +158,7 @@ struct UnitTestsXCTestSmoke: IntergationTestSuite {
             #expect(failed[DDTags.errorCrashLog + ".00"] != nil)
             
             // save all error tags to our test span so we can inspect them in the DD UI
-            if let test = DatadogSDKTesting.Test.current {
+            if let test = DDTest.current {
                 let tags = [DDTags.errorType, DDTags.errorMessage, DDTags.errorStack,
                             DDTags.errorCrashLog + ".00", DDTags.errorCrashLog + ".01",
                             DDTags.errorCrashLog + ".02", DDTags.errorCrashLog + ".03",

--- a/IntegrationTests/UnitTests/SwiftTestingSmokeTests.swift
+++ b/IntegrationTests/UnitTests/SwiftTestingSmokeTests.swift
@@ -18,7 +18,7 @@ import OpenTelemetryApi
 @Suite(.datadogTesting) struct STBasicSkip {
     @Test func basicSkip() throws {
 #if compiler(>=6.3)
-        try Testing.Test.cancel("skip")
+        try Test.cancel("skip")
 #endif
     }
 }
@@ -39,7 +39,7 @@ import OpenTelemetryApi
     @Test func asynchronousSkip() async throws {
         try await Task.sleep(nanoseconds: 1_000_000_000)
 #if compiler(>=6.3)
-        try Testing.Test.cancel("skip")
+        try Test.cancel("skip")
 #endif
     }
 }

--- a/Sources/DatadogSDKTesting/Coverage/CodeCoverage.swift
+++ b/Sources/DatadogSDKTesting/Coverage/CodeCoverage.swift
@@ -108,7 +108,7 @@ struct CodeCoverageFactory: FeatureFactory {
     let priority: CodeCoveragePriority
     let tempFolder: Directory
     let debug: Bool
-    let exporter: EventsExporterProtocol
+    let exporter: ExporterProtocol
     let swiftTestingEnabled: Bool
 
     static func isEnabled(config: Config, env: Environment, remote: TracerSettings) -> Bool {

--- a/Sources/DatadogSDKTesting/Coverage/CodeCoverageProvider.swift
+++ b/Sources/DatadogSDKTesting/Coverage/CodeCoverageProvider.swift
@@ -50,7 +50,7 @@ final class CodeCoverageProvider: TestCoverageCollector {
     let storagePath: Directory
     let debug: Bool
 
-    init(storagePath: Directory, exporter: EventsExporterProtocol,
+    init(storagePath: Directory, exporter: ExporterProtocol,
          workspacePath: String?, priority: CodeCoveragePriority, debug: Bool) throws
     {
         let llvm = try LLVMCoverageProcessor(for: PlatformUtils.xcodeVersion,

--- a/Sources/DatadogSDKTesting/Crashes/DDCrashes.swift
+++ b/Sources/DatadogSDKTesting/Crashes/DDCrashes.swift
@@ -80,7 +80,7 @@ private let ddCrashIsWritingReportCallback: @convention(c) (
     if let info = SanitizerHelper.getSaniziterInfo(), let url = DDCrashes.sanitizerURL {
         try? info.write(to: url, atomically: true, encoding: .utf8)
     }
-    if let url = DDCrashes.spanURL, let test = Test.current {
+    if let url = DDCrashes.spanURL, let test = DDTest.current {
         let data = SimpleSpanSerializer.serializeSpan(simpleSpan: test.toCrashData)
         try? data.write(to: url, options: .atomic)
     }

--- a/Sources/DatadogSDKTesting/Crashes/SimpleSpanData.swift
+++ b/Sources/DatadogSDKTesting/Crashes/SimpleSpanData.swift
@@ -74,7 +74,7 @@ extension TestSuite {
     }
 }
 
-extension Test {
+extension DDTest {
     var toCrashData: SimpleSpanData {
         .init(spanData: span.toSpanData(),
               sessionStartTime: session.startTime,

--- a/Sources/DatadogSDKTesting/DDModule.swift
+++ b/Sources/DatadogSDKTesting/DDModule.swift
@@ -9,8 +9,8 @@ import Foundation
 @preconcurrency internal import OpenTelemetrySdk
 internal import EventsExporter
 
-@objc(DDTestModule)
-public final class Module: NSObject {
+@objc
+public final class DDModule: NSObject {
     struct MutableState {
         var testFrameworks: Set<String> = []
     }
@@ -30,10 +30,10 @@ public final class Module: NSObject {
     var configuration: SessionConfig { _session.configuration }
     var startTime: Date { span.startTime }
 
-    private let _session: Session
+    private let _session: DDSession
     private let _state: Synced<MutableState>
 
-    init(name: String, session: Session, startTime: Date?) {
+    init(name: String, session: DDSession, startTime: Date?) {
         self.name = name
         self._session = session
 
@@ -97,7 +97,7 @@ public final class Module: NSObject {
         span.setAttribute(key: DDTestTags.testFramework,
                           value: .string(_state.value.testFrameworks.joined(separator: ",")))
         span.name = framework
-        // get-status -> set-status round-trip (see DDTestSession).
+        // get-status -> set-status round-trip (see DDSession).
         span.applyStatus(span.testStatus, errorDescription: "module failed")
         span.end(time: endTime)
 
@@ -110,8 +110,8 @@ public final class Module: NSObject {
     }
 }
 
-/// Public interface for DDTestModule
-public extension Module {
+/// Public interface for DDModule
+public extension DDModule {
     /// Ends the module
     /// - Parameters:
     ///   - endTime: Optional, the time where the module ended
@@ -136,16 +136,16 @@ public extension Module {
     /// - Parameters:
     ///   - name: name of the suite
     ///   - startTime: Optional, the time where the suite started
-    @objc func suiteStart(name: String, startTime: Date? = nil) -> Suite {
-        startSuite(named: name, at: startTime, framework: .init(name: "SwiftManual", version: "0.0.0")) as! Suite
+    @objc func suiteStart(name: String, startTime: Date? = nil) -> DDSuite {
+        startSuite(named: name, at: startTime, framework: .init(name: "SwiftManual", version: "0.0.0")) as! DDSuite
     }
 
-    @objc func suiteStart(name: String) -> Suite {
+    @objc func suiteStart(name: String) -> DDSuite {
         return suiteStart(name: name, startTime: nil)
     }
 }
 
-extension Module: TestModule {
+extension DDModule: TestModule {
     var attributes: [String: TestAttributeValue] { span.getAttributes().testAttributes }
 
     func set(tag name: String, value: SpanAttributeConvertible) {
@@ -176,9 +176,9 @@ extension Module: TestModule {
     func end(time: Date?) { end(endTime: time) }
 }
 
-extension Module: TestSuiteProvider {
+extension DDModule: TestSuiteProvider {
     func startSuite(named name: String, at start: Date?, framework: TestFramework) -> any TestRunProvider & TestSuite {
         addFramework(framework.name)
-        return Suite(name: name, module: self, framework: framework, startTime: start)
+        return DDSuite(name: name, module: self, framework: framework, startTime: start)
     }
 }

--- a/Sources/DatadogSDKTesting/DDSession.swift
+++ b/Sources/DatadogSDKTesting/DDSession.swift
@@ -9,8 +9,8 @@ import Foundation
 @preconcurrency internal import OpenTelemetrySdk
 internal import EventsExporter
 
-@objc(DDTestSession)
-public final class Session: NSObject {
+@objc
+public final class DDSession: NSObject {
     struct MutableState {
         var testRunsCount: UInt = 0
         var testFrameworks: Set<String> = []
@@ -113,7 +113,7 @@ public final class Session: NSObject {
     }
 }
 
-extension Session: TestSession {
+extension DDSession: TestSession {
     var attributes: [String: TestAttributeValue] { span.getAttributes().testAttributes }
 
     func set(tag name: String, value: any SpanAttributeConvertible) {
@@ -148,14 +148,14 @@ extension Session: TestSession {
     func end(time: Date?) { end(endTime: time) }
 }
 
-/// Public interface for Session
-public extension Session {
+/// Public interface for DDSession
+public extension DDSession {
     /// Starts the test session
     /// - Parameters:
     ///   - name: name of the session
     ///   - command: Optional, test command that started this session
     ///   - startTime: Optional, the time where the session started
-    @objc static func start(name: String, command: String? = nil, startTime: Date? = nil) -> Session {
+    @objc static func start(name: String, command: String? = nil, startTime: Date? = nil) -> DDSession {
         if DDTestMonitor.instance == nil  {
             let _ = DDTestMonitor.installTestMonitor()
         }
@@ -174,13 +174,13 @@ public extension Session {
                 DDTestMonitor.clock = DateClock()
             }
         }
-        return Session(name: name, config: config,
-                       modules: Module.StatelessManager(config: config,
-                                                        observer: SessionAndModuleObserver()),
-                       startTime: startTime)
+        return DDSession(name: name, config: config,
+                         modules: DDModule.StatelessManager(config: config,
+                                                            observer: SessionAndModuleObserver()),
+                         startTime: startTime)
     }
 
-    @objc static func start(name: String) -> Session {
+    @objc static func start(name: String) -> DDSession {
         return start(name: name, command: nil)
     }
 
@@ -208,22 +208,22 @@ public extension Session {
     /// - Parameters:
     ///   - name: name of the module
     ///   - startTime: Optional, the time where the module started
-    @objc func moduleStart(name: String, startTime: Date? = nil) -> Module {
-        return _moduleManager.module(named: name, at: startTime, provider: self) as! Module
+    @objc func moduleStart(name: String, startTime: Date? = nil) -> DDModule {
+        return _moduleManager.module(named: name, at: startTime, provider: self) as! DDModule
     }
 
-    @objc func moduleStart(name: String) -> Module {
+    @objc func moduleStart(name: String) -> DDModule {
         return moduleStart(name: name, startTime: nil)
     }
 }
 
-extension Session: TestModuleProvider {
+extension DDSession: TestModuleProvider {
     func startModule(named name: String, at start: Date?) -> any TestModule & TestSuiteProvider {
-        Module(name: name, session: self, startTime: start)
+        DDModule(name: name, session: self, startTime: start)
     }
 }
 
-extension Session: TestModuleManager {
+extension DDSession: TestModuleManager {
     func module(named name: String) -> any TestModule & TestSuiteProvider {
         moduleStart(name: name, startTime: configuration.clock.now)
     }

--- a/Sources/DatadogSDKTesting/DDSuite.swift
+++ b/Sources/DatadogSDKTesting/DDSuite.swift
@@ -9,8 +9,8 @@ import Foundation
 @preconcurrency internal import OpenTelemetrySdk
 internal import EventsExporter
 
-@objc(DDTestSuite)
-public final class Suite: NSObject {
+@objc
+public final class DDSuite: NSObject {
     struct MutableState {
         var testsStarted: Int = 0
     }
@@ -30,10 +30,10 @@ public final class Suite: NSObject {
     var module: TestModule { _module }
     var startTime: Date { span.startTime }
 
-    private let _module: Module
+    private let _module: DDModule
     private let _state: Synced<MutableState>
 
-    init(name: String, module: Module, framework: TestFramework, startTime: Date? = nil) {
+    init(name: String, module: DDModule, framework: TestFramework, startTime: Date? = nil) {
         self.name = name
         self._module = module
         self.testFramework = framework
@@ -103,7 +103,7 @@ public final class Suite: NSObject {
             return
         }
 
-        // get-status -> set-status round-trip (see DDTestSession).
+        // get-status -> set-status round-trip (see DDSession).
         span.applyStatus(span.testStatus, errorDescription: "suite failed")
         span.end(time: endTime)
         Log.debug("Exported suite_end event suiteId: \(self.id)")
@@ -133,7 +133,7 @@ public final class Suite: NSObject {
     ///   - name: name of the suite
     ///   - action: callback with test. Test will be ended automatically after call end
     @discardableResult
-    @objc public func testStart(name: String, _ action: (Test) -> Any) -> Any {
+    @objc public func testStart(name: String, _ action: (DDTest) -> Any) -> Any {
         testStart(named: name, action)
     }
 
@@ -142,24 +142,24 @@ public final class Suite: NSObject {
     ///   - name: name of the suite
     ///   - startTime: start time for the test
     ///   - action: callback with test. Test will be ended automatically after call end
-    @objc public func testStart(name: String, startTime: Date, _ action: (Test) -> Any) -> Any {
+    @objc public func testStart(name: String, startTime: Date, _ action: (DDTest) -> Any) -> Any {
         testStart(named: name, at: startTime, action)
     }
 
     public func testStart<T>(named name: String, at start: Date? = nil,
-                             _ action: (Test) throws -> T) rethrows -> T
+                             _ action: (DDTest) throws -> T) rethrows -> T
     {
-        try Test.withActiveTest(named: name, in: self, at: start, action)
+        try DDTest.withActiveTest(named: name, in: self, at: start, action)
     }
 
     public func testStart<T>(named name: String, at start: Date? = nil,
-                             _ action: @Sendable (Test) async throws -> T) async rethrows -> T
+                             _ action: @Sendable (DDTest) async throws -> T) async rethrows -> T
     {
-        try await Test.withActiveTest(named: name, in: self, at: start, action)
+        try await DDTest.withActiveTest(named: name, in: self, at: start, action)
     }
 }
 
-extension Suite: TestSuite {
+extension DDSuite: TestSuite {
     var attributes: [String: TestAttributeValue] { span.getAttributes().testAttributes }
 
     func set(tag name: String, value: SpanAttributeConvertible) {
@@ -190,7 +190,7 @@ extension Suite: TestSuite {
     func end(time: Date?) { end(endTime: time) }
 }
 
-extension Suite: TestRunProvider {
+extension DDSuite: TestRunProvider {
     func withActiveTest<T>(named name: String, _ action: @Sendable (any TestRun) async throws -> T) async rethrows -> T {
         try await testStart(named: name, action)
     }

--- a/Sources/DatadogSDKTesting/DDTest.swift
+++ b/Sources/DatadogSDKTesting/DDTest.swift
@@ -10,8 +10,8 @@ import Foundation
 internal import SigmaSwiftStatistics
 internal import EventsExporter
 
-@objc(DDTest)
-public final class Test: NSObject {
+@objc
+public final class DDTest: NSObject {
     let name: String
     let span: SpanSdk
 
@@ -94,10 +94,10 @@ public final class Test: NSObject {
     }
     
     /// Current active test
-    @objc public static var current: Test? { Self.active as? Test }
+    @objc public static var current: DDTest? { Self.active as? DDTest }
 }
 
-extension Test: TestRun {
+extension DDTest: TestRun {
     var id: SpanId { span.context.spanId }
     var startTime: Date { span.startTime }
     var duration: UInt64 { span.endTime?.timeIntervalSince(span.startTime).toNanoseconds ?? 0 }
@@ -119,7 +119,7 @@ extension Test: TestRun {
     }
 }
 
-extension Test {
+extension DDTest {
     func internalEnd(endTime: Date) {
         guard span.endTime == nil else { return }
         StderrCapture.syncData()
@@ -127,8 +127,8 @@ extension Test {
         DDTestMonitor.instance?.networkInstrumentation?.endAndCleanAliveSpans()
     }
     
-    static func withActiveTest<T>(named name: String, in suite: Suite, at start: Date? = nil,
-                               _ action: @Sendable (Test) async throws -> T) async rethrows -> T
+    static func withActiveTest<T>(named name: String, in suite: DDSuite, at start: Date? = nil,
+                               _ action: @Sendable (DDTest) async throws -> T) async rethrows -> T
     {
         let testStartTime = start ?? suite.configuration.clock.now
         suite.recordTestStarted()
@@ -144,8 +144,8 @@ extension Test {
         }
     }
 
-    static func withActiveTest<T>(named name: String, in suite: Suite, at start: Date? = nil,
-                               _ action: (Test) throws -> T) rethrows -> T
+    static func withActiveTest<T>(named name: String, in suite: DDSuite, at start: Date? = nil,
+                               _ action: (DDTest) throws -> T) rethrows -> T
     {
         let testStartTime = start ?? suite.configuration.clock.now
         suite.recordTestStarted()
@@ -161,7 +161,7 @@ extension Test {
         }
     }
     
-    static func attributes(test name: String, in suite: Suite) -> [String: AttributeValue] {
+    static func attributes(test name: String, in suite: DDSuite) -> [String: AttributeValue] {
         var attributes: [String: AttributeValue] = [
             DDTestTags.testName: .string(name),
             DDTestTags.testSuite: .string(suite.name),

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -665,7 +665,7 @@ internal class DDTestMonitor {
             switch msgid {
                 case DDCFMessageID.setCustomTags:
                 if let data = data as Data?, let decoded = try? JSONDecoder().decode([String: JSONGeneric].self, from: data) {
-                        if let test = Test.active {
+                        if let test = DDTest.active {
                             decoded.forEach {
                                 test.set(tag: $0.key, value: $0.value)
                             }
@@ -673,7 +673,7 @@ internal class DDTestMonitor {
                     }
                 case DDCFMessageID.enableRUM:
                     DDTestMonitor.instance?.isRumActive = true
-                    Test.active?.set(tag: DDTestTags.testIsRUMActive, value: true)
+                    DDTest.active?.set(tag: DDTestTags.testIsRUMActive, value: true)
                 case DDCFMessageID.forceFlush:
                     Log.debug("CFMessagePort forceFlush")
                 default:

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -21,7 +21,7 @@ internal class DDTracer {
     let tracerSdk: TracerSdk
     let tracerProviderSdk: TracerProviderSdk
     let maxObjectSize: UInt64
-    var eventsExporter: EventsExporterProtocol?
+    var eventsExporter: ExporterProtocol?
     /// Backend APIs owned by the SDK (not by the exporter). Held here so
     /// feature factories don't need to reach through `eventsExporter` to talk
     /// to the backend.
@@ -36,7 +36,7 @@ internal class DDTracer {
     private var launchSpanContext: SpanContext?
     private let attributeCountLimit: UInt = 1024
 
-    static var activeSpan: Span? { OpenTelemetry.instance.contextProvider.activeSpan ?? Test.current?.span }
+    static var activeSpan: Span? { OpenTelemetry.instance.contextProvider.activeSpan ?? DDTest.current?.span }
 
     var propagationContext: SpanContext? {
         return DDTracer.activeSpan?.context ?? launchSpanContext
@@ -46,7 +46,7 @@ internal class DDTracer {
         return launchSpanContext != nil
     }
     
-    init(id: String, version: String, exporter: EventsExporterProtocol?,
+    init(id: String, version: String, exporter: ExporterProtocol?,
          api: TestOptimizationApi, enabled: Bool, launchContext: SpanContext?,
          resource: Resource = Resource(),
          logRecordExporter: LogRecordExporter? = nil)
@@ -171,11 +171,11 @@ internal class DDTracer {
         // Exporter files live under the cache manager's session directory so
         // they stay scoped to this test run and get cleaned up alongside the
         // rest of the per-session state.
-        let eventsExporter: EventsExporter?
+        let eventsExporter: Exporter?
         if let storage = try? DDTestMonitor.cacheManager?.session(feature: "exporter") {
-            eventsExporter = try? EventsExporter(config: exporterConfiguration, api: api, storage: storage)
+            eventsExporter = try? Exporter(config: exporterConfiguration, api: api, storage: storage)
         } else {
-            Log.print("EventsExporter init skipped: cache manager unavailable")
+            Log.print("Exporter init skipped: cache manager unavailable")
             eventsExporter = nil
         }
 
@@ -362,7 +362,7 @@ internal class DDTracer {
     }
 
     private func testAttributes() -> [String: AttributeValue] {
-        guard let currentTest = Test.active else {
+        guard let currentTest = DDTest.active else {
             return [:]
         }
         return [DDTestTags.testName: AttributeValue.string(currentTest.name),

--- a/Sources/DatadogSDKTesting/FrameworkLoadHandler.swift
+++ b/Sources/DatadogSDKTesting/FrameworkLoadHandler.swift
@@ -36,7 +36,7 @@ enum FrameworkLoadHandler {
         if config.isInTestMode {
             if config.isTestObserverNeeded && !config.disableTestInstrumenting {
                 let manager = SessionManager(log: Log.instance,
-                                             provider: Session.Provider(),
+                                             provider: DDSession.Provider(),
                                              observer: SessionAndModuleObserver())
                 sessionManager = manager
                 

--- a/Sources/DatadogSDKTesting/SessionManager.swift
+++ b/Sources/DatadogSDKTesting/SessionManager.swift
@@ -96,15 +96,15 @@ extension SessionManager {
     }
 }
 
-extension Session {
+extension DDSession {
     struct Provider: TestSessionProvider {
         func startSession(named name: String, config: SessionConfig, startTime: Date,
                           observer: (any TestModuleManagerObserver)?) async throws -> any TestModuleManager & TestSession
         {
-            Session(name: name, config: config,
-                    modules: Module.StatefulManager(config: config,
-                                                    observer: observer),
-                    startTime: startTime)
+            DDSession(name: name, config: config,
+                      modules: DDModule.StatefulManager(config: config,
+                                                        observer: observer),
+                      startTime: startTime)
         }
     }
 }
@@ -115,7 +115,7 @@ protocol TestModuleManagerSession: Sendable {
     func stop()
 }
 
-extension Module {
+extension DDModule {
     struct StatelessManager: TestModuleManagerSession, Sendable {
         let config: SessionConfig
         let observer: (any TestModuleManagerObserver)?

--- a/Sources/DatadogSDKTesting/XCTest/XCUIApplicationSwizzler.swift
+++ b/Sources/DatadogSDKTesting/XCTest/XCUIApplicationSwizzler.swift
@@ -26,7 +26,7 @@ extension XCUIApplication {
     }()
 
     @objc func swizzled_launch() {
-        Test.current?.setIsUITest(true)
+        DDTest.current?.setIsUITest(true)
         if let testSpanContext = DDTestMonitor.tracer.propagationContext {
             self.launchEnvironment[EnvironmentKey.tracerSpanId.rawValue] = testSpanContext.spanId.hexString
             self.launchEnvironment[EnvironmentKey.tracerTraceId.rawValue] = testSpanContext.traceId.hexString

--- a/Sources/EventsExporter/Exporter.swift
+++ b/Sources/EventsExporter/Exporter.swift
@@ -7,7 +7,7 @@
 import Foundation
 import OpenTelemetrySdk
 
-public protocol EventsExporterProtocol: SpanExporter, LogRecordExporter, CoverageExporterType {
+public protocol ExporterProtocol: SpanExporter, LogRecordExporter, CoverageExporterType {
     var maxObjectSize: UInt64 { get }
 
     /// Rebuild the spans file header from the supplied `SpanMetadata` and
@@ -16,7 +16,7 @@ public protocol EventsExporterProtocol: SpanExporter, LogRecordExporter, Coverag
     func setMetadata(_ metadata: SpanMetadata)
 }
 
-public final class EventsExporter: EventsExporterProtocol {
+public final class Exporter: ExporterProtocol {
     let configuration: ExporterConfiguration
     let spansExporter: SpansExporter
     let logsExporter: LogsExporter
@@ -52,7 +52,7 @@ public final class EventsExporter: EventsExporterProtocol {
             SpanEventsLogExporterAdapter(logRecordExporter: logsExporter),
         ])
 
-        Log.debug("EventsExporter created: \(spansExporter.runtimeId)")
+        Log.debug("Exporter created: \(spansExporter.runtimeId)")
     }
 
     public func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {

--- a/Tests/DatadogSDKTesting/DDXCTestObserverTests.swift
+++ b/Tests/DatadogSDKTesting/DDXCTestObserverTests.swift
@@ -23,7 +23,7 @@ internal class DDXCTestObserverTests: XCTestCase {
                                           "DD_DISABLE_TEST_INSTRUMENTING": "1",
                                           "DD_DISABLE_CRASH_HANDLER": "1"])
         session = SessionManager(log: Mocks.CatchLogger(isDebug: true),
-                                 provider: Session.Provider(), observer: nil)
+                                 provider: DDSession.Provider(), observer: nil)
         testObserver = DDXCTestObserver(session: session, log: Mocks.CatchLogger(isDebug: true))
         theSuite.setValue([self], forKey: "_mutableTests")
     }

--- a/Tests/DatadogSDKTesting/ObjCApi/DDSessionApiTests.m
+++ b/Tests/DatadogSDKTesting/ObjCApi/DDSessionApiTests.m
@@ -8,16 +8,16 @@
 #import <XCTest/XCTest.h>
 @import DatadogSDKTesting;
 
-@interface DDTestModuleApiTests : XCTestCase
+@interface DDSessionApiTests : XCTestCase
 
 @end
 
-@implementation DDTestModuleApiTests
+@implementation DDSessionApiTests
 
 - (void)testApiIsAccessible {
-    DDTestSession* session = [DDTestSession startWithName: @"ManualObjcTestingSession"];
-    DDTestModule *module = [session moduleStartWithName:@"ManualObjcTestingModule" startTime:nil];
-    DDTestSuite *suite = [module suiteStartWithName:@"ManualObjcTestingSuite" startTime:nil];
+    DDSession* session = [DDSession startWithName: @"ManualObjcTestingSession"];
+    DDModule *module = [session moduleStartWithName:@"ManualObjcTestingModule" startTime:nil];
+    DDSuite *suite = [module suiteStartWithName:@"ManualObjcTestingSuite" startTime:nil];
     [suite testStartWithName:@"ManualObjcTestingTest" :^id(DDTest* test) {
         [test setTagWithKey:@"key" value:@"value"];
         [test setErrorInfoWithType:@"errorType" message:@"error Message" callstack:nil];

--- a/Tests/EventsExporter/EventsExporterTests.swift
+++ b/Tests/EventsExporter/EventsExporterTests.swift
@@ -33,7 +33,7 @@ class EventsExporterTests: XCTestCase {
 
         let storage = try! Directory.temporary().createSubdirectory(path: UUID().uuidString)
         defer { try? storage.delete() }
-        let datadogExporter = try! EventsExporter(config: exporterConfiguration, api: api, storage: storage)
+        let datadogExporter = try! Exporter(config: exporterConfiguration, api: api, storage: storage)
         
         let spanProcessor = SimpleSpanProcessor(spanExporter: datadogExporter)
         defer { spanProcessor.shutdown() }

--- a/Tests/EventsExporter/PipelineIntegrationTests.swift
+++ b/Tests/EventsExporter/PipelineIntegrationTests.swift
@@ -28,7 +28,7 @@ class PipelineIntegrationTests: XCTestCase {
         let api = TestOptimizationApiService.mock(endpoint: endpoint)
         let storage = try Directory.temporary().createSubdirectory(path: UUID().uuidString)
         defer { try? storage.delete() }
-        let datadogExporter = try EventsExporter(config: configuration, api: api, storage: storage)
+        let datadogExporter = try Exporter(config: configuration, api: api, storage: storage)
 
         // -- 2. Resource the encoders read service / version / env from ---------
         var resource = Resource()


### PR DESCRIPTION
## Summary

Renames the public test model types to avoid the collision between the existing `Test` class and `Testing.Test` from the swift-testing framework, and gives the exporter a less wordy name.

- `Session` → `DDSession`
- `Module` → `DDModule`
- `Suite` → `DDSuite`
- `Test` → `DDTest`
- `EventsExporter` (class) → `Exporter`
- `EventsExporterProtocol` → `ExporterProtocol`

Files were renamed to match (`DDSession.swift`, `DDModule.swift`, `DDSuite.swift`, `Exporter.swift`, `DDSessionApiTests.m`) and the ObjC test class inside `DDSessionApiTests.m` — which had a stale `DDTestModuleApiTests` name despite testing the session API — was renamed to `DDSessionApiTests`.

Module/target names are unchanged: the `EventsExporter` target still ships as `EventsExporter`, only the type inside it is shortened.

## Notes

- The `@objc(...)` parenthesized ObjC name was dropped from each class because the Swift name now matches the desired ObjC name verbatim.
- `Tests/fixtures/symbols-sdk.log` is intentionally left referencing the old `DDTestModuleApiTests` / `DDTestSessionApiTests.m` strings — it's frozen test data that `FileLocatorTests.testSDKFixtureObjCMethod` parses; editing it would defeat the parser test.
- This is a breaking change for any external consumers of the Swift or ObjC public API of these classes.

## Test plan

- [x] `xcodebuild build` on macOS — succeeds locally
- [x] `xcodebuild build-for-testing` on macOS — succeeds locally
- [x] CI: unit tests + integration tests on all supported platforms
- [x] CI: ObjC API smoke test (`DDSessionApiTests`) still exercises `DDSession`/`DDModule`/`DDSuite`/`DDTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)