### PR TITLE
[SDTEST-3775] Add common telemetry manager with counter/histogram instances

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -13,14 +13,15 @@
 		3B086A157E782A8DCA702976 /* LogsApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = D969899DDA68AF3C690F7FF8 /* LogsApi.swift */; };
 		476CBA69A1DF07E74A0E7311 /* KnownTestsApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1531A96019132E3E9E96A3A7 /* KnownTestsApi.swift */; };
 		4B08F62941D9EB26E5DF3837 /* TestImpactAnalysisApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */; };
+		4CCD47B30A3B513F26C8936E /* TelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BF04956AA1E2FADBB80244 /* TelemetryTests.swift */; };
 		56B58A2FC91F21D1ABB0155E /* TelemetryApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EB970146040DD4967C7411 /* TelemetryApi.swift */; };
+		7972B04FB1DFA64DC20032AE /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E11F924F40C94461C2B6B27 /* Telemetry.swift */; };
 		821FA0CC8B62245A4949FDBB /* APITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85241CF97F1B6DAA49ECA23 /* APITypes.swift */; };
 		86137D23E1704D17A7B6D486 /* TelemetryExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */; };
-		A7926AF42FCDD411007834F2 /* TelemetryMetricExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */; };
-		A7926AF62FCDD411007834F2 /* TelemetryLogExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF52FCDD411007834F2 /* TelemetryLogExporterTests.swift */; };
 		8EF6F88255506A4CEE6D36B6 /* GitUploadApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */; };
 		97326DD4F8EF4EBDB05AC1AA /* TelemetryExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */; };
 		98D8D496CC4210A0D1D07F93 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12536CCE14EC1D3DAAC8DB81 /* Synced.swift */; };
+		A0EC035461740BCF6DFB8171 /* TelemetryMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843CE17ADB4681EE3DC4FF9B /* TelemetryMetrics.swift */; };
 		A70B91132DF0AE19003F284F /* AutoTestRetriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70B91122DF0AE11003F284F /* AutoTestRetriesTests.swift */; };
 		A718EC2D2CBD5DCE00C5F0D9 /* EarlyFlakeDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A718EC2C2CBD5DCE00C5F0D9 /* EarlyFlakeDetection.swift */; };
 		A718EC2F2CBD73F300C5F0D9 /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A718EC2E2CBD73F300C5F0D9 /* CacheManager.swift */; };
@@ -81,6 +82,8 @@
 		A77C123E2D9474E6009C2BA1 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C123D2D9474E6009C2BA1 /* Models.swift */; };
 		A7926AEF2FCDCBFE007834F2 /* TelemetryLogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AEE2FCDCBFE007834F2 /* TelemetryLogExporter.swift */; };
 		A7926AF12FCDD411007834F2 /* TelemetryMetricExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF02FCDD411007834F2 /* TelemetryMetricExporter.swift */; };
+		A7926AF42FCDD411007834F2 /* TelemetryMetricExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */; };
+		A7926AF62FCDD411007834F2 /* TelemetryLogExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7926AF52FCDD411007834F2 /* TelemetryLogExporterTests.swift */; };
 		A794A8FF2E7990D20044FE3C /* TestManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */; };
 		A79DA5B42F928F87004BCA8C /* SwiftTestingSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79DA5B32F928F87004BCA8C /* SwiftTestingSmokeTests.swift */; };
 		A79DA5B72F929812004BCA8C /* DatadogSDKTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7FC25642BA1E83500067E26 /* DatadogSDKTesting.framework */; };
@@ -279,6 +282,7 @@
 		CD1E9CDE6FE677BC07E66905 /* SpansApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1209EC18B790B00EFC90E52 /* SpansApi.swift */; };
 		DCCF75D22681A563B9E4CA1B /* TestManagementApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0083E7241E320B00198C0D71 /* TestManagementApi.swift */; };
 		E101EC71CC9E4715A40188FB /* AutoTestRetriesSwiftTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F8747157604DB48FE692EB /* AutoTestRetriesSwiftTestingTests.swift */; };
