### PR TITLE
Trim span/metadata/log attribute values to backend 5000-char limit

### DIFF
--- a/Sources/DatadogSDKTesting/Models.swift
+++ b/Sources/DatadogSDKTesting/Models.swift
@@ -233,7 +233,7 @@ struct TestError: Error, CustomDebugStringConvertible {
             self.crashLog = nil
             return
         }
-        if stack.count < 5000 {
+        if stack.count < AttributesSanitizer.Constraints.maxAttributeValueLength {
             self.message = message
             self.stack = stack
             self.crashLog = nil
@@ -241,7 +241,7 @@ struct TestError: Error, CustomDebugStringConvertible {
             self.message = message.map { $0 + ". " } ?? ""
                 + "Check error.crash_log for the full crash log."
             self.stack = DDSymbolicator.calculateCrashedThread(stack: stack)
-            self.crashLog = stack.split(by: 5000)
+            self.crashLog = stack.split(by: AttributesSanitizer.Constraints.maxAttributeValueLength)
         }
     }
     

--- a/Sources/EventsExporter/Logs/LogSanitizer.swift
+++ b/Sources/EventsExporter/Logs/LogSanitizer.swift
@@ -22,6 +22,9 @@ internal struct LogSanitizer {
         /// Maximum number of attributes in log.
         /// If this number is exceeded, extra attributes will be ignored.
         static let maxNumberOfAttributes: Int = 256
+        /// Maximum number of characters the backend accepts per attribute value.
+        /// String values exceeding this length will be truncated.
+        static let maxAttributeValueLength: Int = AttributesSanitizer.Constraints.maxAttributeValueLength
         /// Allowed first character of a tag name (given as ASCII values ranging from lowercased `a` to `z`) .
         /// Tags with name starting with different character will be dropped.
         static let allowedTagNameFirstCharacterASCIIRange: [UInt8] = Array(97 ... 122)
@@ -62,6 +65,7 @@ internal struct LogSanitizer {
         userAttributes = removeInvalidAttributes(userAttributes)
         userAttributes = removeReservedAttributes(userAttributes)
         userAttributes = sanitizeAttributeNames(userAttributes)
+        userAttributes = limitAttributeValueLength(userAttributes)
         let userAttributesLimit = Constraints.maxNumberOfAttributes - (rawAttributes.internalAttributes?.count ?? 0)
         userAttributes = limitToMaxNumberOfAttributes(userAttributes, limit: userAttributesLimit)
 
@@ -117,6 +121,17 @@ internal struct LogSanitizer {
             }
         }
         return sanitized
+    }
+
+    private func limitAttributeValueLength(_ attributes: [String: Encodable]) -> [String: Encodable] {
+        // Only string values can realistically exceed the limit; other types are left untouched.
+        return attributes.mapValues { value in
+            guard let string = value as? String, string.count > Constraints.maxAttributeValueLength else {
+                return value
+            }
+            Log.print("Attribute value exceeds the limit of \(Constraints.maxAttributeValueLength) characters. It will be truncated.")
+            return String(string.prefix(Constraints.maxAttributeValueLength))
+        }
     }
 
     private func limitToMaxNumberOfAttributes(_ attributes: [String: Encodable], limit: Int) -> [String: Encodable] {

--- a/Sources/EventsExporter/Spans/SpanMetadata.swift
+++ b/Sources/EventsExporter/Spans/SpanMetadata.swift
@@ -48,6 +48,24 @@ public struct SpanMetadata {
             return mapped.count > 0 ? mapped : nil
         }
     }
+
+    /// Returns a copy with every metadata key and string value truncated to
+    /// `maxLength` characters, to satisfy the backend per-tag length limit.
+    func trimmed(toMaxLength maxLength: Int) -> SpanMetadata {
+        var result = SpanMetadata()
+        for (type, values) in meta {
+            let spanType = SpanType(type)
+            for (key, value) in values {
+                let trimmedKey = key.count > maxLength ? String(key.prefix(maxLength)) : key
+                if case .string(let string) = value, string.count > maxLength {
+                    result[spanType, trimmedKey] = .string(String(string.prefix(maxLength)))
+                } else {
+                    result[spanType, trimmedKey] = value
+                }
+            }
+        }
+        return result
+    }
 }
 
 public extension SpanMetadata {

--- a/Sources/EventsExporter/Spans/SpanSanitizer.swift
+++ b/Sources/EventsExporter/Spans/SpanSanitizer.swift
@@ -11,11 +11,16 @@ internal struct SpanSanitizer {
     private let attributesSanitizer = AttributesSanitizer(featureName: "Span")
 
     func sanitize(span: DDSpan) -> DDSpan {
-        // Sanitize attribute names
+        // Sanitize attribute names, then trim values to the backend per-tag length limit.
         let sanitizedTags = attributesSanitizer.sanitizeKeys(for: span.tags)
 
         var sanitizedSpan = span
-        sanitizedSpan.tags = sanitizedTags
+        sanitizedSpan.tags = attributesSanitizer.sanitizeValues(for: sanitizedTags)
         return sanitizedSpan
+    }
+
+    /// Trims span metadata keys and string values to the backend per-tag length limit.
+    func sanitize(metadata: SpanMetadata) -> SpanMetadata {
+        metadata.trimmed(toMaxLength: AttributesSanitizer.Constraints.maxAttributeValueLength)
     }
 }

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -22,7 +22,7 @@ internal final class SpansExporter: SpanExporter {
             dateProvider: SystemDateProvider()
         )
 
-        var metadata = config.metadata
+        var metadata = SpanSanitizer().sanitize(metadata: config.metadata)
         self.runtimeId = metadata[string: "runtime-id"] ?? UUID().uuidString.lowercased()
         metadata[string: "runtime-id"] = self.runtimeId
 
@@ -51,7 +51,7 @@ internal final class SpansExporter: SpanExporter {
     /// and rotate the writable file so the new header takes effect on the
     /// next batch. The runtime-id stays pinned across updates.
     func setMetadata(_ meta: SpanMetadata) {
-        var meta = meta
+        var meta = SpanSanitizer().sanitize(metadata: meta)
         meta[string: "runtime-id"] = self.runtimeId
         // `try!` is safe: `Header` is a fixed-shape struct that always encodes.
         let dataFormat = try! DataFormat(header: Header(metadata: meta.metadata),

--- a/Sources/EventsExporter/Spans/TestSpan.swift
+++ b/Sources/EventsExporter/Spans/TestSpan.swift
@@ -108,10 +108,11 @@ struct TestSpan: Encodable {
         self.resource = spanData.attributes.resource ?? spanData.name
         self.service = spanData.resource.service ?? ""
 
-        // Sanitize attribute keys (escape over-deep dot paths) before
-        // splitting into meta/metrics.
+        // Sanitize attribute keys (escape over-deep dot paths) and trim
+        // over-long string values before splitting into meta/metrics.
         let filtered = spanData.attributes.filter { !Self.filteredKeys.contains($0.key) }
-        let sanitized = AttributesSanitizer(featureName: "TestSpan").sanitizeKeys(for: filtered)
+        let sanitizer = AttributesSanitizer(featureName: "TestSpan")
+        let sanitized = sanitizer.sanitizeValues(for: sanitizer.sanitizeKeys(for: filtered))
         
         var meta = sanitized.meta
         var metrics = sanitized.metrics

--- a/Sources/EventsExporter/Utils/AttributesSanitizer.swift
+++ b/Sources/EventsExporter/Utils/AttributesSanitizer.swift
@@ -5,16 +5,20 @@
  */
 
 import Foundation
+import OpenTelemetryApi
 
 /// Common attributes sanitizer for all features.
-internal struct AttributesSanitizer {
-    enum Constraints {
+public struct AttributesSanitizer {
+    public enum Constraints {
         /// Maximum number of nested levels in attribute name. E.g. `person.address.street` has 3 levels.
         /// If attribute name exceeds this number, extra levels are escaped by using `_` character (`one.two.(...).nine.ten_eleven_twelve`).
         static let maxNestedLevelsInAttributeName: Int = 10
         /// Maximum number of attributes in log.
         /// If this number is exceeded, extra attributes will be ignored.
         static let maxNumberOfAttributes: Int = 256
+        /// Maximum number of characters the backend accepts per attribute value
+        /// (and per span tag / metadata key). Longer string values are truncated.
+        public static let maxAttributeValueLength: Int = 5_000
     }
 
     let featureName: String
@@ -56,5 +60,30 @@ internal struct AttributesSanitizer {
             }
         }
         return sanitized
+    }
+
+    // MARK: - Attribute values sanitization
+
+    /// Trims attribute values to `Constraints.maxAttributeValueLength` characters
+    /// to match the backend per-tag length limit.
+    func sanitizeValues(for attributes: [String: AttributeValue]) -> [String: AttributeValue] {
+        attributes.mapValues { Self.trim($0) }
+    }
+
+    /// Trims a single attribute value to `Constraints.maxAttributeValueLength` characters.
+    ///
+    /// Numeric values (`.int` / `.double`) are sent as numbers and left unchanged.
+    /// Every other value is serialized to its `description` (the same representation
+    /// the encoders emit), so it is converted to `.string` here and truncated, ensuring
+    /// the value that actually reaches the backend respects the length limit.
+    static func trim(_ value: AttributeValue) -> AttributeValue {
+        switch value {
+        case .int, .double:
+            return value
+        default:
+            let maxLength = Constraints.maxAttributeValueLength
+            let string = value.description
+            return .string(string.count > maxLength ? String(string.prefix(maxLength)) : string)
+        }
     }
 }

--- a/Tests/EventsExporter/Logs/LogSanitizerTests.swift
+++ b/Tests/EventsExporter/Logs/LogSanitizerTests.swift
@@ -103,6 +103,26 @@ class LogSanitizerTests: XCTestCase {
         XCTAssertEqual(sanitized.attributes.userAttributes.count, LogSanitizer.Constraints.maxNumberOfAttributes)
     }
 
+    func testWhenStringAttributeValueExceedsMaxLength_itIsTruncated() {
+        let longValue = String(repeating: "x", count: LogSanitizer.Constraints.maxAttributeValueLength + 100)
+        let shortValue = String(repeating: "y", count: 10)
+        let log = DDLog.mockWith(
+            attributes: .mockWith(
+                userAttributes: [
+                    "long": longValue,
+                    "short": shortValue,
+                    "number": 42,
+                ]
+            )
+        )
+
+        let sanitized = LogSanitizer().sanitize(log: log)
+
+        XCTAssertEqual((sanitized.attributes.userAttributes["long"] as? String)?.count, LogSanitizer.Constraints.maxAttributeValueLength)
+        XCTAssertEqual(sanitized.attributes.userAttributes["short"] as? String, shortValue)
+        XCTAssertEqual(sanitized.attributes.userAttributes["number"] as? Int, 42)
+    }
+
     func testInternalAttributesAreNotSanitized() {
         let log = DDLog.mockWith(
             attributes: .mockWith(

--- a/Tests/EventsExporter/Spans/SpanSanitizerTests.swift
+++ b/Tests/EventsExporter/Spans/SpanSanitizerTests.swift
@@ -46,4 +46,69 @@ class SpanSanitizerTests: XCTestCase {
         XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight.nine.ten_eleven"])
         XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight.nine.ten_eleven_twelve"])
     }
+
+    func testWhenTagValueExceedsMaxLength_itIsTruncated() {
+        let longValue = String(repeating: "x", count: AttributesSanitizer.Constraints.maxAttributeValueLength + 100)
+        let shortValue = String(repeating: "y", count: 10)
+
+        let spanData = SpanData(traceId: TraceId(), spanId: SpanId(), name: "spanName", kind: .client, startTime: Date(), attributes: [
+            "long-tag": AttributeValue(longValue)!,
+            "short-tag": AttributeValue(shortValue)!,
+        ], endTime: Date().addingTimeInterval(1.0))
+
+        let ddSpan = DDSpan(spanData: spanData)
+
+        // When
+        let sanitized = SpanSanitizer().sanitize(span: ddSpan)
+
+        // Then
+        XCTAssertEqual(sanitized.tags["long-tag"]?.description.count, AttributesSanitizer.Constraints.maxAttributeValueLength)
+        XCTAssertEqual(sanitized.tags["short-tag"]?.description, shortValue)
+    }
+
+    func testWhenNonStringTagValueExceedsMaxLength_itIsStringifiedAndTruncated() {
+        let maxLength = AttributesSanitizer.Constraints.maxAttributeValueLength
+        let longArray = Array(repeating: "item", count: maxLength)
+
+        let spanData = SpanData(traceId: TraceId(), spanId: SpanId(), name: "spanName", kind: .client, startTime: Date(), attributes: [
+            "array-tag": AttributeValue(longArray),
+            "bool-tag": AttributeValue(true),
+            "int-tag": AttributeValue(42),
+        ], endTime: Date().addingTimeInterval(1.0))
+
+        let ddSpan = DDSpan(spanData: spanData)
+
+        // When
+        let sanitized = SpanSanitizer().sanitize(span: ddSpan)
+
+        // Then
+        // The array is serialized to its `description` and truncated to the limit.
+        if case .string(let value)? = sanitized.tags["array-tag"] {
+            XCTAssertEqual(value.count, maxLength)
+        } else {
+            XCTFail("Expected array tag to be converted to a string")
+        }
+        // Booleans are stringified (short, so not truncated); numbers are left as-is.
+        XCTAssertEqual(sanitized.tags["bool-tag"], .string("true"))
+        XCTAssertEqual(sanitized.tags["int-tag"], .int(42))
+    }
+
+    func testWhenMetadataKeyOrValueExceedsMaxLength_itIsTruncated() {
+        let longKey = String(repeating: "k", count: AttributesSanitizer.Constraints.maxAttributeValueLength + 100)
+        let longValue = String(repeating: "v", count: AttributesSanitizer.Constraints.maxAttributeValueLength + 100)
+        let shortValue = String(repeating: "s", count: 10)
+
+        var metadata = SpanMetadata()
+        metadata[string: longKey] = longValue
+        metadata[string: "short-key"] = shortValue
+
+        // When
+        let sanitized = SpanSanitizer().sanitize(metadata: metadata).metadata[SpanMetadata.SpanType.generic.rawValue]
+
+        // Then
+        let trimmedKey = String(longKey.prefix(AttributesSanitizer.Constraints.maxAttributeValueLength))
+        XCTAssertNil(sanitized?[longKey])
+        XCTAssertEqual(sanitized?[trimmedKey]?.string?.count, AttributesSanitizer.Constraints.maxAttributeValueLength)
+        XCTAssertEqual(sanitized?["short-key"]?.string, shortValue)
+    }
 }


### PR DESCRIPTION
## What

Enforces the backend's **5000-character-per-tag** limit for spans and span metadata (and applies the same cap to log attribute values), so over-long values are truncated before upload instead of being rejected/mangled by the backend.

### Changes

- **Shared constant**: `AttributesSanitizer.Constraints.maxAttributeValueLength = 5000` lives in the common attributes sanitizer used by all features.
- **Span tags**: trimmed via `AttributesSanitizer.sanitizeValues(for:)`, reused by both `DDSpan` (`SpanSanitizer`) and `TestSpan`. Numeric values (`.int`/`.double`) pass through as metrics; every other value is serialized to its `description` (the exact representation the encoders emit) and truncated.
- **Span metadata**: `SpanMetadata.trimmed(toMaxLength:)` trims both keys and string values; applied when the file header is built/updated in `SpansExporter`.
- **Log attribute values**: `LogSanitizer` now truncates string attribute values, referencing the shared constant.
- **`TestError`**: crash-log split threshold now uses the shared constant instead of a hardcoded `5000`.

## Testing

- `SpanSanitizerTests`, `LogSanitizerTests`, `JSONEncoderTests` pass (19 tests).
- `EventsExporter` and `DatadogSDKTesting` build cleanly on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)