### PR TITLE
Truncate CI Visibility meta tag values

### DIFF
--- a/Sources/EventsExporter/Spans/MetaStringTruncation.swift
+++ b/Sources/EventsExporter/Spans/MetaStringTruncation.swift
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+
+internal let maxMetaStringValueLength = 5_000
+
+internal func truncateMetaStringValue(_ value: String) -> String {
+    value.count <= maxMetaStringValueLength ? value : String(value.prefix(maxMetaStringValueLength))
+}
+
+extension Dictionary where Key == String, Value == String {
+    func truncatingMetaStringValues() -> [String: String] {
+        var truncated: [String: String]?
+        for (key, value) in self {
+            let truncatedValue = truncateMetaStringValue(value)
+            if truncatedValue != value, truncated == nil {
+                truncated = self
+            }
+            truncated?[key] = truncatedValue
+        }
+        return truncated ?? self
+    }
+}

--- a/Sources/EventsExporter/Spans/SpanEncoder.swift
+++ b/Sources/EventsExporter/Spans/SpanEncoder.swift
@@ -173,9 +173,9 @@ internal struct SpanEncoder {
 
         if span.error {
             try container.encode(1, forKey: .error)
-            try meta.encodeIfPresent(span.errorMessage, forKey: .errorMessage)
-            try meta.encodeIfPresent(span.errorType, forKey: .errorType)
-            try meta.encodeIfPresent(span.errorStack, forKey: .errorStack)
+            try meta.encodeIfPresent(span.errorMessage.map(truncateMetaStringValue), forKey: .errorMessage)
+            try meta.encodeIfPresent(span.errorType.map(truncateMetaStringValue), forKey: .errorType)
+            try meta.encodeIfPresent(span.errorStack.map(truncateMetaStringValue), forKey: .errorStack)
         } else {
             try container.encode(0, forKey: .error)
         }
@@ -196,8 +196,8 @@ internal struct SpanEncoder {
     /// Encodes default `meta.*` attributes
     private func encodeDefaultMeta(_ span: DDSpan, to meta: inout KeyedEncodingContainer<CodingKeys>) throws {
         // NOTE: RUMM-299 only string values are supported for `meta.*` attributes
-        try meta.encode(Constants.ddsource, forKey: .source)
-        try meta.encode(span.applicationVersion, forKey: .applicationVersion)
+        try meta.encode(truncateMetaStringValue(Constants.ddsource), forKey: .source)
+        try meta.encode(truncateMetaStringValue(span.applicationVersion), forKey: .applicationVersion)
     }
 
     /// Encodes `meta.*` attributes coming from user
@@ -213,7 +213,7 @@ internal struct SpanEncoder {
             case .double(let doubleValue):
                 try metrics.encode(doubleValue, forKey: CodingKeys($0.key))
             default:
-                try meta.encode($0.value.description, forKey: CodingKeys($0.key))
+                try meta.encode(truncateMetaStringValue($0.value.description), forKey: CodingKeys($0.key))
             }
         }
     }

--- a/Sources/EventsExporter/Spans/SpanMetadata.swift
+++ b/Sources/EventsExporter/Spans/SpanMetadata.swift
@@ -111,8 +111,8 @@ public extension SpanMetadata {
             case .none: try container.encodeNil()
             case .int(let i): try container.encode(i)
             case .double(let d): try container.encode(d)
-            case .string(let s): try container.encode(s)
-            case .bool(let b): try container.encode(b ? "true" : "false")
+            case .string(let s): try container.encode(truncateMetaStringValue(s))
+            case .bool(let b): try container.encode(truncateMetaStringValue(b ? "true" : "false"))
             }
         }
         

--- a/Sources/EventsExporter/Spans/TestSpan.swift
+++ b/Sources/EventsExporter/Spans/TestSpan.swift
@@ -151,7 +151,7 @@ struct TestSpan: Encodable {
             }
         }
 
-        self.meta = meta
+        self.meta = meta.truncatingMetaStringValues()
         self.metrics = metrics
     }
 

--- a/Tests/EventsExporter/Spans/SpansExporterTests.swift
+++ b/Tests/EventsExporter/Spans/SpansExporterTests.swift
@@ -39,7 +39,45 @@ class SpansExporterTests: XCTestCase {
         XCTAssertTrue(spans.count == 1)
     }
 
