### PR TITLE
[SDTEST-3772] Implement TelemetryExporter

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -15,7 +15,9 @@
 		4B08F62941D9EB26E5DF3837 /* TestImpactAnalysisApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */; };
 		56B58A2FC91F21D1ABB0155E /* TelemetryApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EB970146040DD4967C7411 /* TelemetryApi.swift */; };
 		821FA0CC8B62245A4949FDBB /* APITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85241CF97F1B6DAA49ECA23 /* APITypes.swift */; };
+		86137D23E1704D17A7B6D486 /* TelemetryExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */; };
 		8EF6F88255506A4CEE6D36B6 /* GitUploadApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */; };
+		97326DD4F8EF4EBDB05AC1AA /* TelemetryExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */; };
 		98D8D496CC4210A0D1D07F93 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12536CCE14EC1D3DAAC8DB81 /* Synced.swift */; };
 		A70B91132DF0AE19003F284F /* AutoTestRetriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70B91122DF0AE11003F284F /* AutoTestRetriesTests.swift */; };
 		A718EC2D2CBD5DCE00C5F0D9 /* EarlyFlakeDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A718EC2C2CBD5DCE00C5F0D9 /* EarlyFlakeDetection.swift */; };
@@ -95,7 +97,6 @@
 		A79DA6472FB628B4004BCA8C /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79DA6462FB628B4004BCA8C /* Endpoint.swift */; };
 		A79FAD992F8548780080C3F6 /* SessionAndModuleObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79FAD982F8548700080C3F6 /* SessionAndModuleObserver.swift */; };
 		A79FAD9B2F8559530080C3F6 /* AdditionalTagsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79FAD9A2F8559530080C3F6 /* AdditionalTagsFeature.swift */; };
-		A7EE000000031000000000B1 /* LibraryConfigurationCommunicationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000031000000000B0 /* LibraryConfigurationCommunicationError.swift */; };
 		A7A98C202C8F44BC00C93E59 /* CoverageSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A98C1F2C8F44BC00C93E59 /* CoverageSettings.swift */; };
 		A7AB7C0F2F11AA1100000001 /* RunLoopWaiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AB7C0F2F11AA1100000002 /* RunLoopWaiter.swift */; };
 		A7AB7C0F2F11AA1200000001 /* MockHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AB7C0F2F11AA1200000002 /* MockHTTPClient.swift */; };
@@ -146,6 +147,7 @@
 		A7EE000000010000000000A2 /* LibraryConfigurationErrorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000010000000000A1 /* LibraryConfigurationErrorsTests.swift */; };
 		A7EE000000020000000000A2 /* LibraryConfigurationErrorTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */; };
 		A7EE000000020000000000A4 /* AdditionalTagsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000020000000000A3 /* AdditionalTagsFeatureTests.swift */; };
+		A7EE000000031000000000B1 /* LibraryConfigurationCommunicationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000031000000000B0 /* LibraryConfigurationCommunicationError.swift */; };
 		A7EE000000041000000000B1 /* LibraryConfigurationErrorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7EE000000041000000000B0 /* LibraryConfigurationErrorsTests.swift */; };
 		A7F3FC182F924521002EFFAB /* DatadogSDKTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7FC25642BA1E83500067E26 /* DatadogSDKTesting.framework */; };
 		A7F3FC3A2F92465C002EFFAB /* UnitTests+XCTestSmoke.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F3FC392F92465C002EFFAB /* UnitTests+XCTestSmoke.swift */; };
