### PR TITLE
[SDTEST-3774] Add TelemetryMetricExporter bridging OTel metrics to TelemetryExporter

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		56B58A2FC91F21D1ABB0155E /* TelemetryApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EB970146040DD4967C7411 /* TelemetryApi.swift */; };
 		821FA0CC8B62245A4949FDBB /* APITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85241CF97F1B6DAA49ECA23 /* APITypes.swift */; };
 		86137D23E1704D17A7B6D486 /* TelemetryExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */; };
+		A7926AF42FCDD411007834F2 /* TelemetryMetricExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */; };
 		8EF6F88255506A4CEE6D36B6 /* GitUploadApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */; };
 		97326DD4F8EF4EBDB05AC1AA /* TelemetryExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */; };
 		98D8D496CC4210A0D1D07F93 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12536CCE14EC1D3DAAC8DB81 /* Synced.swift */; };
@@ -78,6 +79,7 @@
 		A77C123C2D9425C7009C2BA1 /* KnownTestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */; };
 		A77C123E2D9474E6009C2BA1 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C123D2D9474E6009C2BA1 /* Models.swift */; };
 		A7926AEF2FCDCBFE007834F2 /* TelemetryLogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AEE2FCDCBFE007834F2 /* TelemetryLogExporter.swift */; };
+		A7926AF12FCDD411007834F2 /* TelemetryMetricExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF02FCDD411007834F2 /* TelemetryMetricExporter.swift */; };
 		A794A8FF2E7990D20044FE3C /* TestManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */; };
 		A79DA5B42F928F87004BCA8C /* SwiftTestingSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79DA5B32F928F87004BCA8C /* SwiftTestingSmokeTests.swift */; };
 		A79DA5B72F929812004BCA8C /* DatadogSDKTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7FC25642BA1E83500067E26 /* DatadogSDKTesting.framework */; };
@@ -422,6 +424,7 @@
 		0083E7241E320B00198C0D71 /* TestManagementApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestManagementApi.swift; sourceTree = "<group>"; };
 		01EB970146040DD4967C7411 /* TelemetryApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryApi.swift; sourceTree = "<group>"; };
 		04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelemetryExporterTests.swift; sourceTree = "<group>"; };
+		A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryMetricExporterTests.swift; sourceTree = "<group>"; };
 		0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisSwiftTestingTests.swift; sourceTree = "<group>"; };
 		12536CCE14EC1D3DAAC8DB81 /* Synced.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Synced.swift; sourceTree = "<group>"; };
 		1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisApi.swift; sourceTree = "<group>"; };
@@ -491,6 +494,7 @@
 		A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownTestsTests.swift; sourceTree = "<group>"; };
 		A77C123D2D9474E6009C2BA1 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		A7926AEE2FCDCBFE007834F2 /* TelemetryLogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryLogExporter.swift; sourceTree = "<group>"; };
+		A7926AF02FCDD411007834F2 /* TelemetryMetricExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryMetricExporter.swift; sourceTree = "<group>"; };
 		A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestManagementTests.swift; sourceTree = "<group>"; };
 		A79DA5B22F928F71004BCA8C /* IntegrationTests-UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "IntegrationTests-UnitTests.xctestplan"; sourceTree = "<group>"; };
 		A79DA5B32F928F87004BCA8C /* SwiftTestingSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftTestingSmokeTests.swift; sourceTree = "<group>"; };
@@ -806,6 +810,7 @@
 			isa = PBXGroup;
 			children = (
 				04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */,
+				A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -986,6 +991,7 @@
 			children = (
 				BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */,
 				A7926AEE2FCDCBFE007834F2 /* TelemetryLogExporter.swift */,
+				A7926AF02FCDD411007834F2 /* TelemetryMetricExporter.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -2153,6 +2159,7 @@
 				A7FC264A2BA1ECF800067E26 /* File.swift in Sources */,
 				A7FC264D2BA1ED1200067E26 /* Exporter.swift in Sources */,
 				A7FC26302BA1ECBD00067E26 /* CoverageExporter.swift in Sources */,
+				A7926AF12FCDD411007834F2 /* TelemetryMetricExporter.swift in Sources */,
 				A7AB7C2026E7EB1100000011 /* CoverageData.swift in Sources */,
 				A7AB7C2026E7EB1100000013 /* CoverageProcessor.swift in Sources */,
 				A7FC263B2BA1ECCF00067E26 /* Feature.swift in Sources */,
@@ -2206,6 +2213,7 @@
 				A7FC26822BA1F81D00067E26 /* DeviceMock.swift in Sources */,
 				A7FC26722BA1F80000067E26 /* EncodableValueTests.swift in Sources */,
 				86137D23E1704D17A7B6D486 /* TelemetryExporterTests.swift in Sources */,
+				A7926AF42FCDD411007834F2 /* TelemetryMetricExporterTests.swift in Sources */,
 				A7FC26702BA1F7FA00067E26 /* SpansExporterTests.swift in Sources */,
 				A7FC268C2BA1F82300067E26 /* HTTPClientTests.swift in Sources */,
 				A7FC26742BA1F80000067E26 /* JSONEncoderTests.swift in Sources */,

--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		821FA0CC8B62245A4949FDBB /* APITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85241CF97F1B6DAA49ECA23 /* APITypes.swift */; };
 		86137D23E1704D17A7B6D486 /* TelemetryExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */; };
 		A7926AF42FCDD411007834F2 /* TelemetryMetricExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */; };
+		A7926AF62FCDD411007834F2 /* TelemetryLogExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF52FCDD411007834F2 /* TelemetryLogExporterTests.swift */; };
 		8EF6F88255506A4CEE6D36B6 /* GitUploadApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */; };
 		97326DD4F8EF4EBDB05AC1AA /* TelemetryExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */; };
 		98D8D496CC4210A0D1D07F93 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12536CCE14EC1D3DAAC8DB81 /* Synced.swift */; };
@@ -425,6 +426,7 @@
 		01EB970146040DD4967C7411 /* TelemetryApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryApi.swift; sourceTree = "<group>"; };
 		04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelemetryExporterTests.swift; sourceTree = "<group>"; };
 		A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryMetricExporterTests.swift; sourceTree = "<group>"; };
+		A7926AF52FCDD411007834F2 /* TelemetryLogExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryLogExporterTests.swift; sourceTree = "<group>"; };
 		0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisSwiftTestingTests.swift; sourceTree = "<group>"; };
 		12536CCE14EC1D3DAAC8DB81 /* Synced.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Synced.swift; sourceTree = "<group>"; };
 		1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisApi.swift; sourceTree = "<group>"; };
@@ -811,6 +813,7 @@
 			children = (
 				04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */,
 				A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */,
+				A7926AF52FCDD411007834F2 /* TelemetryLogExporterTests.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -2214,6 +2217,7 @@
 				A7FC26722BA1F80000067E26 /* EncodableValueTests.swift in Sources */,
 				86137D23E1704D17A7B6D486 /* TelemetryExporterTests.swift in Sources */,
 				A7926AF42FCDD411007834F2 /* TelemetryMetricExporterTests.swift in Sources */,
+				A7926AF62FCDD411007834F2 /* TelemetryLogExporterTests.swift in Sources */,
 				A7FC26702BA1F7FA00067E26 /* SpansExporterTests.swift in Sources */,
 				A7FC268C2BA1F82300067E26 /* HTTPClientTests.swift in Sources */,
 				A7FC26742BA1F80000067E26 /* JSONEncoderTests.swift in Sources */,