+		E42959C85F3B9BAB313984F7 /* TelemetryTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = E714A2777988AA4DA1AACB5C /* TelemetryTags.swift */; };
 		E5BF2275FF5E4C7D9EE74AD2 /* TestImpactAnalysisSwiftTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -422,12 +426,11 @@
 		0083E7241E320B00198C0D71 /* TestManagementApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestManagementApi.swift; sourceTree = "<group>"; };
 		01EB970146040DD4967C7411 /* TelemetryApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryApi.swift; sourceTree = "<group>"; };
 		04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelemetryExporterTests.swift; sourceTree = "<group>"; };
-		A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryMetricExporterTests.swift; sourceTree = "<group>"; };
-		A7926AF52FCDD411007834F2 /* TelemetryLogExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryLogExporterTests.swift; sourceTree = "<group>"; };
 		0A9081E25D194D74A4DA020E /* TestImpactAnalysisSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisSwiftTestingTests.swift; sourceTree = "<group>"; };
 		12536CCE14EC1D3DAAC8DB81 /* Synced.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Synced.swift; sourceTree = "<group>"; };
 		1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisApi.swift; sourceTree = "<group>"; };
 		1531A96019132E3E9E96A3A7 /* KnownTestsApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KnownTestsApi.swift; sourceTree = "<group>"; };
+		2E11F924F40C94461C2B6B27 /* Telemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		31F8747157604DB48FE692EB /* AutoTestRetriesSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTestRetriesSwiftTestingTests.swift; sourceTree = "<group>"; };
 		5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GitUploadApi.swift; sourceTree = "<group>"; };
 		6F3EB9ACD93007FC43F039EE /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
@@ -435,6 +438,7 @@
 		8194A2242940B33100B4B592 /* DDSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSession.swift; sourceTree = "<group>"; };
 		81AA244A2978589600DE8F8A /* DDFileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDFileReader.swift; sourceTree = "<group>"; };
 		81EDADB2292698A200279027 /* LLVMTotalsCoverageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLVMTotalsCoverageFormat.swift; sourceTree = "<group>"; };
+		843CE17ADB4681EE3DC4FF9B /* TelemetryMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryMetrics.swift; sourceTree = "<group>"; };
 		8EE92A3947C2E5BD2183BB4E /* MultipartFormURLRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MultipartFormURLRequest.swift; sourceTree = "<group>"; };
 		A70B91122DF0AE11003F284F /* AutoTestRetriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTestRetriesTests.swift; sourceTree = "<group>"; };
 		A718EC2C2CBD5DCE00C5F0D9 /* EarlyFlakeDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlyFlakeDetection.swift; sourceTree = "<group>"; };
@@ -494,6 +498,8 @@
 		A77C123D2D9474E6009C2BA1 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		A7926AEE2FCDCBFE007834F2 /* TelemetryLogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryLogExporter.swift; sourceTree = "<group>"; };
 		A7926AF02FCDD411007834F2 /* TelemetryMetricExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryMetricExporter.swift; sourceTree = "<group>"; };
+		A7926AF32FCDD411007834F2 /* TelemetryMetricExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryMetricExporterTests.swift; sourceTree = "<group>"; };
+		A7926AF52FCDD411007834F2 /* TelemetryLogExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryLogExporterTests.swift; sourceTree = "<group>"; };
 		A794A8FE2E7990C40044FE3C /* TestManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestManagementTests.swift; sourceTree = "<group>"; };
 		A79DA5B22F928F71004BCA8C /* IntegrationTests-UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "IntegrationTests-UnitTests.xctestplan"; sourceTree = "<group>"; };
 		A79DA5B32F928F87004BCA8C /* SwiftTestingSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftTestingSmokeTests.swift; sourceTree = "<group>"; };
@@ -578,6 +584,7 @@
 		B1209EC18B790B00EFC90E52 /* SpansApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpansApi.swift; sourceTree = "<group>"; };
 		BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelemetryExporter.swift; sourceTree = "<group>"; };
 		C1E3348865C204C942F4765C /* SettingsApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsApi.swift; sourceTree = "<group>"; };
+		C8BF04956AA1E2FADBB80244 /* TelemetryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryTests.swift; sourceTree = "<group>"; };
 		CC931D86ADB841B6969C7A7A /* EarlyFlakeDetectionSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlyFlakeDetectionSwiftTestingTests.swift; sourceTree = "<group>"; };
 		D969899DDA68AF3C690F7FF8 /* LogsApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogsApi.swift; sourceTree = "<group>"; };
 		E0B522400A21CABC6BB4F1CA /* TestOptimizationApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestOptimizationApi.swift; sourceTree = "<group>"; };
@@ -692,6 +699,7 @@
 		E1FB483E253891CE0083B263 /* DDCrashes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDCrashes.swift; sourceTree = "<group>"; };
 		E1FB483F253891CE0083B263 /* SimpleSpanData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleSpanData.swift; sourceTree = "<group>"; };
 		E1FB4844253891E70083B263 /* SimpleSpanSerializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleSpanSerializerTests.swift; sourceTree = "<group>"; };
+		E714A2777988AA4DA1AACB5C /* TelemetryTags.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryTags.swift; sourceTree = "<group>"; };
 		E85241CF97F1B6DAA49ECA23 /* APITypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APITypes.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -789,6 +797,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		39448FF1E2A0B109AB63E5C6 /* Telemetry */ = {
+			isa = PBXGroup;
+			children = (
+				2E11F924F40C94461C2B6B27 /* Telemetry.swift */,
+				843CE17ADB4681EE3DC4FF9B /* TelemetryMetrics.swift */,
+				E714A2777988AA4DA1AACB5C /* TelemetryTags.swift */,
+			);
+			path = Telemetry;
+			sourceTree = "<group>";
+		};
 		81EDADB62927957700279027 /* Coverage */ = {
 			isa = PBXGroup;
 			children = (
@@ -899,6 +917,7 @@
 				A77C123B2D9425C7009C2BA1 /* KnownTestsTests.swift */,
 				A7EE000000020000000000A1 /* LibraryConfigurationErrorTagsTests.swift */,
 				A7EE000000020000000000A3 /* AdditionalTagsFeatureTests.swift */,
+				C8BF04956AA1E2FADBB80244 /* TelemetryTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -1277,6 +1296,7 @@
 		E1798E0925260BC4008DEBB9 /* DatadogSDKTesting */ = {
 			isa = PBXGroup;
 			children = (
+				39448FF1E2A0B109AB63E5C6 /* Telemetry */,
 				A7675D472F631AF900A05B5F /* SwiftTesting */,
 				A7675D462F631AF000A05B5F /* XCTest */,
 				81EDADB62927957700279027 /* Coverage */,
@@ -1631,8 +1651,6 @@
 				A79DA5B62F929807004BCA8C /* PBXTargetDependency */,
 			);
 			name = "IntegrationTests-UnitTests";
-			packageProductDependencies = (
-			);
 			productName = "IntegrationTests-UnitTests";
 			productReference = A7F3FC412F928191002EFFAB /* IntegrationTests-UnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -2064,6 +2082,9 @@
 				A74246002BFF94FA00F7EC64 /* TestImpactAnalysisSkippabble.swift in Sources */,
 				A7DEAD022F3DEAD00000001A /* ParallelTestRunnerDetector.swift in Sources */,
 				A7A98C202C8F44BC00C93E59 /* CoverageSettings.swift in Sources */,
+				7972B04FB1DFA64DC20032AE /* Telemetry.swift in Sources */,
+				A0EC035461740BCF6DFB8171 /* TelemetryMetrics.swift in Sources */,
+				E42959C85F3B9BAB313984F7 /* TelemetryTags.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2110,6 +2131,7 @@
 				A794A8FF2E7990D20044FE3C /* TestManagementTests.swift in Sources */,
 				A7FC26632BA1F6BF00067E26 /* StderrCaptureTests.swift in Sources */,
 				A754BB0A2F86CD3B001613EB /* MockSwiftTesting.swift in Sources */,
+				4CCD47B30A3B513F26C8936E /* TelemetryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/DatadogSDKTesting/Config.swift
+++ b/Sources/DatadogSDKTesting/Config.swift
@@ -62,7 +62,12 @@ final class Config {
     /// Test Management
     var testManagementEnabled: Bool = true
     var testManagementAttemptToFixRetries: UInt? = nil
-    
+
+    /// Instrumentation telemetry (SDK self-metrics)
+    var instrumentationTelemetryEnabled: Bool = true
+    /// Telemetry metric collection/export interval, in seconds. Clamped to 1...3600.
+    var telemetryHeartbeatInterval: TimeInterval = 60
+
     /// Avoids configuring the traces exporter
     var disableTracesExporting: Bool = false
 
@@ -149,6 +154,12 @@ final class Config {
         /// Test Managemennt
         testManagementEnabled = env[.testManagementEnabled] ?? testManagementEnabled
         testManagementAttemptToFixRetries = env[.testManagementAttemptToFixRetries]
+
+        /// Instrumentation telemetry
+        instrumentationTelemetryEnabled = env[.instrumentationTelemetryEnabled] ?? instrumentationTelemetryEnabled
+        if let interval = env[.telemetryHeartbeatInterval, Int.self] {
+            telemetryHeartbeatInterval = TimeInterval(min(3600, max(1, interval)))
+        }
         
         /// UI testing properties
         tracerTraceId = env[.tracerTraceId]
@@ -240,6 +251,8 @@ extension Config: CustomDebugStringConvertible {
         Excluded Branches: \(excludedBranches)
         Test Management Enabled: \(testManagementEnabled)
         Test Management Attempt To Fix Retries: \(testManagementAttemptToFixRetries.map(String.init) ?? "nil")
+        Instrumentation Telemetry Enabled: \(instrumentationTelemetryEnabled)
+        Telemetry Heartbeat Interval: \(telemetryHeartbeatInterval)
         Test Retries Enabled: \(testRetriesEnabled)
         Test Retries Count: \(testRetriesTestRetryCount)
         Test Retries Total Count: \(testRetriesTotalRetryCount)

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -21,6 +21,10 @@ internal class DDTracer {
     let tracerSdk: TracerSdk
     let tracerProviderSdk: TracerProviderSdk
     let maxObjectSize: UInt64
+    /// OTel `Resource` describing this SDK (service / version / env / sdk.* tags).
+    /// Reused by the telemetry meter provider so self-metrics carry the same
+    /// identity as spans and logs.
+    let resource: Resource
     var eventsExporter: ExporterProtocol?
     /// Backend APIs owned by the SDK (not by the exporter). Held here so
     /// feature factories don't need to reach through `eventsExporter` to talk
@@ -54,6 +58,7 @@ internal class DDTracer {
         self.launchSpanContext = launchContext
         self.eventsExporter = exporter
         self.api = api
+        self.resource = resource
         self.maxObjectSize = exporter?.maxObjectSize ?? 262144
 
         let spanExporterToUse: SpanExporter

--- a/Sources/DatadogSDKTesting/Environment/EnvironmentKeys.swift
+++ b/Sources/DatadogSDKTesting/Environment/EnvironmentKeys.swift
@@ -52,6 +52,8 @@ internal enum EnvironmentKey: String, CaseIterable {
     case ciVisibilityFlakyRetryCount = "DD_CIVISIBILITY_FLAKY_RETRY_COUNT"
     case ciVisibilityTotalFlakyRetryCount = "DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT"
     case testManagementEnabled = "DD_TEST_MANAGEMENT_ENABLED"
+    case instrumentationTelemetryEnabled = "DD_INSTRUMENTATION_TELEMETRY_ENABLED"
+    case telemetryHeartbeatInterval = "DD_TELEMETRY_HEARTBEAT_INTERVAL"
     case testManagementAttemptToFixRetries = "DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES"
     case disableSourceLocation = "DD_DISABLE_SOURCE_LOCATION"
     case localTestEnvironmentPort = "DD_LOCAL_TEST_ENVIRONMENT_PORT"

--- a/Sources/DatadogSDKTesting/Environment/Span+Environment.swift
+++ b/Sources/DatadogSDKTesting/Environment/Span+Environment.swift
@@ -48,6 +48,13 @@ extension URL: SpanAttributeConvertible {
     }
 }
 
+/// Any string-backed enum is convertible to its tag value via its `rawValue`,
+/// so the typed tag enums below plug straight into `SpanAttributeConvertible`
+/// alongside `Bool` / `Int` / `String`.
+extension SpanAttributeConvertible where Self: RawRepresentable, RawValue == String {
+    var spanAttribute: String { rawValue }
+}
+
 extension SpanMetadata {
     init(libraryVersion: String, env: Environment, capabilities: SDKCapabilities) {
         self.init(libraryVersion: libraryVersion,

--- a/Sources/DatadogSDKTesting/Models.swift
+++ b/Sources/DatadogSDKTesting/Models.swift
@@ -332,6 +332,30 @@ struct SessionConfig: Sendable {
     let service: String
     let metrics: [String: Double]
     let log: Logger
+    /// Common telemetry manager shared with all features so they can record
+    /// SDK self-metrics. `nil` when instrumentation telemetry is disabled.
+    let telemetry: Telemetry?
+
+    init(activeFeatures: TestHooksFeatures,
+         platform: Environment.Platform,
+         clock: Clock,
+         crash: CrashInformation?,
+         command: String?,
+         service: String,
+         metrics: [String: Double],
+         log: Logger,
+         telemetry: Telemetry? = nil)
+    {
+        self.activeFeatures = activeFeatures
+        self.platform = platform
+        self.clock = clock
+        self.crash = crash
+        self.command = command
+        self.service = service
+        self.metrics = metrics
+        self.log = log
+        self.telemetry = telemetry
+    }
 }
 
 struct TestRunParameters: Encodable {

--- a/Sources/DatadogSDKTesting/SessionManager.swift
+++ b/Sources/DatadogSDKTesting/SessionManager.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 internal import EventsExporter
+internal import OpenTelemetrySdk
 
 final actor SessionManager: TestSessionManager {
     typealias SessionWithConfig = (session: any TestModuleManager & TestSession,
@@ -42,6 +43,7 @@ final actor SessionManager: TestSessionManager {
         session.session.end()
         await observer?.didFinish(session: session.session, with: session.config)
         DDTestMonitor.removeTestMonitor()
+        session.config.telemetry?.shutdown()
         DDTestMonitor.tracer.flush()
     }
     
@@ -70,7 +72,12 @@ final actor SessionManager: TestSessionManager {
         log.measure(name: "Setup crash handler") {
             monitor.setupCrashHandler()
         }
-        
+
+        // Common telemetry manager, shared with every feature through the
+        // session config. Gated by `DD_INSTRUMENTATION_TELEMETRY_ENABLED`
+        // (default true); `nil` when disabled or storage is unavailable.
+        let telemetry = DDTestMonitor.config.instrumentationTelemetryEnabled ? makeTelemetry() : nil
+
         let config = SessionConfig(
             activeFeatures: monitor.activeFeatures,
             platform: DDTestMonitor.env.platform,
@@ -79,7 +86,8 @@ final actor SessionManager: TestSessionManager {
             command: DDTestMonitor.env.testCommand,
             service: DDTestMonitor.env.service,
             metrics: DDTestMonitor.env.baseMetrics,
-            log: log
+            log: log,
+            telemetry: telemetry
         )
         
         let session = try await provider.startSession(named: "Swift.session", config: config,
@@ -93,6 +101,43 @@ extension SessionManager {
     enum BoostrapError: Error {
         case monitorInitFailed
         case monitorIsNil
+    }
+
+    /// Build the common telemetry manager wired to the SDK's telemetry intake,
+    /// reusing the tracer's API client, cache directory and resource. Returns
+    /// `nil` when the backing storage or exporter can't be created, in which
+    /// case telemetry is simply not gathered.
+    private func makeTelemetry() -> Telemetry? {
+        let tracer = DDTestMonitor.tracer
+
+        guard let cacheManager = DDTestMonitor.cacheManager,
+              let storage = try? cacheManager.session(feature: "telemetry")
+        else {
+            log.print("Telemetry init skipped: cache manager unavailable")
+            return nil
+        }
+
+        let configuration = ExporterConfiguration(
+            environment: DDTestMonitor.env.environment,
+            metadata: SpanMetadata(),
+            performancePreset: .instantDataDelivery,
+            logger: log
+        )
+
+        guard let telemetryExporter = try? TelemetryExporter(config: configuration,
+                                                             storage: storage,
+                                                             api: tracer.api.telemetry)
+        else {
+            log.print("Telemetry init skipped: telemetry exporter unavailable")
+            return nil
+        }
+
+        let metricExporter = TelemetryMetricExporter(telemetryExporter: telemetryExporter,
+                                                     namespace: .civisibility,
+                                                     distributionNamespace: .civisibility)
+        return Telemetry(exporter: metricExporter,
+                         resource: tracer.resource,
+                         exportInterval: DDTestMonitor.config.telemetryHeartbeatInterval)
     }
 }
 

--- a/Sources/DatadogSDKTesting/Telemetry/Telemetry.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/Telemetry.swift
@@ -1,0 +1,74 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+internal import EventsExporter
+internal import OpenTelemetryApi
+internal import OpenTelemetrySdk
+
+/// Common telemetry manager.
+///
+/// Owns a `MeterProvider` wired to the Datadog instrumentation-telemetry metric
+/// pipeline and exposes every CI Visibility metric through a typed, discoverable
+/// tree — e.g. `telemetry.metrics.git.command.add(command: .getRepository)`.
+/// Each metric's `add` / `record` names exactly the tags it accepts. All
+/// instruments are created up front in `init`.
+///
+/// `@unchecked Sendable`: the OTel metric storage backing each instrument is
+/// internally lock-protected, so the instruments are safe to share across the
+/// session/module/suite/test actors that hold this manager via `SessionConfig`.
+final class Telemetry: @unchecked Sendable {
+    /// Instrumentation scope (meter) name for the CI Visibility self-metrics.
+    static let instrumentationScopeName = "com.datadoghq.civisibility"
+
+    /// Typed tree of all CI Visibility telemetry metric instruments.
+    let metrics: Metrics
+
+    private let meterProvider: MeterProviderSdk
+
+    /// - Parameters:
+    ///   - exporter: where collected metric data is pushed on flush/interval.
+    ///   - resource: identity (service / version / env) for the produced metrics;
+    ///     the `civisibility` telemetry namespaces are stamped on a copy of it.
+    ///   - exportInterval: periodic collection interval. Collection also happens
+    ///     on `flush()` / `shutdown()`.
+    init(exporter: MetricExporter, resource: Resource, exportInterval: TimeInterval = 60) {
+        var resource = resource
+        resource.telemetryMetricNamespace = .civisibility
+        resource.telemetryDistributionNamespace = .civisibility
+
+        let reader = PeriodicMetricReaderBuilder(exporter: exporter)
+            .setInterval(timeInterval: exportInterval)
+            .build()
+
+        // A catch-all View must be registered for any storage to be created;
+        // without it the SDK records nothing (`findViews` only consults
+        // explicitly registered views, not the per-instrument defaults). The
+        // default aggregation per instrument type (sum for counters, explicit
+        // histogram for histograms) is what we want.
+        let provider = MeterProviderSdk.builder()
+            .registerView(selector: InstrumentSelectorBuilder().build(),
+                          view: View.builder().build())
+            .registerMetricReader(reader: reader)
+            .setResource(resource: resource)
+            .build()
+        self.meterProvider = provider
+
+        let meter = provider.get(name: Telemetry.instrumentationScopeName)
+        self.metrics = Metrics(Factory(meter: meter))
+    }
+
+    /// Collect and export the current metric values immediately.
+    @discardableResult
+    func flush() -> Bool {
+        meterProvider.forceFlush() == .success
+    }
+
+    /// Collect, export, and tear down the metric pipeline.
+    func shutdown() {
+        _ = meterProvider.shutdown()
+    }
+}

--- a/Sources/DatadogSDKTesting/Telemetry/TelemetryMetrics.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/TelemetryMetrics.swift
@@ -1,0 +1,669 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+internal import OpenTelemetryApi
+internal import OpenTelemetrySdk
+
+// MARK: - Low-level instrument handles
+
+extension Telemetry {
+    /// A set of metric tags. Values keep their Swift type (enum / `Bool` / `Int`
+    /// / `String`) until the boundary, where `SpanAttributeConvertible` renders
+    /// the wire value.
+    typealias Tags = [String: any SpanAttributeConvertible]
+
+    /// Thin handle over a telemetry counter instrument. Metric types wrap one of
+    /// these and expose a typed `add(...)`; callers don't use this directly.
+    struct Counter {
+        fileprivate let sdk: LongCounterSdk
+        fileprivate func add(_ value: Int, _ tags: Tags) {
+            sdk.add(value: value, attributes: tags.mapValues { .string($0.spanAttribute) })
+        }
+    }
+
+    /// Thin handle over a telemetry distribution (histogram) instrument.
+    struct Distribution {
+        fileprivate let sdk: DoubleHistogramMeterSdk
+        fileprivate func record(_ value: Double, _ tags: Tags) {
+            sdk.record(value: value, attributes: tags.mapValues { .string($0.spanAttribute) })
+        }
+    }
+
+    /// Builds named instruments from a meter; threaded through the metrics tree
+    /// so every metric registers itself once at construction.
+    struct Factory {
+        let meter: MeterSdk
+        func counter(_ name: String) -> Counter {
+            Counter(sdk: meter.counterBuilder(name: name).build())
+        }
+        func distribution(_ name: String) -> Distribution {
+            Distribution(sdk: meter.histogramBuilder(name: name).build())
+        }
+    }
+}
+
+// MARK: - Metrics tree
+
+extension Telemetry {
+    /// The full, discoverable tree of CI Visibility telemetry metrics. Reach a
+    /// metric through its group, e.g. `telemetry.metrics.git.command.add(...)`.
+    /// Each metric's `add` / `record` names exactly the tags it accepts.
+    ///
+    /// Metric names mirror the shared instrumentation-telemetry spec (the wire
+    /// name is `dd.instrumentation_telemetry_data.civisibility.<name>`) and are
+    /// cross-checked against `dd-trace-go`.
+    struct Metrics {
+        let events: Events
+        let session: Session
+        let codeCoverage: CodeCoverage
+        let endpointPayload: EndpointPayload
+        let git: Git
+        let gitRequests: GitRequests
+        let itr: ITR
+        let itrSkippableTests: ITRSkippableTests
+        let knownTests: KnownTests
+        let testManagementTests: TestManagementTests
+        let impactedTests: ImpactedTests
+
+        init(_ f: Factory) {
+            events = Events(f)
+            session = Session(f)
+            codeCoverage = CodeCoverage(f)
+            endpointPayload = EndpointPayload(f)
+            git = Git(f)
+            gitRequests = GitRequests(f)
+            itr = ITR(f)
+            itrSkippableTests = ITRSkippableTests(f)
+            knownTests = KnownTests(f)
+            testManagementTests = TestManagementTests(f)
+            impactedTests = ImpactedTests(f)
+        }
+    }
+}
+
+// MARK: - events / session
+
+extension Telemetry.Metrics {
+    struct Events {
+        let created: Created
+        let finished: Finished
+        let manualApiEvents: ManualApiEvents
+        let enqueuedForSerialization: EnqueuedForSerialization
+
+        init(_ f: Telemetry.Factory) {
+            created = Created(counter: f.counter("event_created"))
+            finished = Finished(counter: f.counter("event_finished"))
+            manualApiEvents = ManualApiEvents(counter: f.counter("manual_api_events"))
+            enqueuedForSerialization = EnqueuedForSerialization(counter: f.counter("events_enqueued_for_serialization"))
+        }
+
+        struct Created {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, testFramework: String, eventType: Telemetry.EventType,
+                     hasCodeowner: Bool? = nil, isUnsupportedCI: Bool? = nil, isBenchmark: Bool? = nil) {
+                // Assigning a nil optional to a dictionary subscript simply
+                // omits the key, so optional tags need no explicit unwrapping.
+                var tags: Telemetry.Tags = ["test_framework": testFramework, "event_type": eventType]
+                tags["has_codeowner"] = hasCodeowner
+                tags["is_unsupported_ci"] = isUnsupportedCI
+                tags["is_benchmark"] = isBenchmark
+                counter.add(count, tags)
+            }
+        }
+
+        struct Finished {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, testFramework: String, eventType: Telemetry.EventType,
+                     isHeadless: Bool? = nil, hasCodeowner: Bool? = nil, isUnsupportedCI: Bool? = nil,
+                     isBenchmark: Bool? = nil, earlyFlakeDetectionAbortReason: Telemetry.EFDAbortReason? = nil,
+                     isNew: Bool? = nil, isModified: Bool? = nil, isRetry: Bool? = nil,
+                     retryReason: Telemetry.RetryReason? = nil, isRum: Bool? = nil, browserDriver: String? = nil) {
+                var tags: Telemetry.Tags = ["test_framework": testFramework, "event_type": eventType]
+                tags["is_headless"] = isHeadless
+                tags["has_codeowner"] = hasCodeowner
+                tags["is_unsupported_ci"] = isUnsupportedCI
+                tags["is_benchmark"] = isBenchmark
+                tags["early_flake_detection_abort_reason"] = earlyFlakeDetectionAbortReason
+                tags["is_new"] = isNew
+                tags["is_modified"] = isModified
+                tags["is_retry"] = isRetry
+                tags["retry_reason"] = retryReason
+                tags["is_rum"] = isRum
+                tags["browser_driver"] = browserDriver
+                counter.add(count, tags)
+            }
+        }
+
+        struct ManualApiEvents {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, eventType: Telemetry.EventType) {
+                counter.add(count, ["event_type": eventType])
+            }
+        }
+
+        struct EnqueuedForSerialization {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+    }
+
+    /// `test_session` — one metric, exposed as its own group for discoverability.
+    struct Session {
+        let started: Started
+
+        init(_ f: Telemetry.Factory) {
+            started = Started(counter: f.counter("test_session"))
+        }
+
+        struct Started {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, provider: String? = nil, autoInjected: Bool? = nil,
+                     agentlessLogSubmissionEnabled: Bool? = nil, failFastTestOrderEnabled: Bool? = nil) {
+                var tags = Telemetry.Tags()
+                tags["provider"] = provider
+                tags["auto_injected"] = autoInjected
+                tags["agentless_log_submission_enabled"] = agentlessLogSubmissionEnabled
+                tags["fail_fast_test_order_enabled"] = failFastTestOrderEnabled
+                counter.add(count, tags)
+            }
+        }
+    }
+}
+
+// MARK: - code coverage
+
+extension Telemetry.Metrics {
+    struct CodeCoverage {
+        let started: Started
+        let finished: Finished
+        let isEmpty: IsEmpty
+        let errors: Errors
+        let files: Files
+
+        init(_ f: Telemetry.Factory) {
+            started = Started(counter: f.counter("code_coverage_started"))
+            finished = Finished(counter: f.counter("code_coverage_finished"))
+            isEmpty = IsEmpty(counter: f.counter("code_coverage.is_empty"))
+            errors = Errors(counter: f.counter("code_coverage.errors"))
+            files = Files(distribution: f.distribution("code_coverage.files"))
+        }
+
+        struct Started {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, library: String? = nil, testFramework: String? = nil) {
+                var tags = Telemetry.Tags()
+                tags["library"] = library
+                tags["test_framework"] = testFramework
+                counter.add(count, tags)
+            }
+        }
+
+        struct Finished {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, library: String? = nil, testFramework: String? = nil) {
+                var tags = Telemetry.Tags()
+                tags["library"] = library
+                tags["test_framework"] = testFramework
+                counter.add(count, tags)
+            }
+        }
+
+        struct IsEmpty {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        struct Errors {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        struct Files {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ files: Double) { distribution.record(files, [:]) }
+        }
+    }
+}
+
+// MARK: - endpoint payload
+
+extension Telemetry.Metrics {
+    struct EndpointPayload {
+        let requests: Requests
+        let requestsErrors: RequestsErrors
+        let requestsMs: RequestsMs
+        let eventsCount: EventsCount
+        let eventsSerializationMs: EventsSerializationMs
+        let bytes: Bytes
+        let dropped: Dropped
+
+        init(_ f: Telemetry.Factory) {
+            requests = Requests(counter: f.counter("endpoint_payload.requests"))
+            requestsErrors = RequestsErrors(counter: f.counter("endpoint_payload.requests_errors"))
+            requestsMs = RequestsMs(distribution: f.distribution("endpoint_payload.requests_ms"))
+            eventsCount = EventsCount(distribution: f.distribution("endpoint_payload.events_count"))
+            eventsSerializationMs = EventsSerializationMs(distribution: f.distribution("endpoint_payload.events_serialization_ms"))
+            bytes = Bytes(distribution: f.distribution("endpoint_payload.bytes"))
+            dropped = Dropped(counter: f.counter("endpoint_payload.dropped"))
+        }
+
+        struct Requests {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, endpoint: Telemetry.Endpoint) {
+                counter.add(count, ["endpoint": endpoint])
+            }
+        }
+
+        struct RequestsErrors {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, errorType: Telemetry.ErrorType, endpoint: Telemetry.Endpoint) {
+                counter.add(count, ["error_type": errorType, "endpoint": endpoint])
+            }
+        }
+
+        struct RequestsMs {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ milliseconds: Double, endpoint: Telemetry.Endpoint) {
+                distribution.record(milliseconds, ["endpoint": endpoint])
+            }
+        }
+
+        struct EventsCount {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ events: Double, endpoint: Telemetry.Endpoint) {
+                distribution.record(events, ["endpoint": endpoint])
+            }
+        }
+
+        struct EventsSerializationMs {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ milliseconds: Double, endpoint: Telemetry.Endpoint) {
+                distribution.record(milliseconds, ["endpoint": endpoint])
+            }
+        }
+
+        struct Bytes {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ bytes: Double, endpoint: Telemetry.Endpoint) {
+                distribution.record(bytes, ["endpoint": endpoint])
+            }
+        }
+
+        struct Dropped {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, endpoint: Telemetry.Endpoint) {
+                counter.add(count, ["endpoint": endpoint])
+            }
+        }
+    }
+}
+
+// MARK: - git
+
+extension Telemetry.Metrics {
+    struct Git {
+        let command: Command
+        let commandErrors: CommandErrors
+        let commandMs: CommandMs
+        let commitShaMatch: CommitShaMatch
+        let commitShaDiscrepancy: CommitShaDiscrepancy
+
+        init(_ f: Telemetry.Factory) {
+            command = Command(counter: f.counter("git.command"))
+            commandErrors = CommandErrors(counter: f.counter("git.command_errors"))
+            commandMs = CommandMs(distribution: f.distribution("git.command_ms"))
+            commitShaMatch = CommitShaMatch(counter: f.counter("git.commit_sha_match"))
+            commitShaDiscrepancy = CommitShaDiscrepancy(counter: f.counter("git.commit_sha_discrepancy"))
+        }
+
+        struct Command {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, command: Telemetry.GitCommand) {
+                counter.add(count, ["command": command])
+            }
+        }
+
+        struct CommandErrors {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, command: Telemetry.GitCommand, exitCode: Int) {
+                counter.add(count, ["command": command, "exit_code": exitCode])
+            }
+        }
+
+        struct CommandMs {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ milliseconds: Double, command: Telemetry.GitCommand) {
+                distribution.record(milliseconds, ["command": command])
+            }
+        }
+
+        struct CommitShaMatch {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, matched: Bool) {
+                counter.add(count, ["matched": matched])
+            }
+        }
+
+        struct CommitShaDiscrepancy {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, expectedProvider: Telemetry.ShaProvider,
+                     discrepantProvider: Telemetry.ShaProvider, type: Telemetry.ShaDiscrepancyType) {
+                counter.add(count, ["expected_provider": expectedProvider,
+                                    "discrepant_provider": discrepantProvider,
+                                    "type": type])
+            }
+        }
+    }
+}
+
+// MARK: - git_requests
+
+extension Telemetry.Metrics {
+    struct GitRequests {
+        let searchCommits: SearchCommits
+        let searchCommitsErrors: Errors
+        let searchCommitsMs: Ms
+        let objectsPack: ObjectsPack
+        let objectsPackErrors: Errors
+        let objectsPackMs: Ms
+        let objectsPackBytes: Bytes
+        let objectsPackFiles: Files
+        let settings: Settings
+        let settingsErrors: Errors
+        let settingsMs: Ms
+        let settingsResponse: SettingsResponse
+
+        init(_ f: Telemetry.Factory) {
+            searchCommits = SearchCommits(counter: f.counter("git_requests.search_commits"))
+            searchCommitsErrors = Errors(counter: f.counter("git_requests.search_commits_errors"))
+            searchCommitsMs = Ms(distribution: f.distribution("git_requests.search_commits_ms"))
+            objectsPack = ObjectsPack(counter: f.counter("git_requests.objects_pack"))
+            objectsPackErrors = Errors(counter: f.counter("git_requests.objects_pack_errors"))
+            objectsPackMs = Ms(distribution: f.distribution("git_requests.objects_pack_ms"))
+            objectsPackBytes = Bytes(distribution: f.distribution("git_requests.objects_pack_bytes"))
+            objectsPackFiles = Files(distribution: f.distribution("git_requests.objects_pack_files"))
+            settings = Settings(counter: f.counter("git_requests.settings"))
+            settingsErrors = Errors(counter: f.counter("git_requests.settings_errors"))
+            settingsMs = Ms(distribution: f.distribution("git_requests.settings_ms"))
+            settingsResponse = SettingsResponse(counter: f.counter("git_requests.settings_response"))
+        }
+
+        struct SearchCommits {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        struct ObjectsPack {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        struct Settings {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        /// Shared shape for the three `*_errors` request counters.
+        struct Errors {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, errorType: Telemetry.ErrorType) {
+                counter.add(count, ["error_type": errorType])
+            }
+        }
+
+        /// Shared shape for the request-duration distributions.
+        struct Ms {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ milliseconds: Double) { distribution.record(milliseconds, [:]) }
+        }
+
+        struct Bytes {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ bytes: Double) { distribution.record(bytes, [:]) }
+        }
+
+        struct Files {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ files: Double) { distribution.record(files, [:]) }
+        }
+
+        struct SettingsResponse {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, coverageEnabled: Bool, itrskipEnabled: Bool, requireGit: Bool,
+                     itrEnabled: Bool, earlyFlakeDetectionEnabled: Bool, flakyTestRetriesEnabled: Bool,
+                     knownTestsEnabled: Bool, impactedTestsDetectionEnabled: Bool) {
+                counter.add(count, [
+                    "coverage_enabled": coverageEnabled,
+                    "itrskip_enabled": itrskipEnabled,
+                    "require_git": requireGit,
+                    "itr_enabled": itrEnabled,
+                    "early_flake_detection_enabled": earlyFlakeDetectionEnabled,
+                    "flaky_test_retries_enabled": flakyTestRetriesEnabled,
+                    "known_tests_enabled": knownTestsEnabled,
+                    "impacted_tests_detection_enabled": impactedTestsDetectionEnabled,
+                ])
+            }
+        }
+    }
+}
+
+// MARK: - ITR (skip events) and skippable-tests requests
+
+extension Telemetry.Metrics {
+    /// Standalone ITR skip-decision counters.
+    struct ITR {
+        let skipped: EventTypeCounter
+        let unskippable: EventTypeCounter
+        let forcedRun: EventTypeCounter
+
+        init(_ f: Telemetry.Factory) {
+            skipped = EventTypeCounter(counter: f.counter("itr_skipped"))
+            unskippable = EventTypeCounter(counter: f.counter("itr_unskippable"))
+            forcedRun = EventTypeCounter(counter: f.counter("itr_forced_run"))
+        }
+
+        struct EventTypeCounter {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, eventType: Telemetry.EventType) {
+                counter.add(count, ["event_type": eventType])
+            }
+        }
+    }
+
+    struct ITRSkippableTests {
+        let request: Request
+        let requestErrors: RequestErrors
+        let requestMs: RequestMs
+        let responseBytes: ResponseBytes
+        let responseTests: ResponseTests
+        let responseSuites: ResponseSuites
+
+        init(_ f: Telemetry.Factory) {
+            request = Request(counter: f.counter("itr_skippable_tests.request"))
+            requestErrors = RequestErrors(counter: f.counter("itr_skippable_tests.request_errors"))
+            requestMs = RequestMs(distribution: f.distribution("itr_skippable_tests.request_ms"))
+            responseBytes = ResponseBytes(distribution: f.distribution("itr_skippable_tests.response_bytes"))
+            responseTests = ResponseTests(counter: f.counter("itr_skippable_tests.response_tests"))
+            responseSuites = ResponseSuites(counter: f.counter("itr_skippable_tests.response_suites"))
+        }
+
+        struct Request {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        struct RequestErrors {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, errorType: Telemetry.ErrorType) {
+                counter.add(count, ["error_type": errorType])
+            }
+        }
+
+        struct RequestMs {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ milliseconds: Double) { distribution.record(milliseconds, [:]) }
+        }
+
+        struct ResponseBytes {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ bytes: Double) { distribution.record(bytes, [:]) }
+        }
+
+        /// `itr_skippable_tests.response_tests` is a count, not a distribution.
+        struct ResponseTests {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ tests: Int) { counter.add(tests, [:]) }
+        }
+
+        /// `itr_skippable_tests.response_suites` is a count, not a distribution.
+        struct ResponseSuites {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ suites: Int) { counter.add(suites, [:]) }
+        }
+    }
+}
+
+// MARK: - known_tests / test_management_tests / impacted_tests_detection
+
+extension Telemetry.Metrics {
+    struct KnownTests {
+        let request: Request
+        let requestErrors: RequestErrors
+        let requestMs: RequestMs
+        let responseBytes: ResponseBytes
+        let responseTests: ResponseTests
+
+        init(_ f: Telemetry.Factory) {
+            request = Request(counter: f.counter("known_tests.request"))
+            requestErrors = RequestErrors(counter: f.counter("known_tests.request_errors"))
+            requestMs = RequestMs(distribution: f.distribution("known_tests.request_ms"))
+            responseBytes = ResponseBytes(distribution: f.distribution("known_tests.response_bytes"))
+            responseTests = ResponseTests(distribution: f.distribution("known_tests.response_tests"))
+        }
+
+        struct Request {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        struct RequestErrors {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, errorType: Telemetry.ErrorType) {
+                counter.add(count, ["error_type": errorType])
+            }
+        }
+
+        struct RequestMs {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ milliseconds: Double) { distribution.record(milliseconds, [:]) }
+        }
+
+        struct ResponseBytes {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ bytes: Double) { distribution.record(bytes, [:]) }
+        }
+
+        /// `known_tests.response_tests` is a distribution.
+        struct ResponseTests {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ tests: Double) { distribution.record(tests, [:]) }
+        }
+    }
+
+    struct TestManagementTests {
+        let request: Request
+        let requestErrors: RequestErrors
+        let requestMs: RequestMs
+        let responseBytes: ResponseBytes
+        let responseTests: ResponseTests
+
+        init(_ f: Telemetry.Factory) {
+            request = Request(counter: f.counter("test_management_tests.request"))
+            requestErrors = RequestErrors(counter: f.counter("test_management_tests.request_errors"))
+            requestMs = RequestMs(distribution: f.distribution("test_management_tests.request_ms"))
+            responseBytes = ResponseBytes(distribution: f.distribution("test_management_tests.response_bytes"))
+            responseTests = ResponseTests(distribution: f.distribution("test_management_tests.response_tests"))
+        }
+
+        struct Request {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        struct RequestErrors {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, errorType: Telemetry.ErrorType) {
+                counter.add(count, ["error_type": errorType])
+            }
+        }
+
+        struct RequestMs {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ milliseconds: Double) { distribution.record(milliseconds, [:]) }
+        }
+
+        struct ResponseBytes {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ bytes: Double) { distribution.record(bytes, [:]) }
+        }
+
+        struct ResponseTests {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ tests: Double) { distribution.record(tests, [:]) }
+        }
+    }
+
+    struct ImpactedTests {
+        let request: Request
+        let requestErrors: RequestErrors
+        let requestMs: RequestMs
+        let responseBytes: ResponseBytes
+        let responseFiles: ResponseFiles
+        let isModified: IsModified
+
+        init(_ f: Telemetry.Factory) {
+            request = Request(counter: f.counter("impacted_tests_detection.request"))
+            requestErrors = RequestErrors(counter: f.counter("impacted_tests_detection.request_errors"))
+            requestMs = RequestMs(distribution: f.distribution("impacted_tests_detection.request_ms"))
+            responseBytes = ResponseBytes(distribution: f.distribution("impacted_tests_detection.response_bytes"))
+            responseFiles = ResponseFiles(distribution: f.distribution("impacted_tests_detection.response_files"))
+            isModified = IsModified(counter: f.counter("impacted_tests_detection.is_modified"))
+        }
+
+        struct Request {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+
+        struct RequestErrors {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1, errorType: Telemetry.ErrorType) {
+                counter.add(count, ["error_type": errorType])
+            }
+        }
+
+        struct RequestMs {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ milliseconds: Double) { distribution.record(milliseconds, [:]) }
+        }
+
+        struct ResponseBytes {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ bytes: Double) { distribution.record(bytes, [:]) }
+        }
+
+        struct ResponseFiles {
+            fileprivate let distribution: Telemetry.Distribution
+            func record(_ files: Double) { distribution.record(files, [:]) }
+        }
+
+        struct IsModified {
+            fileprivate let counter: Telemetry.Counter
+            func add(_ count: Int = 1) { counter.add(count, [:]) }
+        }
+    }
+}

--- a/Sources/DatadogSDKTesting/Telemetry/TelemetryTags.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/TelemetryTags.swift
@@ -1,0 +1,72 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Typed tag values for the CI Visibility telemetry metrics.
+///
+/// Each `rawValue` is the exact string the intake expects, so callers pick a
+/// case (`.testCycle`) instead of remembering a string (`"test_cycle"`). Tags
+/// whose value set is open-ended or language-specific (test framework, coverage
+/// library, CI provider, browser driver) stay plain `String` on the metric APIs.
+extension Telemetry {
+    /// `event_type` — the lifecycle level an event belongs to.
+    enum EventType: String, SpanAttributeConvertible {
+        case test, suite, module, session
+    }
+
+    /// `endpoint` — which intake endpoint a payload targets.
+    enum Endpoint: String, SpanAttributeConvertible {
+        case testCycle = "test_cycle"
+        case codeCoverage = "code_coverage"
+    }
+
+    /// `error_type` — why a backend request failed.
+    enum ErrorType: String, SpanAttributeConvertible {
+        case timeout
+        case network
+        case statusCode4xx = "status_code_4xx_response"
+        case statusCode5xx = "status_code_5xx_response"
+    }
+
+    /// `command` — the git operation a metric refers to.
+    enum GitCommand: String, SpanAttributeConvertible {
+        case getRepository = "get_repository"
+        case getBranch = "get_branch"
+        case checkShallow = "check_shallow"
+        case unshallow
+        case getLocalCommits = "get_local_commits"
+        case getObjects = "get_objects"
+        case packObjects = "pack_objects"
+    }
+
+    /// `retry_reason` — why a test was retried.
+    enum RetryReason: String, SpanAttributeConvertible {
+        case earlyFlakeDetection = "efd"
+        case autoTestRetry = "atr"
+    }
+
+    /// `early_flake_detection_abort_reason` — why EFD was not applied.
+    enum EFDAbortReason: String, SpanAttributeConvertible {
+        case slow
+    }
+
+    /// `expected_provider` / `discrepant_provider` — source of a git value when
+    /// reporting commit-SHA discrepancies.
+    enum ShaProvider: String, SpanAttributeConvertible {
+        case userSupplied = "user_supplied"
+        case ciProvider = "ci_provider"
+        case localGit = "local_git"
+        case gitClient = "git_client"
+        case embedded
+    }
+
+    /// `type` — the kind of commit-SHA discrepancy found.
+    enum ShaDiscrepancyType: String, SpanAttributeConvertible {
+        case repository = "repository_discrepancy"
+        case commit = "commit_discrepancy"
+    }
+}

--- a/Sources/EventsExporter/API/TelemetryApi.swift
+++ b/Sources/EventsExporter/API/TelemetryApi.swift
@@ -32,7 +32,7 @@ public enum TelemetryRequestType: String, Codable {
 public struct TelemetryMetric: TelemetryPayload, Codable {
     /// Per-tracer metric namespace (`dd.instrumentation_telemetry_data.{namespace}.*`).
     public enum Namespace: String, Codable {
-        case tracers, general, telemetry, iast, appsec
+        case tracers, general, telemetry, iast, appsec, civisibility
     }
 
     /// The metric kind. The intake defaults to `.gauge` when omitted.
@@ -111,7 +111,7 @@ public struct TelemetryMetric: TelemetryPayload, Codable {
 public struct TelemetryDistribution: TelemetryPayload, Codable {
     /// Namespace for distribution metrics.
     public enum Namespace: String, Codable {
-        case tracers, profilers, rum, appsec
+        case tracers, profilers, rum, appsec, civisibility
     }
 
     /// A distribution series with one or more raw sample values.

--- a/Sources/EventsExporter/Telemetry/TelemetryLogExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryLogExporter.swift
@@ -8,24 +8,24 @@ import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 
-internal final class TelemetryLogExporter: LogRecordExporter {
+public final class TelemetryLogExporter: LogRecordExporter {
     let telemetryExporter: TelemetryExporter
 
-    init(telemetryExporter: TelemetryExporter) {
+    public init(telemetryExporter: TelemetryExporter) {
         self.telemetryExporter = telemetryExporter
     }
 
-    func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) -> ExportResult {
+    public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) -> ExportResult {
         guard !logRecords.isEmpty else { return .success }
         telemetryExporter.export(item: TelemetryLog.Logs(logRecords.map(TelemetryLog.init(_:))))
         return .success
     }
 
-    func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
+    public func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
         telemetryExporter.flush() ? .success : .failure
     }
 
-    func shutdown(explicitTimeout: TimeInterval?) {
+    public func shutdown(explicitTimeout: TimeInterval?) {
         telemetryExporter.shutdown()
     }
 }

--- a/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryMetricExporter.swift
@@ -8,21 +8,21 @@ import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 
-internal final class TelemetryMetricExporter: MetricExporter {
+public final class TelemetryMetricExporter: MetricExporter {
     let telemetryExporter: TelemetryExporter
     let namespace: TelemetryMetric.Namespace?
     let distributionNamespace: TelemetryDistribution.Namespace?
 
-    init(telemetryExporter: TelemetryExporter,
-         namespace: TelemetryMetric.Namespace? = nil,
-         distributionNamespace: TelemetryDistribution.Namespace? = nil)
+    public init(telemetryExporter: TelemetryExporter,
+                namespace: TelemetryMetric.Namespace? = nil,
+                distributionNamespace: TelemetryDistribution.Namespace? = nil)
     {
         self.telemetryExporter = telemetryExporter
         self.namespace = namespace
         self.distributionNamespace = distributionNamespace
     }
 
-    func export(metrics: [MetricData]) -> ExportResult {
+    public func export(metrics: [MetricData]) -> ExportResult {
         guard !metrics.isEmpty else { return .success }
 
         let scalarSeries = metrics.compactMap(TelemetryMetric.Series.from(_:)).flatMap { $0 }
@@ -38,16 +38,16 @@ internal final class TelemetryMetricExporter: MetricExporter {
         return .success
     }
 
-    func flush() -> ExportResult {
+    public func flush() -> ExportResult {
         telemetryExporter.flush() ? .success : .failure
     }
 
-    func shutdown() -> ExportResult {
+    public func shutdown() -> ExportResult {
         telemetryExporter.shutdown()
         return .success
     }
 
-    func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {
+    public func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {
         switch instrument {
         case .upDownCounter, .observableUpDownCounter:
             // These map to a DD gauge, where the current running total is the value

--- a/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
@@ -1,0 +1,87 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+@testable import DatadogSDKTesting
+import EventsExporter
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class TelemetryTests: XCTestCase {
+    /// Captures the `MetricData` pushed on flush so we can assert what the
+    /// manager produced without touching the network pipeline.
+    final class InMemoryMetricExporter: MetricExporter {
+        private(set) var exported: [MetricData] = []
+
+        func export(metrics: [MetricData]) -> ExportResult {
+            exported.append(contentsOf: metrics)
+            return .success
+        }
+
+        func flush() -> ExportResult { .success }
+        func shutdown() -> ExportResult { .success }
+        func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {
+            .delta
+        }
+    }
+
+    private func makeTelemetry(_ exporter: MetricExporter) -> Telemetry {
+        Telemetry(exporter: exporter, resource: Resource(), exportInterval: 3600)
+    }
+
+    func testRecordsCounterWithTypedTags() throws {
+        let exporter = InMemoryMetricExporter()
+        let telemetry = makeTelemetry(exporter)
+
+        telemetry.metrics.git.command.add(command: .getRepository)
+        telemetry.metrics.endpointPayload.requestsErrors.add(errorType: .timeout, endpoint: .testCycle)
+
+        XCTAssertTrue(telemetry.flush())
+
+        let byName = Dictionary(exporter.exported.map { ($0.name, $0) }) { a, _ in a }
+
+        let gitCommand = try XCTUnwrap(byName["git.command"])
+        XCTAssertEqual(gitCommand.resource.telemetryMetricNamespace, .civisibility)
+        let gitPoint = try XCTUnwrap(gitCommand.data.points.first)
+        XCTAssertEqual(gitPoint.attributes["command"]?.description, "get_repository")
+
+        let errors = try XCTUnwrap(byName["endpoint_payload.requests_errors"])
+        let errPoint = try XCTUnwrap(errors.data.points.first)
+        XCTAssertEqual(errPoint.attributes["error_type"]?.description, "timeout")
+        XCTAssertEqual(errPoint.attributes["endpoint"]?.description, "test_cycle")
+    }
+
+    func testRecordsDistributionWithCivisibilityNamespace() throws {
+        let exporter = InMemoryMetricExporter()
+        let telemetry = makeTelemetry(exporter)
+
+        telemetry.metrics.endpointPayload.bytes.record(2048, endpoint: .codeCoverage)
+        telemetry.metrics.knownTests.responseTests.record(42)
+
+        XCTAssertTrue(telemetry.flush())
+
+        let names = Set(exporter.exported.map(\.name))
+        XCTAssertTrue(names.contains("endpoint_payload.bytes"))
+        XCTAssertTrue(names.contains("known_tests.response_tests"))
+
+        for metric in exporter.exported {
+            XCTAssertEqual(metric.resource.telemetryDistributionNamespace, .civisibility)
+        }
+    }
+
+    func testCounterIncrementsByGivenValue() throws {
+        let exporter = InMemoryMetricExporter()
+        let telemetry = makeTelemetry(exporter)
+
+        telemetry.metrics.itrSkippableTests.responseTests.add(7)
+
+        XCTAssertTrue(telemetry.flush())
+
+        let metric = try XCTUnwrap(exporter.exported.first { $0.name == "itr_skippable_tests.response_tests" })
+        let point = try XCTUnwrap(metric.data.points.first as? LongPointData)
+        XCTAssertEqual(point.value, 7)
+    }
+}

--- a/Tests/EventsExporter/Helpers/CoreMocks.swift
+++ b/Tests/EventsExporter/Helpers/CoreMocks.swift
@@ -57,11 +57,17 @@ struct StoragePerformanceMock: StoragePerformancePreset {
     /// All writes accumulate in the same file until it is explicitly closed via
     /// `flush()`. Use this to test that the uploader correctly assembles a
     /// `message-batch` from several entries that share one on-disk batch.
+    ///
+    /// `minFileAgeForRead` is effectively infinite so the periodic upload worker
+    /// never picks up the still-open file mid-write (which would race with the
+    /// writes and split the batch across uploads). `flush()` drains regardless of
+    /// file age, so it remains the only path that uploads here — exactly the
+    /// behaviour under test.
     static let appendToOneFile = StoragePerformanceMock(
         maxFileSize: .max,
         maxDirectorySize: .max,
         maxFileAgeForWrite: .greatestFiniteMagnitude,
-        minFileAgeForRead: readAllFiles.minFileAgeForRead,
+        minFileAgeForRead: .greatestFiniteMagnitude,
         maxFileAgeForRead: readAllFiles.maxFileAgeForRead,
         maxObjectsInFile: .max,
         maxObjectSize: .max,


### PR DESCRIPTION
## What

Implements [SDTEST-3775](https://datadoghq.atlassian.net/browse/SDTEST-3775) — the first piece of M3 (gather SDK metrics). Adds a common telemetry manager that owns the metric pipeline and provides a counter/histogram instance for **every** CI Visibility metric.

This PR **only provides the instances**; features do not record into them yet (that's the follow-up "gather" subtask).

## Design

- **`Telemetry`** (DatadogSDKTesting) owns a `MeterProviderSdk` wired to the Datadog instrumentation-telemetry pipeline: `PeriodicMetricReader → TelemetryMetricExporter → TelemetryExporter`, with the `civisibility` namespace stamped on the meter `Resource`.
- Metrics are exposed as a **typed, discoverable tree** so callers never need to look up metric names or allowed tags:
  ```swift
  telemetry?.metrics.git.command.add(command: .getRepository)
  telemetry?.metrics.endpointPayload.requestsErrors.add(errorType: .timeout, endpoint: .testCycle)
  telemetry?.metrics.events.created.add(testFramework: "XCTest", eventType: .test, isBenchmark: false)
  telemetry?.metrics.knownTests.responseTests.record(42)
  ```
  Each metric's `add`/`record` names exactly the tags it accepts. Tag values are typed enums / `Bool` / `Int`, rendered to wire strings via the existing `SpanAttributeConvertible`.
- The metric set comes from the shared instrumentation-telemetry spec and is cross-checked against `dd-trace-go` — **59 metrics (37 counters + 22 distributions)**, so nothing is missed.

## Configuration

- `DD_INSTRUMENTATION_TELEMETRY_ENABLED` — default `true`; when off, `SessionConfig.telemetry` is `nil`.
- `DD_TELEMETRY_HEARTBEAT_INTERVAL` — collection/export interval in seconds, clamped to `1...3600`, default `60`.

## Changes

- **EventsExporter**: made `TelemetryMetricExporter` / `TelemetryLogExporter` public (were internal only because previously unused); added `civisibility` to the metric & distribution namespace enums.
- **Config / EnvironmentKeys**: the two env vars above.
- **SessionManager**: builds the manager (gated by the enable flag), threads it through the new optional `SessionConfig.telemetry`, and shuts it down on stop.

## Testing

New `TelemetryTests` verify the typed tags map to correct wire values (`command:get_repository`, `error_type:timeout`, `endpoint:test_cycle`), the `civisibility` namespace, and counter increment values. Build + `TelemetryTests`/`ConfigTests` pass; the full `EventsExporter` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDTEST-3775]: https://datadoghq.atlassian.net/browse/SDTEST-3775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