@@ -418,6 +420,7 @@
 /* Begin PBXFileReference section */
 		0083E7241E320B00198C0D71 /* TestManagementApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestManagementApi.swift; sourceTree = "<group>"; };
 		01EB970146040DD4967C7411 /* TelemetryApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryApi.swift; sourceTree = "<group>"; };
+		04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelemetryExporterTests.swift; sourceTree = "<group>"; };
 		0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisSwiftTestingTests.swift; sourceTree = "<group>"; };
 		12536CCE14EC1D3DAAC8DB81 /* Synced.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Synced.swift; sourceTree = "<group>"; };
 		1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisApi.swift; sourceTree = "<group>"; };
@@ -506,7 +509,6 @@
 		A79DA6462FB628B4004BCA8C /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		A79FAD982F8548700080C3F6 /* SessionAndModuleObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAndModuleObserver.swift; sourceTree = "<group>"; };
 		A79FAD9A2F8559530080C3F6 /* AdditionalTagsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalTagsFeature.swift; sourceTree = "<group>"; };
-		A7EE000000031000000000B0 /* LibraryConfigurationCommunicationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationCommunicationError.swift; sourceTree = "<group>"; };
 		A7A98C1F2C8F44BC00C93E59 /* CoverageSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverageSettings.swift; sourceTree = "<group>"; };
 		A7AB7C0F2F11AA1100000002 /* RunLoopWaiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunLoopWaiter.swift; sourceTree = "<group>"; };
 		A7AB7C0F2F11AA1200000002 /* MockHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPClient.swift; sourceTree = "<group>"; };
@@ -552,6 +554,7 @@
 		A7EE000000010000000000A1 /* LibraryConfigurationErrorsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationErrorsTests.swift; sourceTree = "<group>"; };
 		A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationErrorTagsTests.swift; sourceTree = "<group>"; };
 		A7EE000000020000000000A3 /* AdditionalTagsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalTagsFeatureTests.swift; sourceTree = "<group>"; };
+		A7EE000000031000000000B0 /* LibraryConfigurationCommunicationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationCommunicationError.swift; sourceTree = "<group>"; };
 		A7EE000000041000000000B0 /* LibraryConfigurationErrorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationErrorsTests.swift; sourceTree = "<group>"; };
 		A7F3FC142F924521002EFFAB /* IntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7F3FC392F92465C002EFFAB /* UnitTests+XCTestSmoke.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnitTests+XCTestSmoke.swift"; sourceTree = "<group>"; };
@@ -568,6 +571,7 @@
 		A7FC26E42BA8648300067E26 /* EventsExporter.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EventsExporter.xctestplan; sourceTree = "<group>"; };
 		B0CDA0CDA0CDA0CDA0CDA001 /* CrashLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashLog.swift; sourceTree = "<group>"; };
 		B1209EC18B790B00EFC90E52 /* SpansApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpansApi.swift; sourceTree = "<group>"; };
+		BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelemetryExporter.swift; sourceTree = "<group>"; };
 		C1E3348865C204C942F4765C /* SettingsApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsApi.swift; sourceTree = "<group>"; };
 		CC931D86ADB841B6969C7A7A /* EarlyFlakeDetectionSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlyFlakeDetectionSwiftTestingTests.swift; sourceTree = "<group>"; };
 		D969899DDA68AF3C690F7FF8 /* LogsApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogsApi.swift; sourceTree = "<group>"; };
@@ -796,6 +800,14 @@
 			path = Coverage;
 			sourceTree = "<group>";
 		};
+		A0CB62A8541E4DA48FF4722D /* Telemetry */ = {
+			isa = PBXGroup;
+			children = (
+				04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */,
+			);
+			path = Telemetry;
+			sourceTree = "<group>";
+		};
 		A71E64522BAA0AA100F2ACA5 /* Environment */ = {
 			isa = PBXGroup;
 			children = (
@@ -967,6 +979,14 @@
 			path = UITests;
 			sourceTree = "<group>";
 		};
+		ADCDBCD3D7904ED1922C0C79 /* Telemetry */ = {
+			isa = PBXGroup;
+			children = (
+				BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */,
+			);
+			path = Telemetry;
+			sourceTree = "<group>";
+		};
 		E116D7D925248C280022779D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -1019,6 +1039,7 @@
 				E141EAEC27EB3B9E0057D747 /* Files */,
 				E141EAEF27EB3B9E0057D747 /* Helpers */,
 				E141EAFB27EB3B9E0057D747 /* Upload */,
+				A0CB62A8541E4DA48FF4722D /* Telemetry */,
 				A7FC26E42BA8648300067E26 /* EventsExporter.xctestplan */,
 				E141EAE727EB3B9E0057D747 /* EventsExporterTests.swift */,
 				A7EE000000010000000000A1 /* LibraryConfigurationErrorsTests.swift */,
@@ -1122,6 +1143,7 @@
 				E143CF0D27D7790300F4018A /* Logs */,
 				E143CF1127D7790300F4018A /* Persistence */,
 				E143CF1627D7790300F4018A /* Files */,
+				ADCDBCD3D7904ED1922C0C79 /* Telemetry */,
 				E143CF0C27D7790300F4018A /* ExporterConfiguration.swift */,
 				E143CF1927D7790300F4018A /* Exporter.swift */,
 				A7AB7C2026E7EB1100000002 /* OpenTelemetry+Extensions.swift */,
@@ -2104,6 +2126,7 @@
 				A7FC26442BA1ECE400067E26 /* LogEncoder.swift in Sources */,
 				A7FC26432BA1ECE400067E26 /* LogSanitizer.swift in Sources */,
 				A7FC263D2BA1ECCF00067E26 /* AttributesSanitizer.swift in Sources */,
+				97326DD4F8EF4EBDB05AC1AA /* TelemetryExporter.swift in Sources */,
 				A7FC26322BA1ECC500067E26 /* SpansExporter.swift in Sources */,
 				A7FC26462BA1ECEF00067E26 /* FilesOrchestrator.swift in Sources */,
 				A7FC26482BA1ECEF00067E26 /* FileWriter.swift in Sources */,
@@ -2178,6 +2201,7 @@
 				A7B747C02C60E1E7009B4B93 /* SwiftUtilsTests.swift in Sources */,
 				A7FC26822BA1F81D00067E26 /* DeviceMock.swift in Sources */,
 				A7FC26722BA1F80000067E26 /* EncodableValueTests.swift in Sources */,
+				86137D23E1704D17A7B6D486 /* TelemetryExporterTests.swift in Sources */,
 				A7FC26702BA1F7FA00067E26 /* SpansExporterTests.swift in Sources */,
 				A7FC268C2BA1F82300067E26 /* HTTPClientTests.swift in Sources */,
 				A7FC26742BA1F80000067E26 /* JSONEncoderTests.swift in Sources */,
@@ -2963,7 +2987,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = "2.7.3";
+				MARKETING_VERSION = 2.7.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -3038,7 +3062,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LLVM_LTO = YES_THIN;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = "2.7.3";
+				MARKETING_VERSION = 2.7.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -166,6 +166,7 @@ internal class DDTracer {
             clientId: String(SpanId.random().rawValue),
             payloadCompression: payloadCompression,
             logger: Log.instance,
+            dateProvider: DDTestMonitor.clock,
             debugNetworkRequests: conf.extraDebugNetwork
         )
         // Exporter files live under the cache manager's session directory so

--- a/Sources/DatadogSDKTesting/Utils/Clock.swift
+++ b/Sources/DatadogSDKTesting/Utils/Clock.swift
@@ -11,8 +11,13 @@ internal import Kronos
 #endif
 internal import OpenTelemetrySdk
 
-protocol Clock: OpenTelemetrySdk.Clock, Sendable {
+protocol Clock: OpenTelemetrySdk.Clock, Sendable, DateProvider {
     func sync() async throws
+}
+
+extension Clock {
+    @inlinable
+    func currentDate() -> Date { self.now }
 }
 
 #if !os(watchOS)

--- a/Sources/EventsExporter/API/APITypes.swift
+++ b/Sources/EventsExporter/API/APITypes.swift
@@ -444,12 +444,7 @@ extension HTTPClient {
         }
         request.httpBody = requestData
 
-        let body: Data
-        do {
-            body = try await sendWithResponse(request: request)
-        } catch let err {
-            throw APICallError(from: err)
-        }
+        let body: Data = try await sendWithResponse(api: request)
         return try call.response(from: body, requestId: requestId, coder: coders.1)
     }
 
@@ -462,5 +457,29 @@ extension HTTPClient {
     where Request: APIRequestData, Response: APIResponseData, Request.Meta: APIVoidValue
     {
         try await self.call(call, url: url, meta: .void, data: data, headers: headers, coders: coders)
+    }
+    
+    func send(api request: URLRequest) async throws(APICallError) -> HTTPURLResponse {
+        do {
+            return try await send(request: request)
+        } catch {
+            throw APICallError(from: error)
+        }
+    }
+    
+    func sendWithResponse(api request: URLRequest) async throws(APICallError) -> Data {
+        do {
+            return try await sendWithResponse(request: request)
+        } catch {
+            throw APICallError(from: error)
+        }
+    }
+    
+    func send(api request: MultipartFormURLRequest) async throws(APICallError) -> HTTPURLResponse {
+        try await send(api: request.asURLRequest)
+    }
+
+    func sendWithResponse(api request: MultipartFormURLRequest) async throws(APICallError) -> Data {
+        try await sendWithResponse(api: request.asURLRequest)
     }
 }

--- a/Sources/EventsExporter/API/GitUploadApi.swift
+++ b/Sources/EventsExporter/API/GitUploadApi.swift
@@ -12,7 +12,7 @@ public protocol GitUploadApi: APIService {
     func uploadPackFile(file: URL, commit: String, repositoryURL: String) async throws(APICallError)
 
     func uploadPackFile(name: String, data: Data, commit: String,
-                        repositoryURL: String) async throws(HTTPClient.RequestError)
+                        repositoryURL: String) async throws(APICallError)
 
     func uploadPackFiles(directory: URL, commit: String, repositoryURL: String) async throws(APICallError)
 }
@@ -25,12 +25,8 @@ extension GitUploadApi {
         } catch {
             throw APICallError.fileSystem(error)
         }
-        do {
-            try await uploadPackFile(name: file.lastPathComponent, data: data,
-                                     commit: commit, repositoryURL: repositoryURL)
-        } catch {
-            throw APICallError(from: error)
-        }
+        try await uploadPackFile(name: file.lastPathComponent, data: data,
+                                 commit: commit, repositoryURL: repositoryURL)
     }
 
     public func uploadPackFiles(directory: URL, commit: String, repositoryURL: String) async throws(APICallError) {
@@ -97,7 +93,7 @@ struct GitUploadApiService: GitUploadApi, APIServiceConstructible {
     }
 
     func uploadPackFile(name: String, data: Data, commit: String,
-                        repositoryURL: String) async throws(HTTPClient.RequestError)
+                        repositoryURL: String) async throws(APICallError)
     {
         let log = self.log
         let meta = CommitRequestMeta(repositoryUrl: repositoryURL)
@@ -117,7 +113,7 @@ struct GitUploadApiService: GitUploadApi, APIServiceConstructible {
                        fileName: name,
                        contentType: .applicationOctetStream)
         log.debug("Uploading packfile \(name) for commit \(commit)")
-        let _ = try await httpClient.send(request: request)
+        let _ = try await httpClient.send(api: request)
         log.debug("Packfile upload succeeded for \(name)")
     }
 

--- a/Sources/EventsExporter/API/LogsApi.swift
+++ b/Sources/EventsExporter/API/LogsApi.swift
@@ -8,7 +8,7 @@ import Foundation
 
 public protocol LogsApi: APIService {
     func uploadLogs(batch url: URL) async throws(APICallError)
-    func uploadLogs(batch data: Data) async throws(HTTPClient.RequestError)
+    func uploadLogs(batch data: Data) async throws(APICallError)
 }
 
 extension LogsApi {
@@ -19,11 +19,7 @@ extension LogsApi {
         } catch {
             throw .fileSystem(error)
         }
-        do {
-            try await uploadLogs(batch: data)
-        } catch {
-            throw APICallError(from: error)
-        }
+        try await uploadLogs(batch: data)
     }
 }
 
@@ -46,7 +42,7 @@ struct LogsApiService: LogsApi, APIServiceConstructible {
         self.decoder = config.decoder
     }
 