-    private func createBasicSpan() -> SpanData {
+    func testWhenExportSpanIsCalled_thenMetaAndPayloadMetadataValuesAreTruncated() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let longValue = String(repeating: "m", count: maxMetaStringValueLength + 1)
+        var metadata = SpanMetadata()
+        metadata[string: "global.long"] = longValue
+        let configuration = ExporterConfiguration.mock(metadata: metadata, performancePreset: .readAllFiles)
+        let endpoint: Endpoint = .other(testsBaseURL: server.baseURL, logsBaseURL: server.baseURL)
+        let api = SpansApiService(
+            config: APIServiceConfig.mock(endpoint: endpoint),
+            httpClient: HTTPClient(debug: false),
+            log: configuration.logger
+        )
+        let storage = try Directory.temporary().createSubdirectory(path: UUID().uuidString)
+        defer { try? storage.delete() }
+        let spansExporter = try SpansExporter(config: configuration, storage: storage, api: api)
+
+        let spanData = createBasicSpan(attributes: [
+            "custom.long": .string(longValue),
+            "custom.metric": .int(42),
+        ])
+        spansExporter.exportSpan(span: spanData)
+
+        guard server.waitForSpans(timeout: 30) else {
+            XCTFail("No request received")
+            return
+        }
+
+        let span = try XCTUnwrap(server.requests.allInfoSpans.first)
+        let truncatedValue = String(longValue.prefix(maxMetaStringValueLength))
+        XCTAssertEqual(span.meta["custom.long"], truncatedValue)
+        XCTAssertEqual(span.meta["custom.long"]?.count, maxMetaStringValueLength)
+        XCTAssertEqual(span.meta["global.long"], truncatedValue)
+        XCTAssertEqual(span.metrics["custom.metric"], 42)
+    }
+
+    private func createBasicSpan(attributes: [String: AttributeValue] = [:]) -> SpanData {
         return SpanData(traceId: TraceId(),
                         spanId: SpanId(),
                         traceFlags: TraceFlags(),
@@ -49,6 +87,7 @@ class SpansExporterTests: XCTestCase {
                         name: "spanName",
                         kind: .server,
                         startTime: Date(timeIntervalSinceReferenceDate: 3000),
+                        attributes: attributes,
                         endTime: Date(timeIntervalSinceReferenceDate: 3001),
                         hasRemoteParent: false)
     }

--- a/Tests/EventsExporter/Spans/TestSpanTests.swift
+++ b/Tests/EventsExporter/Spans/TestSpanTests.swift
@@ -136,6 +136,64 @@ final class TestSpanTests: XCTestCase {
         XCTAssertEqual(metrics["_top_level"], 1)
     }
 
+    func testTest_truncatesMetaStringValuesAndPreservesMetricsAndTopLevelIds() throws {
+        let longValue = String(repeating: "a", count: maxMetaStringValueLength + 1)
+        let exactValue = String(repeating: "b", count: maxMetaStringValueLength)
+        let span = SpanData(traceId: TraceId.random(),
+                            spanId: SpanId(id: 0x7777),
+                            traceFlags: TraceFlags(),
+                            traceState: TraceState(),
+                            parentSpanId: nil,
+                            resource: Resource(),
+                            instrumentationScope: InstrumentationScopeInfo(),
+                            name: "MyFramework.test",
+                            kind: .internal,
+                            startTime: Date(timeIntervalSinceReferenceDate: 1000),
+                            attributes: [
+                                "type": .string("test"),
+                                "test_session_id": .string(SpanId(id: 0x1111).hexString),
+                                "test_module_id": .string(SpanId(id: 0x2222).hexString),
+                                "test_suite_id": .string(SpanId(id: 0x3333).hexString),
+                                "custom.long": .string(longValue),
+                                "custom.exact": .string(exactValue),
+                                "custom.metric": .int(42),
+                            ],
+                            endTime: Date(timeIntervalSinceReferenceDate: 1001),
+                            hasRemoteParent: false)
+
+        let json = try encode(TestSpan(spanData: span, spanType: .test))
+        let meta = try XCTUnwrap(json["meta"] as? [String: String])
+        let metrics = try XCTUnwrap(json["metrics"] as? [String: Double])
+
+        XCTAssertEqual(meta["custom.long"], String(longValue.prefix(maxMetaStringValueLength)))
+        XCTAssertEqual(meta["custom.long"]?.count, maxMetaStringValueLength)
+        XCTAssertEqual(meta["custom.exact"], exactValue)
+        XCTAssertEqual(metrics["custom.metric"], 42)
+        XCTAssertNil(meta["test_session_id"])
+        XCTAssertNil(meta["test_module_id"])
+        XCTAssertNil(meta["test_suite_id"])
+        XCTAssertEqual(json["test_session_id"] as? UInt64, 0x1111)
+        XCTAssertEqual(json["test_module_id"] as? UInt64, 0x2222)
+        XCTAssertEqual(json["test_suite_id"] as? UInt64, 0x3333)
+    }
+
+    func testSession_truncatesMetaStringValues() throws {
+        let longValue = String(repeating: "s", count: maxMetaStringValueLength + 1)
+        let span = makeSpan(spanId: SpanId(id: 0x8888), attributes: [
+            "type": .string("test_session_end"),
+            "test_session_id": .string(SpanId(id: 0x8888).hexString),
+            "custom.long": .string(longValue),
+        ])
+
+        let json = try encode(TestSpan(spanData: span, spanType: .sessionEnd))
+        let meta = try XCTUnwrap(json["meta"] as? [String: String])
+
+        XCTAssertEqual(meta["custom.long"], String(longValue.prefix(maxMetaStringValueLength)))
+        XCTAssertEqual(meta["custom.long"]?.count, maxMetaStringValueLength)
+        XCTAssertNil(meta["test_session_id"])
+        XCTAssertEqual(json["test_session_id"] as? UInt64, 0x8888)
+    }
+
     func testTest_omitsTopLevelMetric_whenSpanHasParent() throws {
         var resource = Resource()
         resource.service = "service"


### PR DESCRIPTION
### What and why?

Truncate CI Visibility metadata/tag string values to 5000 characters so exported span metadata respects the backend tag value limit.

### How?

Adds a shared metadata string truncation helper and applies it when encoding metadata dictionaries for exported spans. Non-string metadata values remain unchanged.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference

Validation:

- `git diff --check`

The Swift test run was not completed locally because SwiftPM/toolchain artifact resolution stalled while downloading DatadogSDKTesting.zip.