--- a/Sources/EventsExporter/API/TelemetryApi.swift
+++ b/Sources/EventsExporter/API/TelemetryApi.swift
@@ -20,6 +20,7 @@ public protocol TelemetryPayload: Encodable {
 /// The set of telemetry request_types this service implements.
 public enum TelemetryRequestType: String, Codable {
     case generateMetrics = "generate-metrics"
+    case distributions
     case logs
     case messageBatch = "message-batch"
     case appStarted = "app-started"
@@ -100,6 +101,52 @@ public struct TelemetryMetric: TelemetryPayload, Codable {
     }
     
     public var requestType: TelemetryRequestType { .generateMetrics }
+}
+
+/// A single telemetry distribution payload for `distributions`.
+///
+/// Unlike `generate-metrics`, distribution series carry raw sample values
+/// (not `[timestamp, value]` pairs), and the backend computes the statistical
+/// summary (p50/p75/p90/p95/p99/max). The namespace set is also distinct.
+public struct TelemetryDistribution: TelemetryPayload, Codable {
+    /// Namespace for distribution metrics.
+    public enum Namespace: String, Codable {
+        case tracers, profilers, rum, appsec
+    }
+
+    /// A distribution series with one or more raw sample values.
+    public struct Series: Codable {
+        public var metric: String
+        /// Raw sample values — the backend computes the distribution.
+        public var points: [Double]
+        public var tags: [String]?
+        public var common: Bool?
+        /// Per-series override for the payload-level namespace.
+        public var namespace: Namespace?
+
+        public init(metric: String,
+                    points: [Double],
+                    tags: [String]? = nil,
+                    common: Bool? = nil,
+                    namespace: Namespace? = nil)
+        {
+            self.metric = metric
+            self.points = points
+            self.tags = tags
+            self.common = common
+            self.namespace = namespace
+        }
+    }
+
+    public var namespace: Namespace?
+    public var series: [Series]
+
+    public init(namespace: Namespace?, series: [Series]) {
+        self.namespace = namespace
+        self.series = series
+    }
+
+    public var requestType: TelemetryRequestType { .distributions }
 }
 
 /// A single telemetry log message for the `logs` request type.
@@ -347,6 +394,8 @@ public struct TelemetryMessageBatch: TelemetryPayload, Codable {
                 message = try container.decode(TelemetryLog.Logs.self, forKey: .payload)
             case .generateMetrics:
                 message = try container.decode(TelemetryMetric.self, forKey: .payload)
+            case .distributions:
+                message = try container.decode(TelemetryDistribution.self, forKey: .payload)
             case .messageBatch:
                 message = try container.decode(TelemetryMessageBatch.self, forKey: .payload)
             }
@@ -408,6 +457,10 @@ public protocol TelemetryApi: APIService {
     /// Send a batch of metric series via the `generate-metrics` request type.
     func sendMetrics(_ series: [TelemetryMetric.Series],
                      namespace: TelemetryMetric.Namespace?) async throws(APICallError)
+
+    /// Send a batch of distribution series via the `distributions` request type.
+    func sendDistributions(_ series: [TelemetryDistribution.Series],
+                           namespace: TelemetryDistribution.Namespace?) async throws(APICallError)
 
     /// Send a batch of log messages via the `logs` request type.
     func sendLogs(_ logs: [TelemetryLog]) async throws(APICallError)
@@ -515,6 +568,13 @@ internal struct TelemetryApiService: TelemetryApi {
                      namespace: TelemetryMetric.Namespace?) async throws(APICallError)
     {
         let payload = TelemetryMetric(namespace: namespace, series: series)
+        try await send(payload: payload)
+    }
+
+    func sendDistributions(_ series: [TelemetryDistribution.Series],
+                           namespace: TelemetryDistribution.Namespace?) async throws(APICallError)
+    {
+        let payload = TelemetryDistribution(namespace: namespace, series: series)
         try await send(payload: payload)
     }
 

--- a/Sources/EventsExporter/API/TelemetryApi.swift
+++ b/Sources/EventsExporter/API/TelemetryApi.swift
@@ -535,8 +535,10 @@ internal struct TelemetryApiService: TelemetryApi {
         let dataFormat: DataFormat
         do {
             dataFormat = try DataFormat(header: header, encoder: encoder)
+        } catch let error as EncodingError {
+            throw .encoding(value: header, error: error)
         } catch {
-            throw .transport(error)
+            throw .unknownError(error)
         }
         try await send(requestType: .messageBatch,
                        body: dataFormat.prefix + data + dataFormat.suffix)

--- a/Sources/EventsExporter/OpenTelemetry+Extensions.swift
+++ b/Sources/EventsExporter/OpenTelemetry+Extensions.swift
@@ -49,13 +49,21 @@ public extension Resource {
         set { attributes[SemanticConventions.Deployment.environmentName.rawValue] = newValue.map { .string($0) } }
     }
 
-    /// Datadog telemetry namespace hint for metrics produced by a meter provider.
-    /// The metric exporter uses this as the per-series namespace when it's valid for
-    /// the target payload. The value should match a `TelemetryMetric.Namespace` /
-    /// `TelemetryDistribution.Namespace` raw value (e.g. `"tracers"`, `"general"`).
-    var telemetryNamespace: String? {
-        get { attributes["dd.telemetry.namespace"]?.description }
-        set { attributes["dd.telemetry.namespace"] = newValue.map { .string($0) } }
+    /// Datadog telemetry namespace for `generate-metrics` series (gauge / count /
+    /// summary) produced by a meter provider. Used by the metric exporter as the
+    /// per-series namespace override.
+    var telemetryMetricNamespace: TelemetryMetric.Namespace? {
+        get { (attributes["dd.telemetry.metric.namespace"]?.description).flatMap(TelemetryMetric.Namespace.init(rawValue:)) }
+        set { attributes["dd.telemetry.metric.namespace"] = newValue.map { .string($0.rawValue) } }
+    }
+
+    /// Datadog telemetry namespace for `distributions` series (histograms) produced
+    /// by a meter provider. Used by the metric exporter as the per-series namespace
+    /// override. Kept separate from `telemetryMetricNamespace` because the two
+    /// payload types accept different namespace value sets.
+    var telemetryDistributionNamespace: TelemetryDistribution.Namespace? {
+        get { (attributes["dd.telemetry.distribution.namespace"]?.description).flatMap(TelemetryDistribution.Namespace.init(rawValue:)) }
+        set { attributes["dd.telemetry.distribution.namespace"] = newValue.map { .string($0.rawValue) } }
     }
 }
 

--- a/Sources/EventsExporter/OpenTelemetry+Extensions.swift
+++ b/Sources/EventsExporter/OpenTelemetry+Extensions.swift
@@ -48,6 +48,15 @@ public extension Resource {
         get { attributes[SemanticConventions.Deployment.environmentName.rawValue]?.description }
         set { attributes[SemanticConventions.Deployment.environmentName.rawValue] = newValue.map { .string($0) } }
     }
+
+    /// Datadog telemetry namespace hint for metrics produced by a meter provider.
+    /// The metric exporter uses this as the per-series namespace when it's valid for
+    /// the target payload. The value should match a `TelemetryMetric.Namespace` /
+    /// `TelemetryDistribution.Namespace` raw value (e.g. `"tracers"`, `"general"`).
+    var telemetryNamespace: String? {
+        get { attributes["dd.telemetry.namespace"]?.description }
+        set { attributes["dd.telemetry.namespace"] = newValue.map { .string($0) } }
+    }
 }
 
 // MARK: - Test-attribute accessors on SpanData / AttributeValue dictionaries

--- a/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
@@ -170,7 +170,7 @@ private extension TelemetryDistribution.Series {
 
     // Reconstruct approximate sample values from explicit-boundary histogram buckets.
     // For each bucket, the representative value is:
-    //   - underflow (first) bucket: min if available, else 0
+    //   - underflow (first) bucket: min if available, else the first boundary
     //   - interior buckets: midpoint of the two boundaries
     //   - overflow (last) bucket: max if available, else the upper boundary
     private static func fromHistogram(_ points: [HistogramPointData],
@@ -203,7 +203,7 @@ private extension TelemetryDistribution.Series {
             guard count > 0 else { continue }
             let midpoint: Double
             if i == 0 {
-                midpoint = point.hasMin ? point.min : 0
+                midpoint = point.hasMin ? point.min : boundaries[0]
             } else if i == boundaries.count {
                 midpoint = point.hasMax ? point.max : boundaries[boundaries.count - 1]
             } else {

--- a/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
@@ -107,7 +107,7 @@ private enum MetricConversion {
 private extension TelemetryMetric.Series {
     // Returns nil for histogram types — those go to TelemetryDistribution instead.
     static func from(_ metric: MetricData) -> [TelemetryMetric.Series]? {
-        let namespace = metric.resource.telemetryNamespace.flatMap(TelemetryMetric.Namespace.init(rawValue:))
+        let namespace = metric.resource.telemetryMetricNamespace
         switch metric.type {
         case .LongGauge, .DoubleGauge:
             return scalar(metric.data.points, name: metric.name, type: .gauge, namespace: namespace)
@@ -176,7 +176,7 @@ private extension TelemetryMetric.Series {
 private extension TelemetryDistribution.Series {
     // Returns nil for non-histogram types.
     static func from(_ metric: MetricData) -> [TelemetryDistribution.Series]? {
-        let namespace = metric.resource.telemetryNamespace.flatMap(TelemetryDistribution.Namespace.init(rawValue:))
+        let namespace = metric.resource.telemetryDistributionNamespace
         switch metric.type {
         case .Histogram:
             return fromHistogram(metric.data.points as! [HistogramPointData],

--- a/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
@@ -11,17 +11,30 @@ import OpenTelemetrySdk
 internal final class TelemetryMetricExporter: MetricExporter {
     let telemetryExporter: TelemetryExporter
     let namespace: TelemetryMetric.Namespace?
+    let distributionNamespace: TelemetryDistribution.Namespace?
 
-    init(telemetryExporter: TelemetryExporter, namespace: TelemetryMetric.Namespace? = nil) {
+    init(telemetryExporter: TelemetryExporter,
+         namespace: TelemetryMetric.Namespace? = nil,
+         distributionNamespace: TelemetryDistribution.Namespace? = nil)
+    {
         self.telemetryExporter = telemetryExporter
         self.namespace = namespace
+        self.distributionNamespace = distributionNamespace
     }
 
     func export(metrics: [MetricData]) -> ExportResult {
         guard !metrics.isEmpty else { return .success }
-        let series = metrics.flatMap { TelemetryMetric.Series.from($0) }
-        guard !series.isEmpty else { return .success }
-        telemetryExporter.export(item: TelemetryMetric(namespace: namespace, series: series))
+
+        let scalarSeries = metrics.compactMap(TelemetryMetric.Series.from(_:)).flatMap { $0 }
+        if !scalarSeries.isEmpty {
+            telemetryExporter.export(item: TelemetryMetric(namespace: namespace, series: scalarSeries))
+        }
+
+        let distSeries = metrics.compactMap(TelemetryDistribution.Series.from(_:)).flatMap { $0 }
+        if !distSeries.isEmpty {
+            telemetryExporter.export(item: TelemetryDistribution(namespace: distributionNamespace, series: distSeries))
+        }
+
         return .success
     }
 
@@ -39,77 +52,12 @@ internal final class TelemetryMetricExporter: MetricExporter {
     }
 }
 
-// MARK: - MetricData → TelemetryMetric.Series conversion
+// MARK: - Shared helpers
 
-private extension TelemetryMetric.Series {
-    static func from(_ metric: MetricData) -> [TelemetryMetric.Series] {
-        switch metric.type {
-        case .LongGauge, .DoubleGauge:
-            return scalar(metric.data.points, name: metric.name, type: .gauge)
-        case .LongSum, .DoubleSum:
-            return scalar(metric.data.points, name: metric.name,
-                         type: metric.isMonotonic ? .count : .gauge)
-        case .Histogram:
-            return countAndSum(metric.data.points as! [HistogramPointData],
-                               name: metric.name,
-                               countOf: { Double($0.count) },
-                               sumOf: { $0.sum })
-        case .ExponentialHistogram:
-            return countAndSum(metric.data.points as! [ExponentialHistogramPointData],
-                               name: metric.name,
-                               countOf: { Double($0.count) },
-                               sumOf: { $0.sum })
-        case .Summary:
-            return countAndSum(metric.data.points as! [SummaryPointData],
-                               name: metric.name,
-                               countOf: { Double($0.count) },
-                               sumOf: { $0.sum })
-        }
-    }
-
-    // One series per distinct attribute set, each carrying all matching points.
-    private static func scalar(_ points: [PointData], name: String,
-                               type: TelemetryMetric.MetricType) -> [TelemetryMetric.Series]
-    {
-        groupByAttributes(points).map { attrs, pts in
-            TelemetryMetric.Series(
-                metric: name,
-                points: pts.map { .init(timestamp: epochSeconds($0), value: scalarValue($0)) },
-                type: type,
-                tags: tags(attrs)
-            )
-        }
-    }
-
-    // Histogram-like types emit a `{name}.count` and `{name}.sum` series per attribute set.
-    private static func countAndSum<P: PointData>(
-        _ points: [P],
-        name: String,
-        countOf: (P) -> Double,
-        sumOf: (P) -> Double
-    ) -> [TelemetryMetric.Series] {
-        groupByAttributes(points).flatMap { attrs, pts -> [TelemetryMetric.Series] in
-            let tags = tags(attrs)
-            return [
-                TelemetryMetric.Series(
-                    metric: "\(name).count",
-                    points: pts.map { .init(timestamp: epochSeconds($0), value: countOf($0)) },
-                    type: .count,
-                    tags: tags
-                ),
-                TelemetryMetric.Series(
-                    metric: "\(name).sum",
-                    points: pts.map { .init(timestamp: epochSeconds($0), value: sumOf($0)) },
-                    type: .count,
-                    tags: tags
-                ),
-            ]
-        }
-    }
-
+private enum MetricConversion {
     // Group an array of PointData by their sorted attribute string so that
     // points with the same label set land in the same series.
-    private static func groupByAttributes<P: PointData>(_ points: [P]) -> [([String: AttributeValue], [P])] {
+    static func groupByAttributes<P: PointData>(_ points: [P]) -> [([String: AttributeValue], [P])] {
         var order: [String] = []
         var groups: [String: ([String: AttributeValue], [P])] = [:]
         for point in points {
@@ -123,22 +71,185 @@ private extension TelemetryMetric.Series {
         return order.map { groups[$0]! }
     }
 
-    private static func epochSeconds(_ point: PointData) -> TimeInterval {
+    static func epochSeconds(_ point: PointData) -> TimeInterval {
         TimeInterval(point.endEpochNanos) / 1_000_000_000
     }
 
-    private static func scalarValue(_ point: PointData) -> Double {
+    static func scalarValue(_ point: PointData) -> Double {
         if let p = point as? LongPointData { return Double(p.value) }
         if let p = point as? DoublePointData { return p.value }
         return 0
     }
 
-    private static func tags(_ attributes: [String: AttributeValue]) -> [String]? {
+    static func tags(_ attributes: [String: AttributeValue]) -> [String]? {
         guard !attributes.isEmpty else { return nil }
         return attributes.map { "\($0.key):\($0.value.description)" }.sorted()
     }
 
-    private static func tagString(_ attributes: [String: AttributeValue]) -> String {
+    static func tagString(_ attributes: [String: AttributeValue]) -> String {
         tags(attributes)?.joined(separator: ",") ?? ""
+    }
+}
+
+// MARK: - MetricData → TelemetryMetric.Series (gauge / sum / summary)
+
+private extension TelemetryMetric.Series {
+    // Returns nil for histogram types — those go to TelemetryDistribution instead.
+    static func from(_ metric: MetricData) -> [TelemetryMetric.Series]? {
+        switch metric.type {
+        case .LongGauge, .DoubleGauge:
+            return scalar(metric.data.points, name: metric.name, type: .gauge)
+        case .LongSum, .DoubleSum:
+            return scalar(metric.data.points, name: metric.name,
+                         type: metric.isMonotonic ? .count : .gauge)
+        case .Summary:
+            return countAndSum(metric.data.points as! [SummaryPointData],
+                               name: metric.name,
+                               countOf: { Double($0.count) },
+                               sumOf: { $0.sum })
+        case .Histogram, .ExponentialHistogram:
+            return nil
+        }
+    }
+
+    private static func scalar(_ points: [PointData], name: String,
+                               type: TelemetryMetric.MetricType) -> [TelemetryMetric.Series]
+    {
+        MetricConversion.groupByAttributes(points).map { attrs, pts in
+            TelemetryMetric.Series(
+                metric: name,
+                points: pts.map { .init(timestamp: MetricConversion.epochSeconds($0),
+                                        value: MetricConversion.scalarValue($0)) },
+                type: type,
+                tags: MetricConversion.tags(attrs)
+            )
+        }
+    }
+
+    // Summary emits {name}.count and {name}.sum as generate-metrics (already aggregated).
+    private static func countAndSum<P: PointData>(
+        _ points: [P],
+        name: String,
+        countOf: (P) -> Double,
+        sumOf: (P) -> Double
+    ) -> [TelemetryMetric.Series] {
+        MetricConversion.groupByAttributes(points).flatMap { attrs, pts -> [TelemetryMetric.Series] in
+            let tags = MetricConversion.tags(attrs)
+            return [
+                TelemetryMetric.Series(
+                    metric: "\(name).count",
+                    points: pts.map { .init(timestamp: MetricConversion.epochSeconds($0), value: countOf($0)) },
+                    type: .count,
+                    tags: tags
+                ),
+                TelemetryMetric.Series(
+                    metric: "\(name).sum",
+                    points: pts.map { .init(timestamp: MetricConversion.epochSeconds($0), value: sumOf($0)) },
+                    type: .count,
+                    tags: tags
+                ),
+            ]
+        }
+    }
+}
+
+// MARK: - MetricData → TelemetryDistribution.Series (histogram types)
+
+private extension TelemetryDistribution.Series {
+    // Returns nil for non-histogram types.
+    static func from(_ metric: MetricData) -> [TelemetryDistribution.Series]? {
+        switch metric.type {
+        case .Histogram:
+            return fromHistogram(metric.data.points as! [HistogramPointData], name: metric.name)
+        case .ExponentialHistogram:
+            return fromExponentialHistogram(metric.data.points as! [ExponentialHistogramPointData], name: metric.name)
+        default:
+            return nil
+        }
+    }
+
+    // Reconstruct approximate sample values from explicit-boundary histogram buckets.
+    // For each bucket, the representative value is:
+    //   - underflow (first) bucket: min if available, else 0
+    //   - interior buckets: midpoint of the two boundaries
+    //   - overflow (last) bucket: max if available, else the upper boundary
+    private static func fromHistogram(_ points: [HistogramPointData],
+                                      name: String) -> [TelemetryDistribution.Series]
+    {
+        MetricConversion.groupByAttributes(points).compactMap { attrs, pts -> TelemetryDistribution.Series? in
+            let samples = pts.flatMap { reconstructSamples(from: $0) }
+            guard !samples.isEmpty else { return nil }
+            return TelemetryDistribution.Series(
+                metric: name,
+                points: samples,
+                tags: MetricConversion.tags(attrs)
+            )
+        }
+    }
+
+    private static func reconstructSamples(from point: HistogramPointData) -> [Double] {
+        guard point.count > 0 else { return [] }
+        let boundaries = point.boundaries
+        let counts = point.counts
+
+        // No boundaries: use sum/count as a single representative value repeated count times.
+        guard !boundaries.isEmpty else {
+            let avg = point.count > 0 ? point.sum / Double(point.count) : 0
+            return Array(repeating: avg, count: Int(point.count))
+        }
+
+        var samples: [Double] = []
+        for (i, count) in counts.enumerated() {
+            guard count > 0 else { continue }
+            let midpoint: Double
+            if i == 0 {
+                midpoint = point.hasMin ? point.min : 0
+            } else if i == boundaries.count {
+                midpoint = point.hasMax ? point.max : boundaries[boundaries.count - 1]
+            } else {
+                midpoint = (boundaries[i - 1] + boundaries[i]) / 2
+            }
+            samples.append(contentsOf: Array(repeating: midpoint, count: count))
+        }
+        return samples
+    }
+
+    // Reconstruct approximate sample values from exponential-bucket histogram points.
+    // Base = 2^(2^-scale); each bucket i covers [base^(offset+i), base^(offset+i+1)).
+    // Representative value: geometric midpoint = base^(offset+i+0.5).
+    private static func fromExponentialHistogram(_ points: [ExponentialHistogramPointData],
+                                                 name: String) -> [TelemetryDistribution.Series]
+    {
+        MetricConversion.groupByAttributes(points).compactMap { attrs, pts -> TelemetryDistribution.Series? in
+            let samples = pts.flatMap { reconstructSamples(from: $0) }
+            guard !samples.isEmpty else { return nil }
+            return TelemetryDistribution.Series(
+                metric: name,
+                points: samples,
+                tags: MetricConversion.tags(attrs)
+            )
+        }
+    }
+
+    private static func reconstructSamples(from point: ExponentialHistogramPointData) -> [Double] {
+        guard point.count > 0 else { return [] }
+        // base = 2^(2^-scale)
+        let base = pow(2.0, pow(2.0, Double(-point.scale)))
+        var samples: [Double] = []
+
+        if point.zeroCount > 0 {
+            samples.append(contentsOf: Array(repeating: 0.0, count: Int(point.zeroCount)))
+        }
+        for (i, count) in point.positiveBuckets.bucketCounts.enumerated() {
+            guard count > 0 else { continue }
+            let exp = Double(point.positiveBuckets.offset + i) + 0.5
+            samples.append(contentsOf: Array(repeating: pow(base, exp), count: Int(count)))
+        }
+        for (i, count) in point.negativeBuckets.bucketCounts.enumerated() {
+            guard count > 0 else { continue }
+            let exp = Double(point.negativeBuckets.offset + i) + 0.5
+            samples.append(contentsOf: Array(repeating: -pow(base, exp), count: Int(count)))
+        }
+        return samples
     }
 }

--- a/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
@@ -63,33 +63,9 @@ internal final class TelemetryMetricExporter: MetricExporter {
     }
 }
 
-// MARK: - Resource-driven configuration
-
-internal enum TelemetryMetricResourceKeys {
-    /// Resource attribute key whose value selects the telemetry namespace for the
-    /// metrics / distributions produced from a meter provider. The value must match
-    /// a `TelemetryMetric.Namespace` / `TelemetryDistribution.Namespace` raw value
-    /// (e.g. `"tracers"`, `"general"`). When absent or unrecognized, the exporter's
-    /// configured payload-level namespace is used instead.
-    static let namespace = "dd.telemetry.namespace"
-}
-
 // MARK: - Shared helpers
 
 private enum MetricConversion {
-    // Per-metric namespace override read from the metric's Resource, if present.
-    static func metricNamespace(from resource: Resource) -> TelemetryMetric.Namespace? {
-        namespaceString(from: resource).flatMap(TelemetryMetric.Namespace.init(rawValue:))
-    }
-
-    static func distributionNamespace(from resource: Resource) -> TelemetryDistribution.Namespace? {
-        namespaceString(from: resource).flatMap(TelemetryDistribution.Namespace.init(rawValue:))
-    }
-
-    private static func namespaceString(from resource: Resource) -> String? {
-        resource.attributes[TelemetryMetricResourceKeys.namespace]?.description
-    }
-
     // Group an array of PointData by their sorted attribute string so that
     // points with the same label set land in the same series.
     static func groupByAttributes<P: PointData>(_ points: [P]) -> [([String: AttributeValue], [P])] {
@@ -131,7 +107,7 @@ private enum MetricConversion {
 private extension TelemetryMetric.Series {
     // Returns nil for histogram types — those go to TelemetryDistribution instead.
     static func from(_ metric: MetricData) -> [TelemetryMetric.Series]? {
-        let namespace = MetricConversion.metricNamespace(from: metric.resource)
+        let namespace = metric.resource.telemetryNamespace.flatMap(TelemetryMetric.Namespace.init(rawValue:))
         switch metric.type {
         case .LongGauge, .DoubleGauge:
             return scalar(metric.data.points, name: metric.name, type: .gauge, namespace: namespace)
@@ -200,7 +176,7 @@ private extension TelemetryMetric.Series {
 private extension TelemetryDistribution.Series {
     // Returns nil for non-histogram types.
     static func from(_ metric: MetricData) -> [TelemetryDistribution.Series]? {
-        let namespace = MetricConversion.distributionNamespace(from: metric.resource)
+        let namespace = metric.resource.telemetryNamespace.flatMap(TelemetryDistribution.Namespace.init(rawValue:))
         switch metric.type {
         case .Histogram:
             return fromHistogram(metric.data.points as! [HistogramPointData],

--- a/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
@@ -48,7 +48,18 @@ internal final class TelemetryMetricExporter: MetricExporter {
     }
 
     func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {
-        .cumulative
+        switch instrument {
+        case .upDownCounter, .observableUpDownCounter:
+            // These map to a DD gauge, where the current running total is the value
+            // we want to report — so keep them cumulative.
+            return .cumulative
+        default:
+            // Counters map to DD `count` (summed per interval) and histograms map to
+            // `distributions` (raw samples per interval). Both expect per-interval
+            // deltas; cumulative running totals would inflate counts and re-emit the
+            // full sample set on every collection. Request delta temporality.
+            return .delta
+        }
     }
 }
 

--- a/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
@@ -63,9 +63,33 @@ internal final class TelemetryMetricExporter: MetricExporter {
     }
 }
 
+// MARK: - Resource-driven configuration
+
+internal enum TelemetryMetricResourceKeys {
+    /// Resource attribute key whose value selects the telemetry namespace for the
+    /// metrics / distributions produced from a meter provider. The value must match
+    /// a `TelemetryMetric.Namespace` / `TelemetryDistribution.Namespace` raw value
+    /// (e.g. `"tracers"`, `"general"`). When absent or unrecognized, the exporter's
+    /// configured payload-level namespace is used instead.
+    static let namespace = "dd.telemetry.namespace"
+}
+
 // MARK: - Shared helpers
 
 private enum MetricConversion {
+    // Per-metric namespace override read from the metric's Resource, if present.
+    static func metricNamespace(from resource: Resource) -> TelemetryMetric.Namespace? {
+        namespaceString(from: resource).flatMap(TelemetryMetric.Namespace.init(rawValue:))
+    }
+
+    static func distributionNamespace(from resource: Resource) -> TelemetryDistribution.Namespace? {
+        namespaceString(from: resource).flatMap(TelemetryDistribution.Namespace.init(rawValue:))
+    }
+
+    private static func namespaceString(from resource: Resource) -> String? {
+        resource.attributes[TelemetryMetricResourceKeys.namespace]?.description
+    }
+
     // Group an array of PointData by their sorted attribute string so that
     // points with the same label set land in the same series.
     static func groupByAttributes<P: PointData>(_ points: [P]) -> [([String: AttributeValue], [P])] {
@@ -107,15 +131,17 @@ private enum MetricConversion {
 private extension TelemetryMetric.Series {
     // Returns nil for histogram types — those go to TelemetryDistribution instead.
     static func from(_ metric: MetricData) -> [TelemetryMetric.Series]? {
+        let namespace = MetricConversion.metricNamespace(from: metric.resource)
         switch metric.type {
         case .LongGauge, .DoubleGauge:
-            return scalar(metric.data.points, name: metric.name, type: .gauge)
+            return scalar(metric.data.points, name: metric.name, type: .gauge, namespace: namespace)
         case .LongSum, .DoubleSum:
             return scalar(metric.data.points, name: metric.name,
-                         type: metric.isMonotonic ? .count : .gauge)
+                         type: metric.isMonotonic ? .count : .gauge, namespace: namespace)
         case .Summary:
             return countAndSum(metric.data.points as! [SummaryPointData],
                                name: metric.name,
+                               namespace: namespace,
                                countOf: { Double($0.count) },
                                sumOf: { $0.sum })
         case .Histogram, .ExponentialHistogram:
@@ -124,7 +150,8 @@ private extension TelemetryMetric.Series {
     }
 
     private static func scalar(_ points: [PointData], name: String,
-                               type: TelemetryMetric.MetricType) -> [TelemetryMetric.Series]
+                               type: TelemetryMetric.MetricType,
+                               namespace: TelemetryMetric.Namespace?) -> [TelemetryMetric.Series]
     {
         MetricConversion.groupByAttributes(points).map { attrs, pts in
             TelemetryMetric.Series(
@@ -132,7 +159,8 @@ private extension TelemetryMetric.Series {
                 points: pts.map { .init(timestamp: MetricConversion.epochSeconds($0),
                                         value: MetricConversion.scalarValue($0)) },
                 type: type,
-                tags: MetricConversion.tags(attrs)
+                tags: MetricConversion.tags(attrs),
+                namespace: namespace
             )
         }
     }
@@ -141,6 +169,7 @@ private extension TelemetryMetric.Series {
     private static func countAndSum<P: PointData>(
         _ points: [P],
         name: String,
+        namespace: TelemetryMetric.Namespace?,
         countOf: (P) -> Double,
         sumOf: (P) -> Double
     ) -> [TelemetryMetric.Series] {
@@ -151,13 +180,15 @@ private extension TelemetryMetric.Series {
                     metric: "\(name).count",
                     points: pts.map { .init(timestamp: MetricConversion.epochSeconds($0), value: countOf($0)) },
                     type: .count,
-                    tags: tags
+                    tags: tags,
+                    namespace: namespace
                 ),
                 TelemetryMetric.Series(
                     metric: "\(name).sum",
                     points: pts.map { .init(timestamp: MetricConversion.epochSeconds($0), value: sumOf($0)) },
                     type: .count,
-                    tags: tags
+                    tags: tags,
+                    namespace: namespace
                 ),
             ]
         }
@@ -169,11 +200,14 @@ private extension TelemetryMetric.Series {
 private extension TelemetryDistribution.Series {
     // Returns nil for non-histogram types.
     static func from(_ metric: MetricData) -> [TelemetryDistribution.Series]? {
+        let namespace = MetricConversion.distributionNamespace(from: metric.resource)
         switch metric.type {
         case .Histogram:
-            return fromHistogram(metric.data.points as! [HistogramPointData], name: metric.name)
+            return fromHistogram(metric.data.points as! [HistogramPointData],
+                                 name: metric.name, namespace: namespace)
         case .ExponentialHistogram:
-            return fromExponentialHistogram(metric.data.points as! [ExponentialHistogramPointData], name: metric.name)
+            return fromExponentialHistogram(metric.data.points as! [ExponentialHistogramPointData],
+                                            name: metric.name, namespace: namespace)
         default:
             return nil
         }
@@ -185,7 +219,8 @@ private extension TelemetryDistribution.Series {
     //   - interior buckets: midpoint of the two boundaries
     //   - overflow (last) bucket: max if available, else the upper boundary
     private static func fromHistogram(_ points: [HistogramPointData],
-                                      name: String) -> [TelemetryDistribution.Series]
+                                      name: String,
+                                      namespace: TelemetryDistribution.Namespace?) -> [TelemetryDistribution.Series]
     {
         MetricConversion.groupByAttributes(points).compactMap { attrs, pts -> TelemetryDistribution.Series? in
             let samples = pts.flatMap { reconstructSamples(from: $0) }
@@ -193,7 +228,8 @@ private extension TelemetryDistribution.Series {
             return TelemetryDistribution.Series(
                 metric: name,
                 points: samples,
-                tags: MetricConversion.tags(attrs)
+                tags: MetricConversion.tags(attrs),
+                namespace: namespace
             )
         }
     }
@@ -229,7 +265,8 @@ private extension TelemetryDistribution.Series {
     // Base = 2^(2^-scale); each bucket i covers [base^(offset+i), base^(offset+i+1)).
     // Representative value: geometric midpoint = base^(offset+i+0.5).
     private static func fromExponentialHistogram(_ points: [ExponentialHistogramPointData],
-                                                 name: String) -> [TelemetryDistribution.Series]
+                                                 name: String,
+                                                 namespace: TelemetryDistribution.Namespace?) -> [TelemetryDistribution.Series]
     {
         MetricConversion.groupByAttributes(points).compactMap { attrs, pts -> TelemetryDistribution.Series? in
             let samples = pts.flatMap { reconstructSamples(from: $0) }
@@ -237,7 +274,8 @@ private extension TelemetryDistribution.Series {
             return TelemetryDistribution.Series(
                 metric: name,
                 points: samples,
-                tags: MetricConversion.tags(attrs)
+                tags: MetricConversion.tags(attrs),
+                namespace: namespace
             )
         }
     }

--- a/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
@@ -1,0 +1,144 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+internal final class TelemetryMetricExporter: MetricExporter {
+    let telemetryExporter: TelemetryExporter
+    let namespace: TelemetryMetric.Namespace?
+
+    init(telemetryExporter: TelemetryExporter, namespace: TelemetryMetric.Namespace? = nil) {
+        self.telemetryExporter = telemetryExporter
+        self.namespace = namespace
+    }
+
+    func export(metrics: [MetricData]) -> ExportResult {
+        guard !metrics.isEmpty else { return .success }
+        let series = metrics.flatMap { TelemetryMetric.Series.from($0) }
+        guard !series.isEmpty else { return .success }
+        telemetryExporter.export(item: TelemetryMetric(namespace: namespace, series: series))
+        return .success
+    }
+
+    func flush() -> ExportResult {
+        telemetryExporter.flush() ? .success : .failure
+    }
+
+    func shutdown() -> ExportResult {
+        telemetryExporter.shutdown()
+        return .success
+    }
+
+    func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {
+        .cumulative
+    }
+}
+
+// MARK: - MetricData → TelemetryMetric.Series conversion
+
+private extension TelemetryMetric.Series {
+    static func from(_ metric: MetricData) -> [TelemetryMetric.Series] {
+        switch metric.type {
+        case .LongGauge, .DoubleGauge:
+            return scalar(metric.data.points, name: metric.name, type: .gauge)
+        case .LongSum, .DoubleSum:
+            return scalar(metric.data.points, name: metric.name,
+                         type: metric.isMonotonic ? .count : .gauge)
+        case .Histogram:
+            return countAndSum(metric.data.points as! [HistogramPointData],
+                               name: metric.name,
+                               countOf: { Double($0.count) },
+                               sumOf: { $0.sum })
+        case .ExponentialHistogram:
+            return countAndSum(metric.data.points as! [ExponentialHistogramPointData],
+                               name: metric.name,
+                               countOf: { Double($0.count) },
+                               sumOf: { $0.sum })
+        case .Summary:
+            return countAndSum(metric.data.points as! [SummaryPointData],
+                               name: metric.name,
+                               countOf: { Double($0.count) },
+                               sumOf: { $0.sum })
+        }
+    }
+
+    // One series per distinct attribute set, each carrying all matching points.
+    private static func scalar(_ points: [PointData], name: String,
+                               type: TelemetryMetric.MetricType) -> [TelemetryMetric.Series]
+    {
+        groupByAttributes(points).map { attrs, pts in
+            TelemetryMetric.Series(
+                metric: name,
+                points: pts.map { .init(timestamp: epochSeconds($0), value: scalarValue($0)) },
+                type: type,
+                tags: tags(attrs)
+            )
+        }
+    }
+
+    // Histogram-like types emit a `{name}.count` and `{name}.sum` series per attribute set.
+    private static func countAndSum<P: PointData>(
+        _ points: [P],
+        name: String,
+        countOf: (P) -> Double,
+        sumOf: (P) -> Double
+    ) -> [TelemetryMetric.Series] {
+        groupByAttributes(points).flatMap { attrs, pts -> [TelemetryMetric.Series] in
+            let tags = tags(attrs)
+            return [
+                TelemetryMetric.Series(
+                    metric: "\(name).count",
+                    points: pts.map { .init(timestamp: epochSeconds($0), value: countOf($0)) },
+                    type: .count,
+                    tags: tags
+                ),
+                TelemetryMetric.Series(
+                    metric: "\(name).sum",
+                    points: pts.map { .init(timestamp: epochSeconds($0), value: sumOf($0)) },
+                    type: .count,
+                    tags: tags
+                ),
+            ]
+        }
+    }
+
+    // Group an array of PointData by their sorted attribute string so that
+    // points with the same label set land in the same series.
+    private static func groupByAttributes<P: PointData>(_ points: [P]) -> [([String: AttributeValue], [P])] {
+        var order: [String] = []
+        var groups: [String: ([String: AttributeValue], [P])] = [:]
+        for point in points {
+            let key = tagString(point.attributes)
+            if groups[key] == nil {
+                order.append(key)
+                groups[key] = (point.attributes, [])
+            }
+            groups[key]!.1.append(point)
+        }
+        return order.map { groups[$0]! }
+    }
+
+    private static func epochSeconds(_ point: PointData) -> TimeInterval {
+        TimeInterval(point.endEpochNanos) / 1_000_000_000
+    }
+
+    private static func scalarValue(_ point: PointData) -> Double {
+        if let p = point as? LongPointData { return Double(p.value) }
+        if let p = point as? DoublePointData { return p.value }
+        return 0
+    }
+
+    private static func tags(_ attributes: [String: AttributeValue]) -> [String]? {
+        guard !attributes.isEmpty else { return nil }
+        return attributes.map { "\($0.key):\($0.value.description)" }.sorted()
+    }
+
+    private static func tagString(_ attributes: [String: AttributeValue]) -> String {
+        tags(attributes)?.joined(separator: ",") ?? ""
+    }
+}

--- a/Sources/EventsExporter/Upload/DataUploadWorker.swift
+++ b/Sources/EventsExporter/Upload/DataUploadWorker.swift
@@ -86,7 +86,7 @@ internal final class DataUploadWorker: DataUploadWorkerType {
     /// Drains all pending batches synchronously. Holds the upload queue for
     /// the duration so the periodic worker can't interleave reads with the flush.
     func flush() throws -> Bool {
-        var result = false
+        var result = true
         try queue.sync {
             var iterator = try fileReader.getRemainingBatches()
             while let batchRes = iterator.next() {

--- a/Tests/EventsExporter/Telemetry/TelemetryExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryExporterTests.swift
@@ -70,6 +70,39 @@ class TelemetryExporterTests: XCTestCase {
         XCTAssertEqual(payload[0]["request_type"] as? String, "generate-metrics")
     }
 
+    func testExportDistributions_uploadsWellFormedEnvelope() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let (exporter, storage) = try makeExporter(performancePreset: .readAllFiles, server: server)
+        defer { try? storage.delete() }
+
+        let series = TelemetryDistribution.Series(
+            metric: "test.dist",
+            points: [0, 1, 2, 3, 4, 5],
+            tags: ["env:test"]
+        )
+        exporter.export(item: TelemetryDistribution(namespace: .tracers, series: [series]))
+
+        guard server.waitForTelemetry(timeout: 30) else {
+            XCTFail("No telemetry batch received")
+            return
+        }
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        try assertValidEnvelope(raw, expectedEntryCount: 1)
+        let payload = try XCTUnwrap(
+            (JSONSerialization.jsonObject(with: raw) as? [String: Any])?["payload"] as? [[String: Any]]
+        )
+        XCTAssertEqual(payload[0]["request_type"] as? String, "distributions")
+        let distPayload = try XCTUnwrap(payload[0]["payload"] as? [String: Any])
+        XCTAssertEqual(distPayload["namespace"] as? String, "tracers")
+        let distSeries = try XCTUnwrap(distPayload["series"] as? [[String: Any]])
+        XCTAssertEqual(distSeries[0]["metric"] as? String, "test.dist")
+        XCTAssertEqual(distSeries[0]["points"] as? [Double], [0, 1, 2, 3, 4, 5])
+    }
+
     func testExportLogs_uploadsWellFormedEnvelope() throws {
         let server = MockBackend()
         try server.start()
@@ -107,9 +140,11 @@ class TelemetryExporterTests: XCTestCase {
         defer { try? storage.delete() }
 
         let series = TelemetryMetric.Series(metric: "m", points: [.init(timestamp: 1, value: 1)])
+        let dist = TelemetryDistribution.Series(metric: "d", points: [1, 2, 3])
         let log = TelemetryLog(message: "msg", level: .debug)
         exporter.export(items: [
             TelemetryMetric(namespace: .general, series: [series]),
+            TelemetryDistribution(namespace: .tracers, series: [dist]),
             TelemetryLog.Logs([log]),
             TelemetryAppHeartbeat(),
         ])
@@ -123,14 +158,13 @@ class TelemetryExporterTests: XCTestCase {
         XCTAssertEqual(server.requests.telemetry.count, 1, "All entries should be in one envelope")
 
         let raw = try XCTUnwrap(server.requests.telemetry.first)
-        try assertValidEnvelope(raw, expectedEntryCount: 3)
+        try assertValidEnvelope(raw, expectedEntryCount: 4)
 
         let payload = try XCTUnwrap(
             (JSONSerialization.jsonObject(with: raw) as? [String: Any])?["payload"] as? [[String: Any]]
         )
-        print("PAYLOAD", payload)
         let types = Set(payload.compactMap { $0["request_type"] as? String })
-        XCTAssertEqual(types, ["generate-metrics", "logs", "app-heartbeat"])
+        XCTAssertEqual(types, ["generate-metrics", "distributions", "logs", "app-heartbeat"])
     }
 
     // MARK: - Multiple entries across separate files
@@ -149,15 +183,17 @@ class TelemetryExporterTests: XCTestCase {
         defer { try? storage.delete() }
 
         let series = TelemetryMetric.Series(metric: "m", points: [.init(timestamp: 1, value: 1)])
+        let dist = TelemetryDistribution.Series(metric: "d", points: [1, 2, 3])
         let log = TelemetryLog(message: "msg", level: .debug)
         exporter.export(items: [
             TelemetryMetric(namespace: .general, series: [series]),
+            TelemetryDistribution(namespace: .tracers, series: [dist]),
             TelemetryLog.Logs([log]),
             TelemetryAppHeartbeat(),
         ])
 
-        guard server.waitForTelemetry(count: 3, timeout: 30) else {
-            XCTFail("Expected 3 telemetry batches, got \(server.requests.telemetry.count)")
+        guard server.waitForTelemetry(count: 4, timeout: 30) else {
+            XCTFail("Expected 4 telemetry batches, got \(server.requests.telemetry.count)")
             return
         }
 
@@ -171,6 +207,6 @@ class TelemetryExporterTests: XCTestCase {
             let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
             return payload.compactMap { $0["request_type"] as? String }
         }
-        XCTAssertEqual(Set(allTypes), ["generate-metrics", "logs", "app-heartbeat"])
+        XCTAssertEqual(Set(allTypes), ["generate-metrics", "distributions", "logs", "app-heartbeat"])
     }
 }

--- a/Tests/EventsExporter/Telemetry/TelemetryLogExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryLogExporterTests.swift
@@ -310,13 +310,12 @@ class TelemetryLogExporterTests: XCTestCase {
 
     // MARK: - forceFlush / shutdown
 
-    func testForceFlush_withPendingData_returnsSuccess() throws {
+    func testForceFlush_returnsSuccess() throws {
         let server = MockBackend()
         try server.start()
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
-        _ = exporter.export(logRecords: [record()], explicitTimeout: nil)
         XCTAssertEqual(exporter.forceFlush(explicitTimeout: nil), .success)
     }
 }

--- a/Tests/EventsExporter/Telemetry/TelemetryLogExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryLogExporterTests.swift
@@ -1,0 +1,322 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+@testable import EventsExporter
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+import TestUtils
+
+class TelemetryLogExporterTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeExporter(server: MockBackend) throws -> TelemetryLogExporter {
+        let endpoint: Endpoint = .other(testsBaseURL: server.baseURL, logsBaseURL: server.baseURL)
+        let config = ExporterConfiguration.mock(performancePreset: .readAllFiles)
+        let api = TelemetryApiService.mock(endpoint: endpoint)
+        let storage = try Directory.temporary().createSubdirectory(path: UUID().uuidString)
+        let telemetryExporter = try TelemetryExporter(config: config, storage: storage, api: api)
+        return TelemetryLogExporter(telemetryExporter: telemetryExporter)
+    }
+
+    private func record(
+        body: AttributeValue? = .string("test message"),
+        severity: Severity? = .info,
+        attributes: [String: AttributeValue] = [:],
+        timestamp: Date = Date(timeIntervalSince1970: 1_000),
+        observedTimestamp: Date? = nil,
+        eventName: String? = nil
+    ) -> ReadableLogRecord {
+        ReadableLogRecord(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(),
+            timestamp: timestamp,
+            observedTimestamp: observedTimestamp,
+            severity: severity,
+            body: body,
+            attributes: attributes,
+            eventName: eventName
+        )
+    }
+
+    private func receivedLog(from server: MockBackend) throws -> [String: Any] {
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+        let logsEntry = try XCTUnwrap(payload.first(where: { $0["request_type"] as? String == "logs" }))
+        let logsPayload = try XCTUnwrap(logsEntry["payload"] as? [String: Any])
+        let logs = try XCTUnwrap(logsPayload["logs"] as? [[String: Any]])
+        return try XCTUnwrap(logs.first)
+    }
+
+    // MARK: - Empty input
+
+    func testExport_emptyRecords_returnsSuccess() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        XCTAssertEqual(exporter.export(logRecords: [], explicitTimeout: nil), .success)
+        Thread.sleep(forTimeInterval: 0.5)
+        XCTAssertTrue(server.requests.telemetry.isEmpty)
+    }
+
+    // MARK: - Message extraction
+
+    func testExport_bodyPresent_usesBodyAsMessage() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        XCTAssertEqual(exporter.export(logRecords: [record(body: .string("from body"))], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertEqual(log["message"] as? String, "from body")
+    }
+
+    func testExport_noBody_usesMessageAttribute() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let r = record(body: nil, attributes: ["message": .string("from attribute")])
+        XCTAssertEqual(exporter.export(logRecords: [r], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertEqual(log["message"] as? String, "from attribute")
+    }
+
+    func testExport_noBodyOrAttribute_usesEventName() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let r = record(body: nil, attributes: [:], eventName: "my.event")
+        XCTAssertEqual(exporter.export(logRecords: [r], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertEqual(log["message"] as? String, "my.event")
+    }
+
+    func testExport_noBodyAttributeOrEventName_usesDefaultMessage() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let r = record(body: nil, attributes: [:], eventName: nil)
+        XCTAssertEqual(exporter.export(logRecords: [r], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertEqual(log["message"] as? String, "Log event")
+    }
+
+    // MARK: - Severity → Level mapping
+
+    func testExport_errorSeverity_mapsToErrorLevel() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        // Test one representative from each error/fatal group
+        let records = [Severity.error, .error4, .fatal, .fatal4].map { record(severity: $0) }
+        XCTAssertEqual(exporter.export(logRecords: records, explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+        let logsEntry = try XCTUnwrap(payload.first(where: { $0["request_type"] as? String == "logs" }))
+        let logs = try XCTUnwrap((logsEntry["payload"] as? [String: Any])?["logs"] as? [[String: Any]])
+        XCTAssertEqual(logs.count, 4)
+        XCTAssertTrue(logs.allSatisfy { $0["level"] as? String == "ERROR" })
+    }
+
+    func testExport_warnSeverity_mapsToWarnLevel() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let records = [Severity.warn, .warn2, .warn3, .warn4].map { record(severity: $0) }
+        XCTAssertEqual(exporter.export(logRecords: records, explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+        let logsEntry = try XCTUnwrap(payload.first(where: { $0["request_type"] as? String == "logs" }))
+        let logs = try XCTUnwrap((logsEntry["payload"] as? [String: Any])?["logs"] as? [[String: Any]])
+        XCTAssertEqual(logs.count, 4)
+        XCTAssertTrue(logs.allSatisfy { $0["level"] as? String == "WARN" })
+    }
+
+    func testExport_otherSeverities_mapToDebugLevel() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let records = ([Severity.trace, .debug, .info] + [nil]).map { record(severity: $0) }
+        XCTAssertEqual(exporter.export(logRecords: records, explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+        let logsEntry = try XCTUnwrap(payload.first(where: { $0["request_type"] as? String == "logs" }))
+        let logs = try XCTUnwrap((logsEntry["payload"] as? [String: Any])?["logs"] as? [[String: Any]])
+        XCTAssertEqual(logs.count, 4)
+        XCTAssertTrue(logs.allSatisfy { $0["level"] as? String == "DEBUG" })
+    }
+
+    // MARK: - Stack trace
+
+    func testExport_withStackTrace_extractsStackTraceAttribute() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let r = record(attributes: ["exception.stacktrace": .string("frame1\nframe2")])
+        XCTAssertEqual(exporter.export(logRecords: [r], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertEqual(log["stack_trace"] as? String, "frame1\nframe2")
+        // exception.stacktrace must NOT appear in tags
+        let tags = log["tags"] as? String
+        XCTAssertNil(tags?.contains("exception.stacktrace"))
+    }
+
+    // MARK: - Tags from attributes
+
+    func testExport_withAttributes_producesTagString() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let r = record(attributes: ["env": .string("prod"), "version": .string("1.0")])
+        XCTAssertEqual(exporter.export(logRecords: [r], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        let tags = try XCTUnwrap(log["tags"] as? String)
+        // Tags are sorted alphabetically
+        XCTAssertEqual(tags, "env:prod,version:1.0")
+    }
+
+    func testExport_withNoAttributes_tagsIsNil() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        XCTAssertEqual(exporter.export(logRecords: [record(attributes: [:])], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertNil(log["tags"])
+    }
+
+    func testExport_messageAttributeConsumed_doesNotAppearInTags() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let r = record(body: nil, attributes: ["message": .string("the msg"), "env": .string("test")])
+        XCTAssertEqual(exporter.export(logRecords: [r], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertEqual(log["message"] as? String, "the msg")
+        // "message" key must be consumed, only "env" remains in tags
+        XCTAssertEqual(log["tags"] as? String, "env:test")
+    }
+
+    // MARK: - Timestamp
+
+    func testExport_observedTimestampPreferredOverTimestamp() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let r = record(
+            timestamp: Date(timeIntervalSince1970: 1000),
+            observedTimestamp: Date(timeIntervalSince1970: 2000)
+        )
+        XCTAssertEqual(exporter.export(logRecords: [r], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertEqual(log["tracer_time"] as? Int, 2000)
+    }
+
+    func testExport_noObservedTimestamp_fallsBackToTimestamp() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let r = record(timestamp: Date(timeIntervalSince1970: 1234), observedTimestamp: nil)
+        XCTAssertEqual(exporter.export(logRecords: [r], explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let log = try receivedLog(from: server)
+        XCTAssertEqual(log["tracer_time"] as? Int, 1234)
+    }
+
+    // MARK: - Multiple records in one call
+
+    func testExport_multipleRecords_allForwarded() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let records = [
+            record(body: .string("one"), severity: .error),
+            record(body: .string("two"), severity: .warn),
+            record(body: .string("three"), severity: .info),
+        ]
+        XCTAssertEqual(exporter.export(logRecords: records, explicitTimeout: nil), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+        let logsEntry = try XCTUnwrap(payload.first(where: { $0["request_type"] as? String == "logs" }))
+        let logsPayload = try XCTUnwrap(logsEntry["payload"] as? [String: Any])
+        let logs = try XCTUnwrap(logsPayload["logs"] as? [[String: Any]])
+        XCTAssertEqual(logs.count, 3)
+        XCTAssertEqual(Set(logs.compactMap { $0["message"] as? String }), ["one", "two", "three"])
+    }
+
+    // MARK: - forceFlush / shutdown
+
+    func testForceFlush_withPendingData_returnsSuccess() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        _ = exporter.export(logRecords: [record()], explicitTimeout: nil)
+        XCTAssertEqual(exporter.forceFlush(explicitTimeout: nil), .success)
+    }
+}

--- a/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
@@ -422,6 +422,109 @@ class TelemetryMetricExporterTests: XCTestCase {
         XCTAssertEqual(names, ["gauge.one", "counter.two"])
     }
 
+    // MARK: - Namespace from Resource
+
+    func testExport_resourceNamespace_setsPerSeriesNamespace() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let resource = Resource(attributes: [TelemetryMetricResourceKeys.namespace: .string("general")])
+        let metric = MetricData.createLongGauge(
+            resource: resource,
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "m",
+            description: "",
+            unit: "",
+            data: GaugeData(aggregationTemporality: .cumulative,
+                            points: [longPoint(value: 1, endNanos: 1_000_000_000)])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series[0]["namespace"] as? String, "general")
+    }
+
+    func testExport_resourceNamespace_setsDistributionSeriesNamespace() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let resource = Resource(attributes: [TelemetryMetricResourceKeys.namespace: .string("appsec")])
+        let point = histogramPoint(count: 2, sum: 4, endNanos: 1_000_000_000)
+        let metric = MetricData.createHistogram(
+            resource: resource,
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "h",
+            description: "",
+            unit: "",
+            data: HistogramData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedDistSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series[0]["namespace"] as? String, "appsec")
+    }
+
+    func testExport_unrecognizedResourceNamespace_omitsSeriesNamespace() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let resource = Resource(attributes: [TelemetryMetricResourceKeys.namespace: .string("not-a-namespace")])
+        let metric = MetricData.createLongGauge(
+            resource: resource,
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "m",
+            description: "",
+            unit: "",
+            data: GaugeData(aggregationTemporality: .cumulative,
+                            points: [longPoint(value: 1, endNanos: 1_000_000_000)])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertNil(series[0]["namespace"], "Unrecognized namespace should fall back (no per-series override)")
+    }
+
+    func testExport_distributionRejectsMetricOnlyNamespace() throws {
+        // "general" is valid for generate-metrics but not for distributions.
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let resource = Resource(attributes: [TelemetryMetricResourceKeys.namespace: .string("general")])
+        let point = histogramPoint(count: 1, sum: 1, endNanos: 1_000_000_000)
+        let metric = MetricData.createHistogram(
+            resource: resource,
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "h",
+            description: "",
+            unit: "",
+            data: HistogramData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedDistSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertNil(series[0]["namespace"], "Namespace not valid for distributions should be omitted")
+    }
+
     // MARK: - Aggregation temporality
 
     func testGetAggregationTemporality_deltaForCountersAndHistograms() throws {

--- a/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
@@ -1,0 +1,328 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+@testable import EventsExporter
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+import TestUtils
+
+class TelemetryMetricExporterTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeExporter(server: MockBackend) throws -> TelemetryMetricExporter {
+        let endpoint: Endpoint = .other(testsBaseURL: server.baseURL, logsBaseURL: server.baseURL)
+        let config = ExporterConfiguration.mock(performancePreset: .readAllFiles)
+        let api = TelemetryApiService.mock(endpoint: endpoint)
+        let storage = try Directory.temporary().createSubdirectory(path: UUID().uuidString)
+        let telemetryExporter = try TelemetryExporter(config: config, storage: storage, api: api)
+        return TelemetryMetricExporter(telemetryExporter: telemetryExporter)
+    }
+
+    private func receivedSeries(from server: MockBackend) throws -> [[String: Any]] {
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+        let metricsEntry = try XCTUnwrap(payload.first(where: { $0["request_type"] as? String == "generate-metrics" }))
+        let metricsPayload = try XCTUnwrap(metricsEntry["payload"] as? [String: Any])
+        return try XCTUnwrap(metricsPayload["series"] as? [[String: Any]])
+    }
+
+    private func longPoint(value: Int, endNanos: UInt64,
+                           attributes: [String: AttributeValue] = [:]) -> LongPointData
+    {
+        LongPointData(startEpochNanos: 0, endEpochNanos: endNanos,
+                      attributes: attributes, exemplars: [], value: value)
+    }
+
+    private func doublePoint(value: Double, endNanos: UInt64,
+                             attributes: [String: AttributeValue] = [:]) -> DoublePointData
+    {
+        DoublePointData(startEpochNanos: 0, endEpochNanos: endNanos,
+                        attributes: attributes, exemplars: [], value: value)
+    }
+
+    private func histogramPoint(count: UInt64, sum: Double, endNanos: UInt64,
+                                attributes: [String: AttributeValue] = [:]) -> HistogramPointData
+    {
+        HistogramPointData(startEpochNanos: 0, endEpochNanos: endNanos,
+                           attributes: attributes, exemplars: [],
+                           sum: sum, count: count, min: 0, max: sum,
+                           boundaries: [], counts: [Int(count)], hasMin: false, hasMax: false)
+    }
+
+    // MARK: - Empty input
+
+    func testExport_emptyMetrics_returnsSuccess() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        XCTAssertEqual(exporter.export(metrics: []), .success)
+        // Allow any background flush and confirm nothing was sent.
+        Thread.sleep(forTimeInterval: 0.5)
+        XCTAssertTrue(server.requests.telemetry.isEmpty)
+    }
+
+    // MARK: - Gauge
+
+    func testExport_longGauge_producesGaugeSeries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let point = longPoint(value: 42, endNanos: 1_000_000_000)
+        let metric = MetricData.createLongGauge(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "cpu.usage",
+            description: "",
+            unit: "",
+            data: GaugeData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series[0]["metric"] as? String, "cpu.usage")
+        XCTAssertEqual(series[0]["type"] as? String, "gauge")
+        let points = series[0]["points"] as? [[Double]]
+        XCTAssertEqual(points?.first?.last, 42.0)
+    }
+
+    func testExport_doubleGauge_producesGaugeSeries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let point = doublePoint(value: 3.14, endNanos: 2_000_000_000)
+        let metric = MetricData.createDoubleGauge(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "temp",
+            description: "",
+            unit: "",
+            data: GaugeData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series[0]["metric"] as? String, "temp")
+        XCTAssertEqual(series[0]["type"] as? String, "gauge")
+        // Timestamp is endEpochNanos / 1e9 = 2.0 seconds
+        let rawPoints = try XCTUnwrap(series[0]["points"] as? [[Double]])
+        let firstPoint = try XCTUnwrap(rawPoints.first)
+        XCTAssertEqual(firstPoint[0], 2.0, accuracy: 0.001)
+        XCTAssertEqual(firstPoint[1], 3.14, accuracy: 0.001)
+    }
+
+    // MARK: - Sum (Counter)
+
+    func testExport_monotonicSum_producesCountSeries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let point = longPoint(value: 100, endNanos: 1_000_000_000)
+        let metric = MetricData.createLongSum(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "requests.total",
+            description: "",
+            unit: "",
+            isMonotonic: true,
+            data: SumData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series[0]["metric"] as? String, "requests.total")
+        XCTAssertEqual(series[0]["type"] as? String, "count")
+    }
+
+    func testExport_nonMonotonicSum_producesGaugeSeries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let point = doublePoint(value: -5.0, endNanos: 1_000_000_000)
+        let metric = MetricData.createDoubleSum(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "active.connections",
+            description: "",
+            unit: "",
+            isMonotonic: false,
+            data: SumData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series[0]["type"] as? String, "gauge")
+    }
+
+    // MARK: - Histogram
+
+    func testExport_histogram_producesCountAndSumSeries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let point = histogramPoint(count: 10, sum: 55.5, endNanos: 1_000_000_000)
+        let metric = MetricData.createHistogram(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "request.duration",
+            description: "",
+            unit: "ms",
+            data: HistogramData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 2)
+        let names = Set(series.compactMap { $0["metric"] as? String })
+        XCTAssertEqual(names, ["request.duration.count", "request.duration.sum"])
+
+        let countSeries = try XCTUnwrap(series.first(where: { $0["metric"] as? String == "request.duration.count" }))
+        XCTAssertEqual(countSeries["type"] as? String, "count")
+        let countRawPoints = try XCTUnwrap(countSeries["points"] as? [[Double]])
+        XCTAssertEqual(try XCTUnwrap(countRawPoints.first).last, 10.0)
+
+        let sumSeries = try XCTUnwrap(series.first(where: { $0["metric"] as? String == "request.duration.sum" }))
+        let sumRawPoints = try XCTUnwrap(sumSeries["points"] as? [[Double]])
+        XCTAssertEqual(try XCTUnwrap(sumRawPoints.first).last ?? 0, 55.5, accuracy: 0.001)
+    }
+
+    // MARK: - Attributes → Tags
+
+    func testExport_withAttributes_producesTagsInSeries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let attributes: [String: AttributeValue] = ["env": .string("prod"), "service": .string("api")]
+        let point = longPoint(value: 1, endNanos: 1_000_000_000, attributes: attributes)
+        let metric = MetricData.createLongGauge(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "m",
+            description: "",
+            unit: "",
+            data: GaugeData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        let tags = try XCTUnwrap(series[0]["tags"] as? [String])
+        XCTAssertTrue(tags.contains("env:prod"))
+        XCTAssertTrue(tags.contains("service:api"))
+    }
+
+    // MARK: - Multiple attribute sets → multiple series
+
+    func testExport_multipleAttributeSets_producesMultipleSeries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let point1 = longPoint(value: 1, endNanos: 1_000_000_000,
+                               attributes: ["env": .string("prod")])
+        let point2 = longPoint(value: 2, endNanos: 2_000_000_000,
+                               attributes: ["env": .string("staging")])
+        let metric = MetricData.createLongGauge(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "error.rate",
+            description: "",
+            unit: "",
+            data: GaugeData(aggregationTemporality: .cumulative, points: [point1, point2])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 2)
+        let allTags = series.compactMap { $0["tags"] as? [String] }
+        let tagStrings = allTags.flatMap { $0 }
+        XCTAssertTrue(tagStrings.contains("env:prod"))
+        XCTAssertTrue(tagStrings.contains("env:staging"))
+    }
+
+    // MARK: - Multiple metrics in one call
+
+    func testExport_multipleMetrics_allSeriesForwarded() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let gauge = MetricData.createLongGauge(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "gauge.one",
+            description: "", unit: "",
+            data: GaugeData(aggregationTemporality: .cumulative,
+                            points: [longPoint(value: 1, endNanos: 1_000_000_000)])
+        )
+        let counter = MetricData.createLongSum(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "counter.two",
+            description: "", unit: "",
+            isMonotonic: true,
+            data: SumData(aggregationTemporality: .cumulative,
+                          points: [longPoint(value: 2, endNanos: 1_000_000_000)])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [gauge, counter]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedSeries(from: server)
+        XCTAssertEqual(series.count, 2)
+        let names = Set(series.compactMap { $0["metric"] as? String })
+        XCTAssertEqual(names, ["gauge.one", "counter.two"])
+    }
+
+    // MARK: - Aggregation temporality
+
+    func testGetAggregationTemporality_returnsCumulative() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        for instrument in InstrumentType.allCases {
+            XCTAssertEqual(exporter.getAggregationTemporality(for: instrument), .cumulative)
+        }
+    }
+}

--- a/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
@@ -424,14 +424,18 @@ class TelemetryMetricExporterTests: XCTestCase {
 
     // MARK: - Aggregation temporality
 
-    func testGetAggregationTemporality_returnsCumulative() throws {
+    func testGetAggregationTemporality_deltaForCountersAndHistograms() throws {
         let server = MockBackend()
         try server.start()
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
-        for instrument in InstrumentType.allCases {
-            XCTAssertEqual(exporter.getAggregationTemporality(for: instrument), .cumulative)
+        // Up/down counters → DD gauge: keep cumulative (current running total).
+        XCTAssertEqual(exporter.getAggregationTemporality(for: .upDownCounter), .cumulative)
+        XCTAssertEqual(exporter.getAggregationTemporality(for: .observableUpDownCounter), .cumulative)
+        // Everything else → DD count / distributions: per-interval delta.
+        for instrument in [InstrumentType.counter, .observableCounter, .histogram, .gauge, .observableGauge] {
+            XCTAssertEqual(exporter.getAggregationTemporality(for: instrument), .delta)
         }
     }
 }

--- a/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
@@ -430,7 +430,8 @@ class TelemetryMetricExporterTests: XCTestCase {
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
-        let resource = Resource(attributes: [TelemetryMetricResourceKeys.namespace: .string("general")])
+        var resource = Resource(attributes: [:])
+        resource.telemetryNamespace = "general"
         let metric = MetricData.createLongGauge(
             resource: resource,
             instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
@@ -455,7 +456,8 @@ class TelemetryMetricExporterTests: XCTestCase {
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
-        let resource = Resource(attributes: [TelemetryMetricResourceKeys.namespace: .string("appsec")])
+        var resource = Resource(attributes: [:])
+        resource.telemetryNamespace = "appsec"
         let point = histogramPoint(count: 2, sum: 4, endNanos: 1_000_000_000)
         let metric = MetricData.createHistogram(
             resource: resource,
@@ -480,7 +482,8 @@ class TelemetryMetricExporterTests: XCTestCase {
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
-        let resource = Resource(attributes: [TelemetryMetricResourceKeys.namespace: .string("not-a-namespace")])
+        var resource = Resource(attributes: [:])
+        resource.telemetryNamespace = "not-a-namespace"
         let metric = MetricData.createLongGauge(
             resource: resource,
             instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
@@ -506,7 +509,8 @@ class TelemetryMetricExporterTests: XCTestCase {
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
-        let resource = Resource(attributes: [TelemetryMetricResourceKeys.namespace: .string("general")])
+        var resource = Resource(attributes: [:])
+        resource.telemetryNamespace = "general"
         let point = histogramPoint(count: 1, sum: 1, endNanos: 1_000_000_000)
         let metric = MetricData.createHistogram(
             resource: resource,

--- a/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
@@ -47,12 +47,27 @@ class TelemetryMetricExporterTests: XCTestCase {
     }
 
     private func histogramPoint(count: UInt64, sum: Double, endNanos: UInt64,
+                                boundaries: [Double] = [],
+                                counts: [Int]? = nil,
+                                min: Double = 0, max: Double = 0,
+                                hasMin: Bool = false, hasMax: Bool = false,
                                 attributes: [String: AttributeValue] = [:]) -> HistogramPointData
     {
-        HistogramPointData(startEpochNanos: 0, endEpochNanos: endNanos,
-                           attributes: attributes, exemplars: [],
-                           sum: sum, count: count, min: 0, max: sum,
-                           boundaries: [], counts: [Int(count)], hasMin: false, hasMax: false)
+        let bucketCounts = counts ?? [Int(count)]
+        return HistogramPointData(startEpochNanos: 0, endEpochNanos: endNanos,
+                                  attributes: attributes, exemplars: [],
+                                  sum: sum, count: count, min: min, max: max,
+                                  boundaries: boundaries, counts: bucketCounts,
+                                  hasMin: hasMin, hasMax: hasMax)
+    }
+
+    private func receivedDistSeries(from server: MockBackend) throws -> [[String: Any]] {
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+        let distEntry = try XCTUnwrap(payload.first(where: { $0["request_type"] as? String == "distributions" }))
+        let distPayload = try XCTUnwrap(distEntry["payload"] as? [String: Any])
+        return try XCTUnwrap(distPayload["series"] as? [[String: Any]])
     }
 
     // MARK: - Empty input
@@ -181,15 +196,17 @@ class TelemetryMetricExporterTests: XCTestCase {
         XCTAssertEqual(series[0]["type"] as? String, "gauge")
     }
 
-    // MARK: - Histogram
+    // MARK: - Histogram → distributions
 
-    func testExport_histogram_producesCountAndSumSeries() throws {
+    func testExport_histogram_noBoundaries_producesDistributionSeriesWithAvgRepeated() throws {
         let server = MockBackend()
         try server.start()
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
-        let point = histogramPoint(count: 10, sum: 55.5, endNanos: 1_000_000_000)
+        // No boundaries: 4 samples, sum=10 → avg=2.5 repeated 4 times
+        let point = histogramPoint(count: 4, sum: 10, endNanos: 1_000_000_000,
+                                   boundaries: [], counts: [4])
         let metric = MetricData.createHistogram(
             resource: Resource(),
             instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
@@ -202,19 +219,77 @@ class TelemetryMetricExporterTests: XCTestCase {
         XCTAssertEqual(exporter.export(metrics: [metric]), .success)
         guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
 
-        let series = try receivedSeries(from: server)
-        XCTAssertEqual(series.count, 2)
-        let names = Set(series.compactMap { $0["metric"] as? String })
-        XCTAssertEqual(names, ["request.duration.count", "request.duration.sum"])
+        let series = try receivedDistSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        XCTAssertEqual(series[0]["metric"] as? String, "request.duration")
+        let points = try XCTUnwrap(series[0]["points"] as? [Double])
+        XCTAssertEqual(points.count, 4)
+        XCTAssertEqual(points[0], 2.5, accuracy: 0.001)
+    }
 
-        let countSeries = try XCTUnwrap(series.first(where: { $0["metric"] as? String == "request.duration.count" }))
-        XCTAssertEqual(countSeries["type"] as? String, "count")
-        let countRawPoints = try XCTUnwrap(countSeries["points"] as? [[Double]])
-        XCTAssertEqual(try XCTUnwrap(countRawPoints.first).last, 10.0)
+    func testExport_histogram_withBoundaries_reconstructsSamplesFromMidpoints() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
 
-        let sumSeries = try XCTUnwrap(series.first(where: { $0["metric"] as? String == "request.duration.sum" }))
-        let sumRawPoints = try XCTUnwrap(sumSeries["points"] as? [[Double]])
-        XCTAssertEqual(try XCTUnwrap(sumRawPoints.first).last ?? 0, 55.5, accuracy: 0.001)
+        let exporter = try makeExporter(server: server)
+        // Boundaries [0, 10, 100], counts [1, 2, 3, 1]:
+        //   bucket 0 (underflow, hasMin=true, min=0): 1 sample → 0.0
+        //   bucket 1 [0,10): midpoint 5.0: 2 samples
+        //   bucket 2 [10,100): midpoint 55.0: 3 samples
+        //   bucket 3 (overflow, hasMax=true, max=120): 1 sample → 120.0
+        let point = histogramPoint(count: 7, sum: 0, endNanos: 1_000_000_000,
+                                   boundaries: [0, 10, 100], counts: [1, 2, 3, 1],
+                                   min: 0, max: 120, hasMin: true, hasMax: true)
+        let metric = MetricData.createHistogram(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "latency",
+            description: "",
+            unit: "ms",
+            data: HistogramData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedDistSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        let points = try XCTUnwrap(series[0]["points"] as? [Double])
+        XCTAssertEqual(points.count, 7)
+        XCTAssertEqual(points[0], 0.0, accuracy: 0.001)   // underflow → min
+        XCTAssertEqual(points[1], 5.0, accuracy: 0.001)   // bucket [0,10) midpoint
+        XCTAssertEqual(points[2], 5.0, accuracy: 0.001)
+        XCTAssertEqual(points[3], 55.0, accuracy: 0.001)  // bucket [10,100) midpoint
+        XCTAssertEqual(points[4], 55.0, accuracy: 0.001)
+        XCTAssertEqual(points[5], 55.0, accuracy: 0.001)
+        XCTAssertEqual(points[6], 120.0, accuracy: 0.001) // overflow → max
+    }
+
+    func testExport_histogram_doesNotProduceGenerateMetricsSeries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        let point = histogramPoint(count: 3, sum: 9, endNanos: 1_000_000_000)
+        let metric = MetricData.createHistogram(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "h",
+            description: "",
+            unit: "",
+            data: HistogramData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let raw = try XCTUnwrap(server.requests.telemetry.first)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+        let payload = try XCTUnwrap(json["payload"] as? [[String: Any]])
+        let hasMetrics = payload.contains(where: { $0["request_type"] as? String == "generate-metrics" })
+        XCTAssertFalse(hasMetrics, "Histogram must not produce generate-metrics entries")
     }
 
     // MARK: - Attributes → Tags

--- a/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
@@ -424,14 +424,26 @@ class TelemetryMetricExporterTests: XCTestCase {
 
     // MARK: - Namespace from Resource
 
-    func testExport_resourceNamespace_setsPerSeriesNamespace() throws {
+    func testResourceNamespaceAccessors_roundTrip() {
+        var resource = Resource(attributes: [:])
+        resource.telemetryMetricNamespace = .iast
+        resource.telemetryDistributionNamespace = .rum
+        XCTAssertEqual(resource.telemetryMetricNamespace, .iast)
+        XCTAssertEqual(resource.telemetryDistributionNamespace, .rum)
+
+        // A malformed raw value (e.g. from a deserialized resource) decodes to nil.
+        let bad = Resource(attributes: ["dd.telemetry.metric.namespace": .string("not-a-namespace")])
+        XCTAssertNil(bad.telemetryMetricNamespace)
+    }
+
+    func testExport_metricResourceNamespace_setsPerSeriesNamespace() throws {
         let server = MockBackend()
         try server.start()
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
         var resource = Resource(attributes: [:])
-        resource.telemetryNamespace = "general"
+        resource.telemetryMetricNamespace = .general
         let metric = MetricData.createLongGauge(
             resource: resource,
             instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
@@ -450,14 +462,14 @@ class TelemetryMetricExporterTests: XCTestCase {
         XCTAssertEqual(series[0]["namespace"] as? String, "general")
     }
 
-    func testExport_resourceNamespace_setsDistributionSeriesNamespace() throws {
+    func testExport_distributionResourceNamespace_setsDistributionSeriesNamespace() throws {
         let server = MockBackend()
         try server.start()
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
         var resource = Resource(attributes: [:])
-        resource.telemetryNamespace = "appsec"
+        resource.telemetryDistributionNamespace = .appsec
         let point = histogramPoint(count: 2, sum: 4, endNanos: 1_000_000_000)
         let metric = MetricData.createHistogram(
             resource: resource,
@@ -476,57 +488,48 @@ class TelemetryMetricExporterTests: XCTestCase {
         XCTAssertEqual(series[0]["namespace"] as? String, "appsec")
     }
 
-    func testExport_unrecognizedResourceNamespace_omitsSeriesNamespace() throws {
+    func testExport_metricAndDistributionNamespacesAreIndependent() throws {
+        // A single resource carries both keys; the scalar series picks up the
+        // metric namespace and the histogram series the distribution namespace.
         let server = MockBackend()
         try server.start()
         defer { server.stop() }
 
         let exporter = try makeExporter(server: server)
         var resource = Resource(attributes: [:])
-        resource.telemetryNamespace = "not-a-namespace"
-        let metric = MetricData.createLongGauge(
+        resource.telemetryMetricNamespace = .general
+        resource.telemetryDistributionNamespace = .profilers
+
+        let gauge = MetricData.createLongGauge(
             resource: resource,
             instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
-            name: "m",
-            description: "",
-            unit: "",
+            name: "g", description: "", unit: "",
             data: GaugeData(aggregationTemporality: .cumulative,
                             points: [longPoint(value: 1, endNanos: 1_000_000_000)])
         )
-
-        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
-        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
-
-        let series = try receivedSeries(from: server)
-        XCTAssertEqual(series.count, 1)
-        XCTAssertNil(series[0]["namespace"], "Unrecognized namespace should fall back (no per-series override)")
-    }
-
-    func testExport_distributionRejectsMetricOnlyNamespace() throws {
-        // "general" is valid for generate-metrics but not for distributions.
-        let server = MockBackend()
-        try server.start()
-        defer { server.stop() }
-
-        let exporter = try makeExporter(server: server)
-        var resource = Resource(attributes: [:])
-        resource.telemetryNamespace = "general"
-        let point = histogramPoint(count: 1, sum: 1, endNanos: 1_000_000_000)
-        let metric = MetricData.createHistogram(
+        let hist = MetricData.createHistogram(
             resource: resource,
             instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
-            name: "h",
-            description: "",
-            unit: "",
-            data: HistogramData(aggregationTemporality: .cumulative, points: [point])
+            name: "h", description: "", unit: "",
+            data: HistogramData(aggregationTemporality: .cumulative,
+                                points: [histogramPoint(count: 1, sum: 1, endNanos: 1_000_000_000)])
         )
 
-        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
-        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+        XCTAssertEqual(exporter.export(metrics: [gauge, hist]), .success)
+        guard server.waitForTelemetry(count: 2, timeout: 10) else { XCTFail("No telemetry received"); return }
 
-        let series = try receivedDistSeries(from: server)
-        XCTAssertEqual(series.count, 1)
-        XCTAssertNil(series[0]["namespace"], "Namespace not valid for distributions should be omitted")
+        // The two payloads may arrive in separate requests, so scan all of them.
+        let entries = try server.requests.telemetry.flatMap { raw -> [[String: Any]] in
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: raw) as? [String: Any])
+            return (json["payload"] as? [[String: Any]]) ?? []
+        }
+        func series(forRequestType type: String) throws -> [[String: Any]] {
+            let entry = try XCTUnwrap(entries.first { $0["request_type"] as? String == type })
+            return try XCTUnwrap((entry["payload"] as? [String: Any])?["series"] as? [[String: Any]])
+        }
+
+        XCTAssertEqual(try series(forRequestType: "generate-metrics")[0]["namespace"] as? String, "general")
+        XCTAssertEqual(try series(forRequestType: "distributions")[0]["namespace"] as? String, "profilers")
     }
 
     // MARK: - Aggregation temporality

--- a/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
+++ b/Tests/EventsExporter/Telemetry/TelemetryMetricExporterTests.swift
@@ -266,6 +266,40 @@ class TelemetryMetricExporterTests: XCTestCase {
         XCTAssertEqual(points[6], 120.0, accuracy: 0.001) // overflow → max
     }
 
+    func testExport_histogram_noMinMax_fallsBackToBoundaries() throws {
+        let server = MockBackend()
+        try server.start()
+        defer { server.stop() }
+
+        let exporter = try makeExporter(server: server)
+        // Boundaries [10, 100], counts [1, 1, 1], no min/max available:
+        //   bucket 0 (underflow, no min): falls back to first boundary → 10.0
+        //   bucket 1 [10,100): midpoint 55.0
+        //   bucket 2 (overflow, no max): falls back to last boundary → 100.0
+        let point = histogramPoint(count: 3, sum: 0, endNanos: 1_000_000_000,
+                                   boundaries: [10, 100], counts: [1, 1, 1],
+                                   hasMin: false, hasMax: false)
+        let metric = MetricData.createHistogram(
+            resource: Resource(),
+            instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+            name: "latency",
+            description: "",
+            unit: "ms",
+            data: HistogramData(aggregationTemporality: .cumulative, points: [point])
+        )
+
+        XCTAssertEqual(exporter.export(metrics: [metric]), .success)
+        guard server.waitForTelemetry(timeout: 10) else { XCTFail("No telemetry received"); return }
+
+        let series = try receivedDistSeries(from: server)
+        XCTAssertEqual(series.count, 1)
+        let points = try XCTUnwrap(series[0]["points"] as? [Double])
+        XCTAssertEqual(points.count, 3)
+        XCTAssertEqual(points[0], 10.0, accuracy: 0.001)  // underflow → first boundary
+        XCTAssertEqual(points[1], 55.0, accuracy: 0.001)  // [10,100) midpoint
+        XCTAssertEqual(points[2], 100.0, accuracy: 0.001) // overflow → last boundary
+    }
+
     func testExport_histogram_doesNotProduceGenerateMetricsSeries() throws {
         let server = MockBackend()
         try server.start()


### PR DESCRIPTION
## What & why

Implements [SDTEST-3774](https://datadoghq.atlassian.net/browse/SDTEST-3774): a `MetricExporter` bridge that converts OTel metrics into our telemetry format and forwards them to `TelemetryExporter` for batching/upload — mirroring `TelemetryLogExporter`.

## Changes

- **`TelemetryMetricExporter`** — implements OTel's `MetricExporter`. Converts `[MetricData]` and forwards to `TelemetryExporter`.
  - Gauge → `gauge`; monotonic Sum → `count`; non-monotonic Sum → `gauge`; Summary → `{name}.count` + `{name}.sum`.
  - **Histograms → `distributions`**: explicit-boundary histograms reconstruct approximate samples from bucket midpoints (edge buckets use min/max, falling back to the boundary edge); exponential histograms use the geometric bucket midpoint.
  - **Temporality** mirrors OTel's `deltaPreferred()`: counters/histograms request `.delta` (DD `count`/`distributions` are per-interval); up/down counters stay `.cumulative` (mapped to gauge).
  - Attribute sets are grouped per series; attributes become sorted tags.
- **`TelemetryDistribution`** — new payload type for the `distributions` request type (raw sample points, its own namespace set), wired into `TelemetryRequestType`, `TelemetryMessageBatch`, and `TelemetryApi.sendDistributions`.
- **Per-metric namespace via `Resource`** — typed accessors `Resource.telemetryMetricNamespace` / `telemetryDistributionNamespace` (separate keys, enum-typed get/set) set the per-series namespace override.
- **Fix** — `DataUploadWorker.flush()` returned `false` on an empty queue; an empty flush is a success.

## Tests

- `TelemetryMetricExporterTests` — gauge/sum/summary/histogram/exponential conversions, sample reconstruction, namespace-from-resource, temporality.
- `TelemetryLogExporterTests` — message extraction, severity mapping, stack trace, tags, timestamps, flush.
- `TelemetryExporterTests` — extended for the `distributions` round-trip and mixed-type batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDTEST-3774]: https://datadoghq.atlassian.net/browse/SDTEST-3774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