-    func uploadLogs(batch data: Data) async throws(HTTPClient.RequestError) {
+    func uploadLogs(batch data: Data) async throws(APICallError) {
         var url = endpoint.logsURL
         url.appendQueryItems([
             .ddsource(source: LogQueryValues.ddsource),
@@ -62,7 +58,7 @@ struct LogsApiService: LogsApi, APIServiceConstructible {
         request.httpBody = data
         let log = self.log
         log.debug("Uploading logs...")
-        let _ = try await httpClient.send(request: request)
+        let _ = try await httpClient.send(api: request)
         log.debug("Logs upload succeeded")
     }
 

--- a/Sources/EventsExporter/API/SpansApi.swift
+++ b/Sources/EventsExporter/API/SpansApi.swift
@@ -8,7 +8,7 @@ import Foundation
 
 public protocol SpansApi: APIService {
     func uploadSpans(batch url: URL) async throws(APICallError)
-    func uploadSpans(batch data: Data) async throws(HTTPClient.RequestError)
+    func uploadSpans(batch data: Data) async throws(APICallError)
 }
 
 extension SpansApi {
@@ -19,11 +19,7 @@ extension SpansApi {
         } catch {
             throw .fileSystem(error)
         }
-        do {
-            try await uploadSpans(batch: data)
-        } catch {
-            throw APICallError(from: error)
-        }
+        try await uploadSpans(batch: data)
     }
 }
 
@@ -46,7 +42,7 @@ struct SpansApiService: SpansApi, APIServiceConstructible {
         self.decoder = config.decoder
     }
 
-    func uploadSpans(batch data: Data) async throws(HTTPClient.RequestError) {
+    func uploadSpans(batch data: Data) async throws(APICallError) {
         var request = URLRequest(url: endpoint.spansURL)
         request.httpMethod = "POST"
         request.httpHeaders = headers
@@ -57,7 +53,7 @@ struct SpansApiService: SpansApi, APIServiceConstructible {
         request.httpBody = data
         let log = self.log
         log.debug("Uploading spans...")
-        let _ = try await httpClient.send(request: request)
+        let _ = try await httpClient.send(api: request)
         log.debug("Spans upload succeeded")
     }
 

--- a/Sources/EventsExporter/API/TelemetryApi.swift
+++ b/Sources/EventsExporter/API/TelemetryApi.swift
@@ -13,8 +13,22 @@ import Glibc
 
 // MARK: - Public domain types
 
+public protocol TelemetryPayload: Encodable {
+    var requestType: TelemetryRequestType { get }
+}
+
+/// The set of telemetry request_types this service implements.
+public enum TelemetryRequestType: String, Codable {
+    case generateMetrics = "generate-metrics"
+    case logs
+    case messageBatch = "message-batch"
+    case appStarted = "app-started"
+    case appHeartbeat = "app-heartbeat"
+    case appClosing = "app-closing"
+}
+
 /// A single telemetry metric series for `generate-metrics`.
-public struct TelemetryMetric {
+public struct TelemetryMetric: TelemetryPayload, Codable {
     /// Per-tracer metric namespace (`dd.instrumentation_telemetry_data.{namespace}.*`).
     public enum Namespace: String, Codable {
         case tracers, general, telemetry, iast, appsec
@@ -76,6 +90,16 @@ public struct TelemetryMetric {
             self.namespace = namespace
         }
     }
+    
+    public var namespace: Namespace?
+    public var series: [Series]
+    
+    public init(namespace: Namespace?, series: [Series]) {
+        self.namespace = namespace
+        self.series = series
+    }
+    
+    public var requestType: TelemetryRequestType { .generateMetrics }
 }
 
 /// A single telemetry log message for the `logs` request type.
@@ -100,7 +124,7 @@ public struct TelemetryLog: Codable {
     public var stackTrace: String?
     /// Per-log unix-seconds timestamp. When `nil`, the envelope's `tracer_time` is used.
     public var tracerTime: Int64?
-
+    
     public init(message: String,
                 level: Level,
                 count: Int? = nil,
@@ -120,6 +144,22 @@ public struct TelemetryLog: Codable {
         case message, level, count, tags
         case stackTrace = "stack_trace"
         case tracerTime = "tracer_time"
+    }
+    
+    public struct Logs: TelemetryPayload, ExpressibleByArrayLiteral, Codable {
+        public typealias ArrayLiteralElement = TelemetryLog
+        
+        public var logs: [TelemetryLog]
+        
+        public init(_ logs: [TelemetryLog]) {
+            self.logs = logs
+        }
+        
+        public init(arrayLiteral elements: TelemetryLog...) {
+            self.logs = elements
+        }
+        
+        public var requestType: TelemetryRequestType { .logs }
     }
 }
 
@@ -243,20 +283,106 @@ public struct TelemetryInstallSignature: Codable {
     }
 }
 
-/// A single entry inside a `message-batch` telemetry payload.
-///
-/// Each entry is one of the concrete telemetry request types that this SDK
-/// supports today. Adding a new variant here is the only change needed to
-/// let it ride in a batch.
-public enum TelemetryBatchItem {
-    case metrics(series: [TelemetryMetric.Series], namespace: TelemetryMetric.Namespace?)
-    case logs([TelemetryLog])
-    case appStarted(products: TelemetryProducts? = nil,
-                    configuration: [TelemetryConfigItem]? = nil,
-                    error: TelemetryError? = nil,
-                    installSignature: TelemetryInstallSignature? = nil)
-    case appHeartbeat
-    case appClosing
+/// Wire shape for `app-started` payload. All fields optional; `Encodable`
+/// default behavior skips them when `nil`.
+public struct TelemetryAppStarted: TelemetryPayload, Codable {
+    var products: TelemetryProducts?
+    var configuration: [TelemetryConfigItem]?
+    var error: TelemetryError?
+    var installSignature: TelemetryInstallSignature?
+    
+    public init(products: TelemetryProducts? = nil,
+                configuration: [TelemetryConfigItem]? = nil,
+                error: TelemetryError? = nil,
+                installSignature: TelemetryInstallSignature? = nil)
+    {
+        self.products = products
+        self.configuration = configuration
+        self.error = error
+        self.installSignature = installSignature
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case products, configuration, error
+        case installSignature = "install_signature"
+    }
+    
+    public var requestType: TelemetryRequestType { .appStarted }
+}
+
+public struct TelemetryAppHeartbeat: TelemetryPayload, Codable {
+    public init() {}
+    public var requestType: TelemetryRequestType { .appHeartbeat }
+}
+
+public struct TelemetryAppClosing: TelemetryPayload, Codable {
+    public init() {}
+    public var requestType: TelemetryRequestType { .appClosing }
+}
+
+public struct TelemetryMessageBatch: TelemetryPayload, Codable {
+    public struct Message: Codable {
+        var message: any TelemetryPayload
+        
+        enum CodingKeys: String, CodingKey {
+            case requestType = "request_type"
+            case payload
+        }
+        
+        public init(_ message: any TelemetryPayload) {
+            self.message = message
+        }
+        
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let requestType = try container.decode(TelemetryRequestType.self, forKey: .requestType)
+            switch requestType {
+            case .appStarted:
+                message = try container.decode(TelemetryAppStarted.self, forKey: .payload)
+            case .appHeartbeat:
+                message = try container.decode(TelemetryAppHeartbeat.self, forKey: .payload)
+            case .appClosing:
+                message = try container.decode(TelemetryAppClosing.self, forKey: .payload)
+            case .logs:
+                message = try container.decode(TelemetryLog.Logs.self, forKey: .payload)
+            case .generateMetrics:
+                message = try container.decode(TelemetryMetric.self, forKey: .payload)
+            case .messageBatch:
+                message = try container.decode(TelemetryMessageBatch.self, forKey: .payload)
+            }
+        }
+        
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(message.requestType, forKey: .requestType)
+            try container.encode(message, forKey: .payload)
+        }
+    }
+    
+    var messages: [any TelemetryPayload]
+    
+    public init(messages: [any TelemetryPayload]) {
+        self.messages = messages
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case requestType = "request_type"
+        case payload
+    }
+    
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let messages = try container.decode([Message].self)
+        self.messages = messages.map(\.message)
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        let messages = self.messages.map(Message.init)
+        var container = encoder.singleValueContainer()
+        try container.encode(messages)
+    }
+    
+    public var requestType: TelemetryRequestType { .messageBatch }
 }
 
 // MARK: - Protocol
@@ -268,41 +394,45 @@ public protocol TelemetryApi: APIService {
     func sendAppStarted(products: TelemetryProducts?,
                         configuration: [TelemetryConfigItem]?,
                         error: TelemetryError?,
-                        installSignature: TelemetryInstallSignature?) async throws(HTTPClient.RequestError)
+                        installSignature: TelemetryInstallSignature?) async throws(APICallError)
 
     /// Send an `app-heartbeat` event. Per spec callers should schedule this
     /// once per minute after `sendAppStarted` for as long as the app is alive,
     /// even if other telemetry events were sent in the same window.
-    func sendAppHeartbeat() async throws(HTTPClient.RequestError)
+    func sendAppHeartbeat() async throws(APICallError)
 
     /// Send the `app-closing` event when the app is about to terminate.
     /// Should use a short timeout so it doesn't delay shutdown.
-    func sendAppClosing() async throws(HTTPClient.RequestError)
+    func sendAppClosing() async throws(APICallError)
 
     /// Send a batch of metric series via the `generate-metrics` request type.
     func sendMetrics(_ series: [TelemetryMetric.Series],
-                     namespace: TelemetryMetric.Namespace?) async throws(HTTPClient.RequestError)
+                     namespace: TelemetryMetric.Namespace?) async throws(APICallError)
 
     /// Send a batch of log messages via the `logs` request type.
-    func sendLogs(_ logs: [TelemetryLog]) async throws(HTTPClient.RequestError)
+    func sendLogs(_ logs: [TelemetryLog]) async throws(APICallError)
 
     /// Send a mixed batch of telemetry items via the `message-batch` request
     /// type. Items keep their original request_type tag inside the batch and
     /// share the outer envelope's `application`/`host`/`runtime_id`/`seq_id`.
     /// An empty `items` array is a no-op and does not hit the network.
-    func send(batch items: [TelemetryBatchItem]) async throws(HTTPClient.RequestError)
+    func send(batch items: [any TelemetryPayload]) async throws(APICallError)
 
-    /// Send a pre-built `message-batch` HTTP body from a file. The file must
-    /// hold a complete telemetry envelope (`api_version` / `request_type` /
-    /// `runtime_id` / `seq_id` / `tracer_time` / `application` / `host` /
-    /// `payload`) — bytes are POSTed verbatim. Use this when replaying a
-    /// telemetry payload that was queued to disk upstream. Note that any
-    /// timestamp / sequence-id fields baked into the file are used as-is.
+    /// Send a batch of pre-encoded `TelemetryBatchEntry` values stored in a
+    /// file. The file must contain one or more JSON-encoded batch entries
+    /// separated by commas with no surrounding array brackets — the format
+    /// written by `TelemetryExporter`. The service wraps them with a fresh
+    /// `message-batch` envelope (current timestamp, next `seq_id`, full
+    /// `application` / `host` identity) before POSTing.
     func send(batch url: URL) async throws(APICallError)
 
-    /// Send pre-built `message-batch` HTTP body bytes directly. Same
-    /// semantics as the URL variant — `data` is POSTed as the body verbatim.
-    func send(batch data: Data) async throws(HTTPClient.RequestError)
+    /// Send a batch of pre-encoded `TelemetryBatchEntry` values. `data` must
+    /// contain one or more JSON-encoded batch entries separated by commas with
+    /// no surrounding array brackets — the format written by
+    /// `TelemetryExporter`. The service wraps them with a fresh
+    /// `message-batch` envelope (current timestamp, next `seq_id`, full
+    /// `application` / `host` identity) before POSTing.
+    func send(batch data: Data) async throws(APICallError)
 }
 
 extension TelemetryApi {
@@ -313,17 +443,13 @@ extension TelemetryApi {
         } catch {
             throw .fileSystem(error)
         }
-        do {
-            try await send(batch: data)
-        } catch {
-            throw APICallError(from: error)
-        }
+        try await send(batch: data)
     }
 }
 
 // MARK: - Service
 
-internal struct TelemetryApiService: TelemetryApi, APIServiceConstructible {
+internal struct TelemetryApiService: TelemetryApi {
     var endpoint: Endpoint
     var headers: [HTTPHeader]
     var encoder: JSONEncoder
@@ -331,6 +457,7 @@ internal struct TelemetryApiService: TelemetryApi, APIServiceConstructible {
     let compression: Bool
     let httpClient: HTTPClient
     let log: Logger
+    let dateProvider: DateProvider
 
     /// Stable identifier for this tracer session. Reused as the telemetry
     /// `runtime_id` so backend can correlate telemetry with traces.
@@ -342,10 +469,11 @@ internal struct TelemetryApiService: TelemetryApi, APIServiceConstructible {
     /// telemetry requests within a runtime.
     private let seq: Synced<UInt64>
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    init(config: APIServiceConfig, httpClient: HTTPClient, dateProvider: DateProvider, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log
+        self.dateProvider = dateProvider
         // The telemetry intake does NOT accept the trace-style headers — strip
         // them. Keep the auth / user-agent / hostname additions.
         self.headers = config.defaultHeaders.filter { header in
@@ -365,84 +493,91 @@ internal struct TelemetryApiService: TelemetryApi, APIServiceConstructible {
         self.seq = Synced<UInt64>(0)
     }
 
+    func sendAppStarted(products: TelemetryProducts?,
+                        configuration: [TelemetryConfigItem]?,
+                        error: TelemetryError?,
+                        installSignature: TelemetryInstallSignature?) async throws(APICallError)
+    {
+        let payload = TelemetryAppStarted(products: products, configuration: configuration,
+                                          error: error, installSignature: installSignature)
+        try await send(payload: payload)
+    }
+
+    func sendAppHeartbeat() async throws(APICallError) {
+        try await send(payload: TelemetryAppHeartbeat())
+    }
+
+    func sendAppClosing() async throws(APICallError) {
+        try await send(payload: TelemetryAppClosing())
+    }
+
+    func sendMetrics(_ series: [TelemetryMetric.Series],
+                     namespace: TelemetryMetric.Namespace?) async throws(APICallError)
+    {
+        let payload = TelemetryMetric(namespace: namespace, series: series)
+        try await send(payload: payload)
+    }
+
+    func sendLogs(_ logs: [TelemetryLog]) async throws(APICallError) {
+        guard !logs.isEmpty else { return }
+        try await send(payload: TelemetryLog.Logs(logs))
+    }
+
+    func send(batch items: [any TelemetryPayload]) async throws(APICallError) {
+        guard !items.isEmpty else { return }
+        try await send(payload: TelemetryMessageBatch(messages: items))
+    }
+
+    func send(batch data: Data) async throws(APICallError) {
+        // Wrap the raw comma-separated batch entries with a fresh envelope:
+        // prefix = {"api_version":…,"payload":[ and suffix = ]}
+        let header = makeEnvelope(payload: TelemetryVoidBatch())
+        let dataFormat: DataFormat
+        do {
+            dataFormat = try DataFormat(header: header, encoder: encoder)
+        } catch {
+            throw .transport(error)
+        }
+        try await send(requestType: .messageBatch,
+                       body: dataFormat.prefix + data + dataFormat.suffix)
+    }
+
+    var endpointURLs: Set<URL> { [endpoint.telemetryURL] }
+    
     private func nextSeqId() -> UInt64 {
         seq.update { value in
             value &+= 1
             return value
         }
     }
-
-    func sendAppStarted(products: TelemetryProducts?,
-                        configuration: [TelemetryConfigItem]?,
-                        error: TelemetryError?,
-                        installSignature: TelemetryInstallSignature?) async throws(HTTPClient.RequestError)
-    {
-        let payload = TelemetryAppStartedPayload(products: products,
-                                                 configuration: configuration,
-                                                 error: error,
-                                                 installSignature: installSignature)
-        try await send(requestType: .appStarted, payload: payload)
-    }
-
-    func sendAppHeartbeat() async throws(HTTPClient.RequestError) {
-        try await send(requestType: .appHeartbeat, payload: TelemetryEmptyPayload())
-    }
-
-    func sendAppClosing() async throws(HTTPClient.RequestError) {
-        try await send(requestType: .appClosing, payload: TelemetryEmptyPayload())
-    }
-
-    func sendMetrics(_ series: [TelemetryMetric.Series],
-                     namespace: TelemetryMetric.Namespace?) async throws(HTTPClient.RequestError)
-    {
-        let payload = TelemetryMetricsPayload(namespace: namespace, series: series)
-        try await send(requestType: .generateMetrics, payload: payload)
-    }
-
-    func sendLogs(_ logs: [TelemetryLog]) async throws(HTTPClient.RequestError) {
-        let payload = TelemetryLogsPayload(logs: logs)
-        try await send(requestType: .logs, payload: payload)
-    }
-
-    func send(batch items: [TelemetryBatchItem]) async throws(HTTPClient.RequestError) {
-        guard !items.isEmpty else { return }
-        try await send(requestType: .messageBatch,
-                       payload: items.map(TelemetryBatchEntry.init(item:)))
-    }
-
-    func send(batch data: Data) async throws(HTTPClient.RequestError) {
-        try await send(requestType: .messageBatch, body: data)
-    }
-
-    var endpointURLs: Set<URL> { [endpoint.telemetryURL] }
-
-    private func send<Payload: Encodable>(
-        requestType: TelemetryRequestType,
-        payload: Payload
-    ) async throws(HTTPClient.RequestError) {
-        let envelope = TelemetryEnvelope(
-            requestType: requestType,
-            tracerTime: Int64(Date().timeIntervalSince1970),
+    
+    private func makeEnvelope<Payload: TelemetryPayload>(payload: Payload) -> TelemetryEnvelope<Payload> {
+        TelemetryEnvelope(
+            requestType: payload.requestType,
+            tracerTime: UInt64(dateProvider.currentDate().timeIntervalSince1970),
             runtimeId: runtimeId,
             seqId: nextSeqId(),
             application: application,
             host: host,
             payload: payload
         )
+    }
+
+    private func send<Payload: TelemetryPayload>(payload: Payload) async throws(APICallError) {
+        let envelope = makeEnvelope(payload: payload)
         let data: Data
         do {
             data = try encoder.encode(envelope)
+        } catch let err as EncodingError {
+            throw .encoding(value: envelope, error: err)
         } catch {
-            // The intake never produces a decoding error, but if our own
-            // encoding fails we surface it through `.transport` since the
-            // wire protocol is throws(HTTPClient.RequestError).
-            throw .transport(error)
+            throw .unknownError(error)
         }
-        try await send(requestType: requestType, body: data)
+        try await send(requestType: payload.requestType, body: data)
     }
 
     private func send(requestType: TelemetryRequestType,
-                      body: Data) async throws(HTTPClient.RequestError)
+                      body: Data) async throws(APICallError)
     {
         var request = URLRequest(url: endpoint.telemetryURL)
         request.httpMethod = "POST"
@@ -463,82 +598,17 @@ internal struct TelemetryApiService: TelemetryApi, APIServiceConstructible {
 
         let log = self.log
         log.debug("Telemetry \(requestType.rawValue) sending \(body.count) bytes...")
-        let _ = try await httpClient.send(request: request)
+        let _ = try await httpClient.send(api: request)
         log.debug("Telemetry \(requestType.rawValue) accepted")
     }
 }
 
 // MARK: - Wire types
 
-/// The set of telemetry request_types this service implements.
-private enum TelemetryRequestType: String, Encodable {
-    case generateMetrics = "generate-metrics"
-    case logs
-    case messageBatch = "message-batch"
-    case appStarted = "app-started"
-    case appHeartbeat = "app-heartbeat"
-    case appClosing = "app-closing"
-}
-
-/// One entry of a `message-batch` payload. The case itself is the
-/// discriminator: each variant carries its concrete inner payload, and
-/// `encode(to:)` emits the matching `request_type` tag.
-private enum TelemetryBatchEntry: Encodable {
-    case metrics(TelemetryMetricsPayload)
-    case logs(TelemetryLogsPayload)
-    case appStarted(TelemetryAppStartedPayload)
-    case appHeartbeat
-    case appClosing
-
-    init(item: TelemetryBatchItem) {
-        switch item {
-        case .metrics(let series, let namespace):
-            self = .metrics(TelemetryMetricsPayload(namespace: namespace, series: series))
-        case .logs(let logs):
-            self = .logs(TelemetryLogsPayload(logs: logs))
-        case let .appStarted(products, configuration, error, installSignature):
-            self = .appStarted(TelemetryAppStartedPayload(products: products,
-                                                          configuration: configuration,
-                                                          error: error,
-                                                          installSignature: installSignature))
-        case .appHeartbeat:
-            self = .appHeartbeat
-        case .appClosing:
-            self = .appClosing
-        }
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case requestType = "request_type"
-        case payload
-    }
-
-    func encode(to encoder: any Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case .metrics(let payload):
-            try container.encode(TelemetryRequestType.generateMetrics, forKey: .requestType)
-            try container.encode(payload, forKey: .payload)
-        case .logs(let payload):
-            try container.encode(TelemetryRequestType.logs, forKey: .requestType)
-            try container.encode(payload, forKey: .payload)
-        case .appStarted(let payload):
-            try container.encode(TelemetryRequestType.appStarted, forKey: .requestType)
-            try container.encode(payload, forKey: .payload)
-        case .appHeartbeat:
-            try container.encode(TelemetryRequestType.appHeartbeat, forKey: .requestType)
-            try container.encode(TelemetryEmptyPayload(), forKey: .payload)
-        case .appClosing:
-            try container.encode(TelemetryRequestType.appClosing, forKey: .requestType)
-            try container.encode(TelemetryEmptyPayload(), forKey: .payload)
-        }
-    }
-}
-
-private struct TelemetryEnvelope<Payload: Encodable>: Encodable {
+internal struct TelemetryEnvelope<Payload: Encodable>: Encodable {
     let apiVersion: String = TelemetryHeaders.apiVersion
     let requestType: TelemetryRequestType
-    let tracerTime: Int64
+    let tracerTime: UInt64
     let runtimeId: String
     let seqId: UInt64
     let application: TelemetryApplication
@@ -555,9 +625,27 @@ private struct TelemetryEnvelope<Payload: Encodable>: Encodable {
         case host
         case payload
     }
+
+    func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(apiVersion, forKey: .apiVersion)
+        try c.encode(requestType, forKey: .requestType)
+        try c.encode(tracerTime, forKey: .tracerTime)
+        try c.encode(runtimeId, forKey: .runtimeId)
+        try c.encode(seqId, forKey: .seqId)
+        try c.encode(application, forKey: .application)
+        try c.encode(host, forKey: .host)
+        if payload as? any APIVoidValue == nil {
+            try c.encode(payload, forKey: .payload)
+        }
+    }
 }
 
-private struct TelemetryApplication: Encodable {
+extension TelemetryEnvelope: JSONFileHeader {
+    static var batchFieldName: String { "payload" }
+}
+
+internal struct TelemetryApplication: Encodable {
     let serviceName: String
     let env: String
     let serviceVersion: String
@@ -590,7 +678,7 @@ private struct TelemetryApplication: Encodable {
     }
 }
 
-private struct TelemetryHost: Encodable {
+internal struct TelemetryHost: Encodable {
     let hostname: String
     let os: String
     let osVersion: String
@@ -619,35 +707,12 @@ private struct TelemetryHost: Encodable {
     }
 }
 
-private struct TelemetryMetricsPayload: Encodable {
-    let namespace: TelemetryMetric.Namespace?
-    let series: [TelemetryMetric.Series]
-}
-
-private struct TelemetryLogsPayload: Encodable {
-    let logs: [TelemetryLog]
-}
-
-/// Wire shape for `app-started` payload. All fields optional; `Encodable`
-/// default behavior skips them when `nil`.
-private struct TelemetryAppStartedPayload: Encodable {
-    let products: TelemetryProducts?
-    let configuration: [TelemetryConfigItem]?
-    let error: TelemetryError?
-    let installSignature: TelemetryInstallSignature?
-
-    enum CodingKeys: String, CodingKey {
-        case products, configuration, error
-        case installSignature = "install_signature"
-    }
-}
-
-/// Empty `{}` payload used by `app-heartbeat` and `app-closing`. The schema
-/// description says payload is required even when there's nothing to send;
-/// emitting an empty object satisfies that contract.
-private struct TelemetryEmptyPayload: Encodable {}
-
 // MARK: - Helpers
+
+private struct TelemetryVoidBatch: TelemetryPayload, APIVoidValue, Encodable {
+    var requestType: TelemetryRequestType { .messageBatch }
+    static var void: TelemetryVoidBatch { .init() }
+}
 
 private enum TelemetryHeaders {
     static let apiVersion = "v2"

--- a/Sources/EventsExporter/API/TestImpactAnalysisApi.swift
+++ b/Sources/EventsExporter/API/TestImpactAnalysisApi.swift
@@ -49,7 +49,7 @@ public protocol TestImpactAnalysisApi: APIService {
                         customConfigurations: [String: String]) async throws(APICallError) -> SkipTests
 
     func uploadCoverage(batch url: URL) async throws(APICallError)
-    func uploadCoverage(batch data: Data) async throws(HTTPClient.RequestError)
+    func uploadCoverage(batch data: Data) async throws(APICallError)
 }
 
 extension TestImpactAnalysisApi {
@@ -60,11 +60,7 @@ extension TestImpactAnalysisApi {
         } catch {
             throw .fileSystem(error)
         }
-        do {
-            try await uploadCoverage(batch: data)
-        } catch {
-            throw APICallError(from: error)
-        }
+        try await uploadCoverage(batch: data)
     }
 }
 
@@ -137,7 +133,7 @@ struct TestImpactAnalysisApiService: TestImpactAnalysisApi, APIServiceConstructi
         return SkipTests(correlationId: correlationId, tests: tests)
     }
 
-    func uploadCoverage(batch data: Data) async throws(HTTPClient.RequestError) {
+    func uploadCoverage(batch data: Data) async throws(APICallError) {
         var request = MultipartFormURLRequest(url: endpoint.coverageURL)
         request.headers = headers
         if compression {
@@ -151,8 +147,8 @@ struct TestImpactAnalysisApiService: TestImpactAnalysisApi, APIServiceConstructi
                        contentType: .applicationJSON)
         let log = self.log
         log.debug("Uploading coverage batch...")
-        let response = try await httpClient.send(request: request)
-        log.debug("Coverage batch upload response: \(response.statusCode)")
+        let _ = try await httpClient.send(api: request)
+        log.debug("Coverage batch accepted...")
     }
 
     var endpointURLs: Set<URL> { [endpoint.skippableTestsURL, endpoint.coverageURL] }

--- a/Sources/EventsExporter/API/TestOptimizationApi.swift
+++ b/Sources/EventsExporter/API/TestOptimizationApi.swift
@@ -82,7 +82,9 @@ public struct TestOptimizationApiService: TestOptimizationApi {
     public private(set) var logs: LogsApi
     public private(set) var telemetry: TelemetryApi
 
-    internal init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    internal init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger,
+                  dateProvider: DateProvider = SystemDateProvider())
+    {
         settings = SettingsApiService(config: config, httpClient: httpClient, log: log)
         knownTests = KnownTestsApiService(config: config, httpClient: httpClient, log: log)
         git = GitUploadApiService(config: config, httpClient: httpClient, log: log)
@@ -90,7 +92,8 @@ public struct TestOptimizationApiService: TestOptimizationApi {
         testManagement = TestManagementApiService(config: config, httpClient: httpClient, log: log)
         spans = SpansApiService(config: config, httpClient: httpClient, log: log)
         logs = LogsApiService(config: config, httpClient: httpClient, log: log)
-        telemetry = TelemetryApiService(config: config, httpClient: httpClient, log: log)
+        telemetry = TelemetryApiService(config: config, httpClient: httpClient,
+                                        dateProvider: dateProvider, log: log)
     }
 
     /// Build the full set of test-optimization API services that share one
@@ -101,7 +104,7 @@ public struct TestOptimizationApiService: TestOptimizationApi {
                 hostname: String?, apiKey: String,
                 endpoint: Endpoint, clientId: String,
                 payloadCompression: Bool,
-                logger: Logger,
+                logger: Logger, dateProvider: DateProvider = SystemDateProvider(),
                 debugNetworkRequests: Bool = false)
     {
         let config = APIServiceConfig(serviceName: serviceName, environment: environment,
@@ -111,7 +114,8 @@ public struct TestOptimizationApiService: TestOptimizationApi {
                                       payloadCompression: payloadCompression)
         self.init(config: config,
                   httpClient: HTTPClient(debug: debugNetworkRequests),
-                  log: logger)
+                  log: logger,
+                  dateProvider: dateProvider)
     }
 
     public var endpointURLs: Set<URL> {

--- a/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
+++ b/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
@@ -53,7 +53,7 @@ internal final class CoverageExporter: CoverageExporterType {
                                 orchestrator: filesOrchestrator,
                                 encoder: encoder)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
-        let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(HTTPClient.RequestError) -> Void in
+        let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(APICallError) -> Void in
             try await api.uploadCoverage(batch: data)
         }
         let uploader = ClosureDataUploader(upload: upload)

--- a/Sources/EventsExporter/Logs/LogsExporter.swift
+++ b/Sources/EventsExporter/Logs/LogsExporter.swift
@@ -42,7 +42,7 @@ internal final class LogsExporter: LogRecordExporter {
                                 orchestrator: filesOrchestrator,
                                 encoder: encoder)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
-        let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(HTTPClient.RequestError) -> Void in
+        let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(APICallError) -> Void in
             try await api.uploadLogs(batch: data)
         }
         let uploader = ClosureDataUploader(upload: upload)

--- a/Sources/EventsExporter/Persistence/DataFormat.swift
+++ b/Sources/EventsExporter/Persistence/DataFormat.swift
@@ -7,9 +7,9 @@
 import Foundation
 
 internal protocol DataFormatType {
-    var prefix: Data { get }
-    var suffix: Data { get }
-    var separator: Data { get }
+    var prefix: Data { get throws }
+    var suffix: Data { get throws }
+    var separator: Data { get throws }
 }
 
 internal protocol JSONFileHeader: Encodable {

--- a/Sources/EventsExporter/Persistence/FileReader.swift
+++ b/Sources/EventsExporter/Persistence/FileReader.swift
@@ -56,12 +56,12 @@ internal final class FileReader {
             return nil
         }
         let data = try file.read()
-        return Batch(data: data + dataFormat.suffix, file: file)
+        return try Batch(data: data + dataFormat.suffix, file: file)
     }
 
     func getRemainingBatches() throws -> Batch.Iterator {
         let files = try orchestrator.getAllReadableFiles()
-        return Batch.Iterator(files.makeIterator(), suffix: dataFormat.suffix)
+        return try Batch.Iterator(files.makeIterator(), suffix: dataFormat.suffix)
     }
 
     // MARK: - Accepting batches

--- a/Sources/EventsExporter/Persistence/FileWriter.swift
+++ b/Sources/EventsExporter/Persistence/FileWriter.swift
@@ -69,7 +69,7 @@ internal final class FileWriter {
         // write. Once the closure returns, the file becomes visible to the
         // reader.
         try orchestrator.withWritableFile(writeSize: UInt64(data.count)) { writable, isNew in
-            let payload = isNew ? (dataFormat.prefix + data) : (dataFormat.separator + data)
+            let payload = try isNew ? (dataFormat.prefix + data) : (dataFormat.separator + data)
             try writable.append(data: payload, synchronized: sync)
         }
     }

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -36,7 +36,7 @@ internal final class SpansExporter: SpanExporter {
                                 orchestrator: filesOrchestrator,
                                 encoder: encoder)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
-        let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(HTTPClient.RequestError) -> Void in
+        let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(APICallError) -> Void in
             try await api.uploadSpans(batch: data)
         }
         let uploader = ClosureDataUploader(upload: upload)

--- a/Sources/EventsExporter/Telemetry/TelemetryExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryExporter.swift
@@ -1,0 +1,68 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+
+public final class TelemetryExporter {
+    let telemetryStorage: FeatureStoreAndUpload
+    private let synchronousWrite: Bool
+
+    public init(config: ExporterConfiguration, storage: Directory, api: TelemetryApi) throws {
+        self.synchronousWrite = config.performancePreset.synchronousWrite
+
+        let filesOrchestrator = FilesOrchestrator(
+            directory: try storage.createSubdirectory(path: "v1"),
+            performance: config.performancePreset,
+            dateProvider: SystemDateProvider()
+        )
+
+        let encoder = api.encoder
+        // Entries are stored as a bare comma-separated sequence of JSON objects with no surrounding
+        // array brackets or envelope wrapper. TelemetryApi.send(batch:) adds the full message-batch
+        // envelope (timestamp, seq_id, application, host) at upload time.
+        let dataFormat = DataFormat(prefix: Data(), suffix: Data(), separator: Data(",".utf8))
+        let writer = FileWriter(entity: "telemetry",
+                                dataFormat: dataFormat,
+                                orchestrator: filesOrchestrator,
+                                encoder: encoder)
+        let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
+        let uploader = ClosureDataUploader() { (data) async throws(APICallError) -> Void in
+            try await api.send(batch: data)
+        }
+        self.telemetryStorage = FeatureStoreAndUpload(featureName: "telemetry",
+                                                      reader: reader,
+                                                      writer: writer,
+                                                      performance: config.performancePreset,
+                                                      uploader: uploader)
+    }
+
+    public func export(items: [any TelemetryPayload]) {
+        for item in items {
+            write(TelemetryMessageBatch.Message(item))
+        }
+    }
+
+    public func export(item: any TelemetryPayload) {
+        write(TelemetryMessageBatch.Message(item))
+    }
+
+    @discardableResult
+    public func flush() -> Bool {
+        (try? telemetryStorage.flush()) ?? false
+    }
+
+    public func shutdown() {
+        telemetryStorage.stop()
+    }
+
+    private func write<T: Encodable>(_ value: T) {
+        if synchronousWrite {
+            try? telemetryStorage.writeSync(value: value)
+        } else {
+            telemetryStorage.write(value: value)
+        }
+    }
+}

--- a/Sources/EventsExporter/Upload/DataUploadStatus.swift
+++ b/Sources/EventsExporter/Upload/DataUploadStatus.swift
@@ -75,13 +75,14 @@ extension DataUploadStatus {
             self.init(needsRetry: statusCode.needsRetry, waitTime: nil)
         }
     }
-
-    init(networkError: HTTPClient.RequestError) {
-        switch networkError {
-        case .http(code: let code, headers: let headers, body: _):
+    
+    init(api error: APICallError) {
+        switch error {
+        case .httpError(code: let code, headers: let headers, body: _):
             self.init(httpCode: code, headers: headers)
-        case .transport, .inconsistentSession:
+        case .transport, .fileSystem, .idMismatch, .decoding:
             self.init(needsRetry: true, waitTime: nil)
+        default: self.init(needsRetry: false, waitTime: nil)
         }
     }
 

--- a/Sources/EventsExporter/Upload/DataUploader.swift
+++ b/Sources/EventsExporter/Upload/DataUploader.swift
@@ -15,7 +15,7 @@ internal protocol DataUploaderType {
 /// the typed API services in `EventsExporter/API/`). The closure throws
 /// `HTTPClient.RequestError`; the result is mapped to a `DataUploadStatus`.
 internal struct ClosureDataUploader: DataUploaderType {
-    typealias UploadCallback = @Sendable (Data) async throws(HTTPClient.RequestError) -> Void
+    typealias UploadCallback = @Sendable (Data) async throws(APICallError) -> Void
 
     private let _upload: UploadCallback
 
@@ -26,12 +26,12 @@ internal struct ClosureDataUploader: DataUploaderType {
     func upload(data: Data) -> DataUploadStatus {
         let upload = self._upload
         do {
-            try waitForAsync { () async throws(HTTPClient.RequestError) -> Void in
+            try waitForAsync { () async throws(APICallError) -> Void in
                 try await upload(data)
             }
             return .success
-        } catch let error {
-            return DataUploadStatus(networkError: error)
+        } catch {
+            return DataUploadStatus(api: error)
         }
     }
 }

--- a/Sources/EventsExporter/Utils/DateProvider.swift
+++ b/Sources/EventsExporter/Utils/DateProvider.swift
@@ -7,11 +7,13 @@
 import Foundation
 
 /// Interface for date provider used for files orchestration.
-internal protocol DateProvider {
+public protocol DateProvider {
     func currentDate() -> Date
 }
 
-internal struct SystemDateProvider: DateProvider {
+public struct SystemDateProvider: DateProvider {
+    public init() {}
+    
     @inlinable
-    func currentDate() -> Date { return Date() }
+    public func currentDate() -> Date { return Date() }
 }

--- a/Tests/EventsExporter/Helpers/CoreMocks.swift
+++ b/Tests/EventsExporter/Helpers/CoreMocks.swift
@@ -53,6 +53,20 @@ struct StoragePerformanceMock: StoragePerformancePreset {
         maxObjectSize: .max,
         synchronousWrite: true
     )
+
+    /// All writes accumulate in the same file until it is explicitly closed via
+    /// `flush()`. Use this to test that the uploader correctly assembles a
+    /// `message-batch` from several entries that share one on-disk batch.
+    static let appendToOneFile = StoragePerformanceMock(
+        maxFileSize: .max,
+        maxDirectorySize: .max,
+        maxFileAgeForWrite: .greatestFiniteMagnitude,
+        minFileAgeForRead: readAllFiles.minFileAgeForRead,
+        maxFileAgeForRead: readAllFiles.maxFileAgeForRead,
+        maxObjectsInFile: .max,
+        maxObjectSize: .max,
+        synchronousWrite: true
+    )
 }
 
 struct UploadPerformanceMock: UploadPerformancePreset {
@@ -76,9 +90,10 @@ struct UploadPerformanceMock: UploadPerformancePreset {
 extension PerformancePreset {
     static let readAllFiles = Self(any: StoragePerformanceMock.readAllFiles,
                                    upload: UploadPerformanceMock.veryQuick)
-    
     static let writeEachObjectToNewFileAndReadAllFiles = Self(any: StoragePerformanceMock.writeEachObjectToNewFileAndReadAllFiles,
                                                               upload: UploadPerformanceMock.veryQuick)
+    static let appendToOneFile = Self(any: StoragePerformanceMock.appendToOneFile,
+                                      upload: UploadPerformanceMock.veryQuick)
 }
 
 extension DataFormat {
@@ -176,7 +191,7 @@ internal struct MockClosureDataUploader: DataUploaderType {
             }
             return DataUploadStatus(httpResponse: response)
         } catch {
-            return DataUploadStatus(networkError: error)
+            return DataUploadStatus(api: .init(from: error))
         }
     }
 }
@@ -244,6 +259,15 @@ extension APIServiceConfig {
                          device: .current, hostname: hostname, apiKey: apiKey,
                          endpoint: endpoint, clientId: clientId,
                          payloadCompression: payloadCompression)
+    }
+}
+
+extension TelemetryApiService {
+    static func mock(endpoint: Endpoint = .us1, logger: Logger = Log()) -> TelemetryApiService {
+        TelemetryApiService(config: APIServiceConfig.mock(endpoint: endpoint),
+                            httpClient: HTTPClient(debug: false),
+                            dateProvider: SystemDateProvider(),
+                            log: logger)
     }
 }
 

--- a/Tests/EventsExporter/Telemetry/TelemetryExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryExporterTests.swift
@@ -1,0 +1,176 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+@testable import EventsExporter
+import XCTest
+import TestUtils
+
+class TelemetryExporterTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeExporter(performancePreset: PerformancePreset,
+                               server: MockBackend) throws -> (TelemetryExporter, Directory)
+    {
+        let endpoint: Endpoint = .other(testsBaseURL: server.baseURL, logsBaseURL: server.baseURL)
+        let config = ExporterConfiguration.mock(performancePreset: performancePreset)
+        let api = TelemetryApiService.mock(endpoint: endpoint)
+        let storage = try Directory.temporary().createSubdirectory(path: UUID().uuidString)
+        let exporter = try TelemetryExporter(config: config, storage: storage, api: api)
+        return (exporter, storage)
+    }
+
+    private func assertValidEnvelope(_ raw: Data,
+                                     expectedEntryCount: Int,
+                                     file: StaticString = #filePath,
+                                     line: UInt = #line) throws
+    {
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any],
+                                 file: file, line: line)
+        XCTAssertEqual(json["api_version"] as? String, "v2", file: file, line: line)
+        XCTAssertEqual(json["request_type"] as? String, "message-batch", file: file, line: line)
+        XCTAssertNotNil(json["runtime_id"], file: file, line: line)
+        XCTAssertNotNil(json["application"], file: file, line: line)
+        XCTAssertNotNil(json["host"], file: file, line: line)
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]], file: file, line: line)
+        XCTAssertEqual(payload.count, expectedEntryCount, file: file, line: line)
+    }
+
+    // MARK: - Single-entry upload
+
+    func testExportMetrics_uploadsWellFormedEnvelope() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let (exporter, storage) = try makeExporter(performancePreset: .readAllFiles, server: server)
+        defer { try? storage.delete() }
+
+        let series = TelemetryMetric.Series(
+            metric: "test.metric",
+            points: [.init(timestamp: 1_000_000, value: 42.0)],
+            type: .count,
+            tags: ["env:test"]
+        )
+        exporter.export(item: TelemetryMetric(namespace: .tracers, series: [series]))
+
+        guard server.waitForTelemetry(timeout: 30) else {
+            XCTFail("No telemetry batch received")
+            return
+        }
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        try assertValidEnvelope(raw, expectedEntryCount: 1)
+        let payload = try XCTUnwrap(
+            (JSONSerialization.jsonObject(with: raw) as? [String: Any])?["payload"] as? [[String: Any]]
+        )
+        XCTAssertEqual(payload[0]["request_type"] as? String, "generate-metrics")
+    }
+
+    func testExportLogs_uploadsWellFormedEnvelope() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let (exporter, storage) = try makeExporter(performancePreset: .readAllFiles, server: server)
+        defer { try? storage.delete() }
+
+        exporter.export(item: TelemetryLog.Logs([TelemetryLog(message: "oops", level: .error)]))
+
+        guard server.waitForTelemetry(timeout: 30) else {
+            XCTFail("No telemetry batch received")
+            return
+        }
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        try assertValidEnvelope(raw, expectedEntryCount: 1)
+        let payload = try XCTUnwrap(
+            (JSONSerialization.jsonObject(with: raw) as? [String: Any])?["payload"] as? [[String: Any]]
+        )
+        XCTAssertEqual(payload[0]["request_type"] as? String, "logs")
+    }
+
+    // MARK: - Multiple entries in one file
+
+    /// When several exports are written before the file is closed they land in
+    /// the same on-disk batch. A single upload must wrap them all inside one
+    /// `message-batch` payload array.
+    func testExportMultipleItems_batchedInOneFile_uploadedAsOneEnvelope() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let (exporter, storage) = try makeExporter(performancePreset: .appendToOneFile, server: server)
+        defer { try? storage.delete() }
+
+        let series = TelemetryMetric.Series(metric: "m", points: [.init(timestamp: 1, value: 1)])
+        let log = TelemetryLog(message: "msg", level: .debug)
+        exporter.export(items: [
+            TelemetryMetric(namespace: .general, series: [series]),
+            TelemetryLog.Logs([log]),
+            TelemetryAppHeartbeat(),
+        ])
+        // Close the in-progress file and drain it synchronously.
+        exporter.flush()
+
+        guard server.waitForTelemetry(count: 1, timeout: 5) else {
+            XCTFail("Expected 1 telemetry batch, got \(server.requests.telemetry.count)")
+            return
+        }
+        XCTAssertEqual(server.requests.telemetry.count, 1, "All entries should be in one envelope")
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        try assertValidEnvelope(raw, expectedEntryCount: 3)
+
+        let payload = try XCTUnwrap(
+            (JSONSerialization.jsonObject(with: raw) as? [String: Any])?["payload"] as? [[String: Any]]
+        )
+        print("PAYLOAD", payload)
+        let types = Set(payload.compactMap { $0["request_type"] as? String })
+        XCTAssertEqual(types, ["generate-metrics", "logs", "app-heartbeat"])
+    }
+
+    // MARK: - Multiple entries across separate files
+
+    /// When each export goes to its own file (maxObjectsInFile=1) the upload
+    /// worker sends them as separate `message-batch` requests, each containing
+    /// exactly one entry.
+    func testExportMultipleItems_acrossSeparateFiles_eachUploadedIndependently() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let (exporter, storage) = try makeExporter(
+            performancePreset: .writeEachObjectToNewFileAndReadAllFiles, server: server
+        )
+        defer { try? storage.delete() }
+
+        let series = TelemetryMetric.Series(metric: "m", points: [.init(timestamp: 1, value: 1)])
+        let log = TelemetryLog(message: "msg", level: .debug)
+        exporter.export(items: [
+            TelemetryMetric(namespace: .general, series: [series]),
+            TelemetryLog.Logs([log]),
+            TelemetryAppHeartbeat(),
+        ])
+
+        guard server.waitForTelemetry(count: 3, timeout: 30) else {
+            XCTFail("Expected 3 telemetry batches, got \(server.requests.telemetry.count)")
+            return
+        }
+
+        // Each file becomes its own well-formed envelope containing one entry.
+        for raw in server.requests.telemetry {
+            try assertValidEnvelope(raw, expectedEntryCount: 1)
+        }
+
+        let allTypes = try server.requests.telemetry.flatMap { raw -> [String] in
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+            let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+            return payload.compactMap { $0["request_type"] as? String }
+        }
+        XCTAssertEqual(Set(allTypes), ["generate-metrics", "logs", "app-heartbeat"])
+    }
+}

--- a/Tests/EventsExporter/Upload/DataUploaderTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploaderTests.swift
@@ -42,7 +42,7 @@ class DataUploaderTests: XCTestCase {
         let uploadStatus = uploader.upload(data: .mockAny())
 
         // Then
-        let expectedUploadStatus = DataUploadStatus(networkError: .transport(randomError))
+        let expectedUploadStatus = DataUploadStatus(api: .transport(randomError))
         XCTAssertEqual(uploadStatus, expectedUploadStatus)
         httpClient.waitFor(requestsCompletion: 1)
     }

--- a/Tests/TestUtils/MockBackend.swift
+++ b/Tests/TestUtils/MockBackend.swift
@@ -69,6 +69,8 @@ public final class MockBackend {
         public var searchCommits: [Data] = []
         /// All packfiles received so far.
         public var packfile: [Data] = []
+        /// Raw bodies of all telemetry (apmtelemetry) requests.
+        public var telemetry: [Data] = []
 
         /// All spans across all received envelopes.
         public var allSpans: [Span] { spanEnvelopes.flatMap(\.allSpans) }
@@ -170,6 +172,12 @@ public final class MockBackend {
         poll(timeout: timeout) { self._lock.withLock { self._requests.settings.count >= count } }
     }
 
+    /// Blocks until at least `count` telemetry batches have been received, or `timeout` elapses.
+    @discardableResult
+    public func waitForTelemetry(count: Int = 1, timeout: TimeInterval = 10) -> Bool {
+        poll(timeout: timeout) { self._lock.withLock { self._requests.telemetry.count >= count } }
+    }
+
     private func poll(timeout: TimeInterval, condition: () -> Bool) -> Bool {
         let deadline = Date(timeIntervalSinceNow: timeout)
         while Date() < deadline {
@@ -221,6 +229,10 @@ public final class MockBackend {
 
         case "/api/v2/git/repository/packfile":
             _lock.withLock { _requests.packfile.append(body) }
+            return (.ok, "application/json", Data("{}".utf8))
+
+        case "/api/v2/apmtelemetry":
+            _lock.withLock { _requests.telemetry.append(body) }
             return (.ok, "application/json", Data("{}".utf8))
 
         case "/api/v2/test/libraries/test-management/tests":


### PR DESCRIPTION
## Summary

- Adds `TelemetryExporter` — a file-backed batching exporter that writes telemetry items to disk and uploads them as `message-batch` envelopes via `TelemetryApi`
- Refactors internal wire types (`TelemetryMetric`, `TelemetryLog.Logs`, `TelemetryAppStarted/Heartbeat/Closing`, `TelemetryMessageBatch`) into public `Codable` structs conforming to a new `TelemetryPayload` protocol; replaces the old `TelemetryBatchItem` enum
- Cleans up `ClosureDataUploader` / `DataUploadStatus` to use typed `APICallError` throws throughout; extends `MockBackend` with `/api/v2/apmtelemetry` endpoint and `waitForTelemetry()` helper

## Test plan

- [x] `TelemetryExporterTests/testExportMetrics_uploadsWellFormedEnvelope` — single metric item produces a valid `message-batch` envelope
- [x] `TelemetryExporterTests/testExportLogs_uploadsWellFormedEnvelope` — single log item produces a valid envelope
- [x] `TelemetryExporterTests/testExportMultipleItems_batchedInOneFile_uploadedAsOneEnvelope` — multiple items written to one file are batched into a single upload
- [x] `TelemetryExporterTests/testExportMultipleItems_acrossSeparateFiles_eachUploadedIndependently` — items written to separate files produce independent uploads
- [x] Full `EventsExporter` test suite passes with no regressions

Jira: [SDTEST-3772](https://datadoghq.atlassian.net/browse/SDTEST-3772)

🤖 Generated with [Claude Code](https://claude.com/claude-code)