### PR TITLE
[SDTEST-3776] Wire telemetry manager through the SDK to gather request/upload metrics

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F26679E6F497C3AEF3A4845 /* MetricObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5687C35EB7CCAF30113528FC /* MetricObservers.swift */; };
 		1FB416017E14C140B15E1D97 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3EB9ACD93007FC43F039EE /* Async.swift */; };
 		300F42B595C3462AB9656B0C /* EarlyFlakeDetectionSwiftTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC931D86ADB841B6969C7A7A /* EarlyFlakeDetectionSwiftTestingTests.swift */; };
 		3592750B292103668D7668F7 /* MultipartFormURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE92A3947C2E5BD2183BB4E /* MultipartFormURLRequest.swift */; };
@@ -16,6 +17,7 @@
 		4CCD47B30A3B513F26C8936E /* TelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BF04956AA1E2FADBB80244 /* TelemetryTests.swift */; };
 		56B58A2FC91F21D1ABB0155E /* TelemetryApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EB970146040DD4967C7411 /* TelemetryApi.swift */; };
 		7972B04FB1DFA64DC20032AE /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E11F924F40C94461C2B6B27 /* Telemetry.swift */; };
+		7C6CBEE99C831DBEBB28BD67 /* TelemetryObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA2B1C720A94291E83285B /* TelemetryObservers.swift */; };
 		821FA0CC8B62245A4949FDBB /* APITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85241CF97F1B6DAA49ECA23 /* APITypes.swift */; };
 		86137D23E1704D17A7B6D486 /* TelemetryExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DFE52D135C457D9160920A /* TelemetryExporterTests.swift */; };
 		8EF6F88255506A4CEE6D36B6 /* GitUploadApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */; };
@@ -430,8 +432,10 @@
 		12536CCE14EC1D3DAAC8DB81 /* Synced.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Synced.swift; sourceTree = "<group>"; };
 		1495758A45B516A2C584B845 /* TestImpactAnalysisApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestImpactAnalysisApi.swift; sourceTree = "<group>"; };
 		1531A96019132E3E9E96A3A7 /* KnownTestsApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KnownTestsApi.swift; sourceTree = "<group>"; };
+		26CA2B1C720A94291E83285B /* TelemetryObservers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TelemetryObservers.swift; sourceTree = "<group>"; };
 		2E11F924F40C94461C2B6B27 /* Telemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		31F8747157604DB48FE692EB /* AutoTestRetriesSwiftTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTestRetriesSwiftTestingTests.swift; sourceTree = "<group>"; };
+		5687C35EB7CCAF30113528FC /* MetricObservers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetricObservers.swift; sourceTree = "<group>"; };
 		5F3AA8F51FDDEF0C319080E8 /* GitUploadApi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GitUploadApi.swift; sourceTree = "<group>"; };
 		6F3EB9ACD93007FC43F039EE /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
 		81894A4E29B0A28B00108C51 /* Retrying.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Retrying.swift; sourceTree = "<group>"; };
@@ -803,6 +807,7 @@
 				2E11F924F40C94461C2B6B27 /* Telemetry.swift */,
 				843CE17ADB4681EE3DC4FF9B /* TelemetryMetrics.swift */,
 				E714A2777988AA4DA1AACB5C /* TelemetryTags.swift */,
+				26CA2B1C720A94291E83285B /* TelemetryObservers.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -1008,6 +1013,7 @@
 				BC161A86B91745F4BDC88FF1 /* TelemetryExporter.swift */,
 				A7926AEE2FCDCBFE007834F2 /* TelemetryLogExporter.swift */,
 				A7926AF02FCDD411007834F2 /* TelemetryMetricExporter.swift */,
+				5687C35EB7CCAF30113528FC /* MetricObservers.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -2085,6 +2091,7 @@
 				7972B04FB1DFA64DC20032AE /* Telemetry.swift in Sources */,
 				A0EC035461740BCF6DFB8171 /* TelemetryMetrics.swift in Sources */,
 				E42959C85F3B9BAB313984F7 /* TelemetryTags.swift in Sources */,
+				7C6CBEE99C831DBEBB28BD67 /* TelemetryObservers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2198,6 +2205,7 @@
 				CD1E9CDE6FE677BC07E66905 /* SpansApi.swift in Sources */,
 				56B58A2FC91F21D1ABB0155E /* TelemetryApi.swift in Sources */,
 				98D8D496CC4210A0D1D07F93 /* Synced.swift in Sources */,
+				1F26679E6F497C3AEF3A4845 /* MetricObservers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -239,7 +239,8 @@ internal class DDTestMonitor {
                 DDTestMonitor.instance?.gitUploader = GitUploader(
                     log: Log.instance, api: DDTestMonitor.tracer.api.git, gitDirectory: gitDirectory,
                     commitFolder: try? DDTestMonitor.cacheManager?.commit(feature: "git"),
-                    unshallowEnabled: DDTestMonitor.config.gitUnshallowEnabled
+                    unshallowEnabled: DDTestMonitor.config.gitUnshallowEnabled,
+                    telemetry: DDTestMonitor.tracer.telemetry
                 )
             } else {
                 Log.debug("Git Upload Disabled")
@@ -291,7 +292,8 @@ internal class DDTestMonitor {
                             sha: commit,
                             testLevel: .test,
                             configurations: baseConfigurations,
-                            customConfigurations: customConfigurations
+                            customConfigurations: customConfigurations,
+                            observer: DDTestMonitor.tracer.telemetry?.gitSettingsRequestObserver
                         )
                     }
                 }
@@ -396,7 +398,8 @@ internal class DDTestMonitor {
                                             environment: DDTestMonitor.env.environment,
                                             configurations: DDTestMonitor.env.baseConfigurations,
                                             custom: DDTestMonitor.config.customConfigurations,
-                                            api: DDTestMonitor.tracer.api.knownTests, cache: cache)
+                                            api: DDTestMonitor.tracer.api.knownTests, cache: cache,
+                                            telemetry: DDTestMonitor.tracer.telemetry)
             self.knownTests = runFactory(factory, errorKind: .knownTests)
         }
         knownTestsSetup.addDependency(updateTracerConfig)
@@ -454,7 +457,8 @@ internal class DDTestMonitor {
                                                 module: module,
                                                 attemptToFixRetries: attemptToFixRetryCount,
                                                 api: DDTestMonitor.tracer.api.testManagement,
-                                                cache: cache)
+                                                cache: cache,
+                                                telemetry: DDTestMonitor.tracer.telemetry)
             self.testManagement = runFactory(factory, errorKind: .testManagementTests)
         }
         testManagementSetup.addDependency(updateTracerConfig)
@@ -485,7 +489,8 @@ internal class DDTestMonitor {
                                                     repository: repository,
                                                     cache: cache,
                                                     skippingEnabled: remote.itr.testsSkipping,
-                                                    swiftTestingEnabled: DDTestMonitor.env.tiaSwiftTestingEnabled)
+                                                    swiftTestingEnabled: DDTestMonitor.env.tiaSwiftTestingEnabled,
+                                                    telemetry: DDTestMonitor.tracer.telemetry)
             self.tia = runFactory(factory, errorKind: .skippableTests)
         }
         tiaSetup.addDependency(updateTracerConfig)

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -30,6 +30,10 @@ internal class DDTracer {
     /// feature factories don't need to reach through `eventsExporter` to talk
     /// to the backend.
     var api: TestOptimizationApi
+    /// Common telemetry manager. Created alongside the tracer so the API /
+    /// exporter layers and every feature can record SDK self-metrics. `nil`
+    /// when instrumentation telemetry is disabled or storage is unavailable.
+    let telemetry: Telemetry?
 
     /// Logger used to emit `print()`/stderr captures and test-error context as
     /// first-class OTel `LogRecord`s through the registered LoggerProvider.
@@ -53,9 +57,11 @@ internal class DDTracer {
     init(id: String, version: String, exporter: ExporterProtocol?,
          api: TestOptimizationApi, enabled: Bool, launchContext: SpanContext?,
          resource: Resource = Resource(),
-         logRecordExporter: LogRecordExporter? = nil)
+         logRecordExporter: LogRecordExporter? = nil,
+         telemetry: Telemetry? = nil)
     {
         self.launchSpanContext = launchContext
+        self.telemetry = telemetry
         self.eventsExporter = exporter
         self.api = api
         self.resource = resource
@@ -157,7 +163,6 @@ internal class DDTracer {
         let exporterConfiguration = ExporterConfiguration(
             environment: env.environment,
             metadata: metadata,
-            performancePreset: .instantDataDelivery,
             logger: Log.instance
         )
         let api = TestOptimizationApiService(
@@ -174,17 +179,6 @@ internal class DDTracer {
             dateProvider: DDTestMonitor.clock,
             debugNetworkRequests: conf.extraDebugNetwork
         )
-        // Exporter files live under the cache manager's session directory so
-        // they stay scoped to this test run and get cleaned up alongside the
-        // rest of the per-session state.
-        let eventsExporter: Exporter?
-        if let storage = try? DDTestMonitor.cacheManager?.session(feature: "exporter") {
-            eventsExporter = try? Exporter(config: exporterConfiguration, api: api, storage: storage)
-        } else {
-            Log.print("Exporter init skipped: cache manager unavailable")
-            eventsExporter = nil
-        }
-
         var resource = Resource()
         resource.applicationName = identifier
         resource.applicationVersion = version
@@ -194,11 +188,96 @@ internal class DDTracer {
         resource.sdkName = identifier
         resource.sdkVersion = DDTestMonitor.tracerVersion
 
+        // Build the telemetry manager before the exporter so its observers can
+        // be wired into the exporter's upload/serialization pipeline.
+        let telemetry: Telemetry? = conf.instrumentationTelemetryEnabled
+            ? DDTracer.makeTelemetry(api: api, configuration: exporterConfiguration, resource: resource,
+                                     exportInterval: conf.telemetryHeartbeatInterval)
+            : nil
+
+        // Exporter files live under the cache manager's session directory so
+        // they stay scoped to this test run and get cleaned up alongside the
+        // rest of the per-session state.
+        let eventsExporter: Exporter?
+        if let storage = try? DDTestMonitor.cacheManager?.session(feature: "exporter") {
+            eventsExporter = try? Exporter(config: exporterConfiguration, api: api, storage: storage,
+                                           observers: DDTracer.exporterObservers(telemetry: telemetry))
+        } else {
+            Log.print("Exporter init skipped: cache manager unavailable")
+            eventsExporter = nil
+        }
+
         self.init(id: identifier, version: version, exporter: eventsExporter,
                   api: api,
                   enabled: !conf.disableTracesExporting, launchContext: launchSpanContext,
                   resource: resource,
-                  logRecordExporter: logRecordExporter)
+                  logRecordExporter: logRecordExporter,
+                  telemetry: telemetry)
+    }
+
+    /// Build the common telemetry manager wired to the SDK's telemetry intake,
+    /// reusing the exporter's configuration. Returns `nil` when the backing
+    /// storage or exporter can't be created, in which case telemetry is simply
+    /// not gathered.
+    private static func makeTelemetry(api: TestOptimizationApi, configuration: ExporterConfiguration,
+                                      resource: Resource, exportInterval: TimeInterval) -> Telemetry?
+    {
+        guard let cacheManager = DDTestMonitor.cacheManager,
+              let storage = try? cacheManager.session(feature: "telemetry")
+        else {
+            Log.print("Telemetry init skipped: cache manager unavailable")
+            return nil
+        }
+
+        guard let telemetryExporter = try? TelemetryExporter(config: configuration,
+                                                             storage: storage,
+                                                             api: api.telemetry)
+        else {
+            Log.print("Telemetry init skipped: telemetry exporter unavailable")
+            return nil
+        }
+
+        let metricExporter = TelemetryMetricExporter(telemetryExporter: telemetryExporter,
+                                                     namespace: .civisibility,
+                                                     distributionNamespace: .civisibility)
+        return Telemetry(exporter: metricExporter, resource: resource, exportInterval: exportInterval)
+    }
+
+    /// Build the exporter's telemetry observers, mapping each upload feature to
+    /// its `endpoint_payload.*` metrics tagged by endpoint (spans → `test_cycle`,
+    /// coverage → `code_coverage`). Empty when telemetry is disabled.
+    private static func exporterObservers(telemetry: Telemetry?) -> ExporterObservers {
+        guard let telemetry else { return .init() }
+        return ExporterObservers(
+            spans: endpointPayloadObservers(telemetry: telemetry, endpoint: .testCycle),
+            coverage: endpointPayloadObservers(telemetry: telemetry, endpoint: .codeCoverage)
+        )
+    }
+
+    private static func endpointPayloadObservers(telemetry: Telemetry,
+                                                 endpoint: Telemetry.Endpoint) -> ExporterObservers.Feature
+    {
+        ExporterObservers.Feature(
+            // Transport facts (size sent, duration, status) come from the upload
+            // request itself.
+            request: Telemetry.RequestMetricsObserver(
+                onRequest: { telemetry.metrics.endpointPayload.requests.add(endpoint: endpoint) },
+                onDurationMs: { telemetry.metrics.endpointPayload.requestsMs.record($0, endpoint: endpoint) },
+                onRequestBytes: { telemetry.metrics.endpointPayload.bytes.record(Double($0), endpoint: endpoint) },
+                onError: { telemetry.metrics.endpointPayload.requestsErrors.add(errorType: $0, endpoint: endpoint) }
+            ),
+            // The worker owns the batch lifecycle; only `dropped` is unique to it.
+            upload: Telemetry.UploadMetricsObserver(
+                onDropped: { _ in telemetry.metrics.endpointPayload.dropped.add(endpoint: endpoint) }
+            ),
+            // Serialization happens at the storage layer.
+            payload: Telemetry.PayloadMetricsObserver(
+                onFinalized: { count, serializationMs in
+                    telemetry.metrics.endpointPayload.eventsCount.record(Double(count), endpoint: endpoint)
+                    telemetry.metrics.endpointPayload.eventsSerializationMs.record(serializationMs, endpoint: endpoint)
+                }
+            )
+        )
     }
     
     private func createSpanBuilder(name: String, attributes: [String: AttributeValue], startTime: Date? = nil) -> SpanBuilder {

--- a/Sources/DatadogSDKTesting/KnownTests.swift
+++ b/Sources/DatadogSDKTesting/KnownTests.swift
@@ -76,11 +76,12 @@ struct KnownTestsFactory: FeatureFactory {
     let customConfigurations: [String: String]
     let cacheFolder: Directory
     let api: KnownTestsApi
+    let telemetry: Telemetry?
     let cacheFileName = "known_tests.json"
 
     init(repository: String, service: String, environment: String,
          configurations: [String: String], custom: [String: String],
-         api: KnownTestsApi, cache: Directory)
+         api: KnownTestsApi, cache: Directory, telemetry: Telemetry? = nil)
     {
         self.configurations = configurations
         self.customConfigurations = custom
@@ -89,6 +90,7 @@ struct KnownTestsFactory: FeatureFactory {
         self.service = service
         self.environment = environment
         self.api = api
+        self.telemetry = telemetry
     }
 
     static func isEnabled(config: Config, env: Environment, remote: TracerSettings) -> Bool {
@@ -128,7 +130,8 @@ struct KnownTestsFactory: FeatureFactory {
             tests = try await api.tests(service: service, env: environment,
                                         repositoryURL: repository,
                                         configurations: configurations,
-                                        customConfigurations: customConfigurations).tests
+                                        customConfigurations: customConfigurations,
+                                        observer: telemetry?.knownTestsRequestObserver).tests
         } catch {
             throw LibraryConfigurationCommunicationError(
                 requestName: "Known Tests Request",

--- a/Sources/DatadogSDKTesting/SessionManager.swift
+++ b/Sources/DatadogSDKTesting/SessionManager.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 internal import EventsExporter
-internal import OpenTelemetrySdk
 
 final actor SessionManager: TestSessionManager {
     typealias SessionWithConfig = (session: any TestModuleManager & TestSession,
@@ -73,11 +72,9 @@ final actor SessionManager: TestSessionManager {
             monitor.setupCrashHandler()
         }
 
-        // Common telemetry manager, shared with every feature through the
-        // session config. Gated by `DD_INSTRUMENTATION_TELEMETRY_ENABLED`
-        // (default true); `nil` when disabled or storage is unavailable.
-        let telemetry = DDTestMonitor.config.instrumentationTelemetryEnabled ? makeTelemetry() : nil
-
+        // The common telemetry manager is created with the tracer (so it's
+        // available to the API/exporter layers) and shared with every feature
+        // through the session config. `nil` when telemetry is disabled.
         let config = SessionConfig(
             activeFeatures: monitor.activeFeatures,
             platform: DDTestMonitor.env.platform,
@@ -87,7 +84,7 @@ final actor SessionManager: TestSessionManager {
             service: DDTestMonitor.env.service,
             metrics: DDTestMonitor.env.baseMetrics,
             log: log,
-            telemetry: telemetry
+            telemetry: DDTestMonitor.tracer.telemetry
         )
         
         let session = try await provider.startSession(named: "Swift.session", config: config,
@@ -101,43 +98,6 @@ extension SessionManager {
     enum BoostrapError: Error {
         case monitorInitFailed
         case monitorIsNil
-    }
-
-    /// Build the common telemetry manager wired to the SDK's telemetry intake,
-    /// reusing the tracer's API client, cache directory and resource. Returns
-    /// `nil` when the backing storage or exporter can't be created, in which
-    /// case telemetry is simply not gathered.
-    private func makeTelemetry() -> Telemetry? {
-        let tracer = DDTestMonitor.tracer
-
-        guard let cacheManager = DDTestMonitor.cacheManager,
-              let storage = try? cacheManager.session(feature: "telemetry")
-        else {
-            log.print("Telemetry init skipped: cache manager unavailable")
-            return nil
-        }
-
-        let configuration = ExporterConfiguration(
-            environment: DDTestMonitor.env.environment,
-            metadata: SpanMetadata(),
-            performancePreset: .instantDataDelivery,
-            logger: log
-        )
-
-        guard let telemetryExporter = try? TelemetryExporter(config: configuration,
-                                                             storage: storage,
-                                                             api: tracer.api.telemetry)
-        else {
-            log.print("Telemetry init skipped: telemetry exporter unavailable")
-            return nil
-        }
-
-        let metricExporter = TelemetryMetricExporter(telemetryExporter: telemetryExporter,
-                                                     namespace: .civisibility,
-                                                     distributionNamespace: .civisibility)
-        return Telemetry(exporter: metricExporter,
-                         resource: tracer.resource,
-                         exportInterval: DDTestMonitor.config.telemetryHeartbeatInterval)
     }
 }
 

--- a/Sources/DatadogSDKTesting/Telemetry/ARCHITECTURE.md
+++ b/Sources/DatadogSDKTesting/Telemetry/ARCHITECTURE.md
@@ -1,0 +1,214 @@
+# Telemetry architecture
+
+SDK self-telemetry (CI Visibility "instrumentation telemetry" metrics). This
+document explains how the pieces fit together and what is intentionally left
+for **SDTEST-3777** (gather the remaining metrics).
+
+Milestone history:
+- **SDTEST-3775** — the metric instances + the common `Telemetry` manager.
+- **SDTEST-3776** — wiring: observer hooks in `EventsExporter`, `Telemetry`
+  created with the tracer, request/upload/payload metrics gathered.
+- **SDTEST-3777** — gather the remaining (local + response-count) metrics.
+
+---
+
+## 1. Big picture
+
+```
+                       DatadogSDKTesting (high level)                EventsExporter (low level)
+                       ─────────────────────────────                ──────────────────────────
+ features ── record ─▶ Telemetry.metrics.<group>.<metric>
+   (events, git cmd,        │  (typed tree, 59 metrics)
+    itr, coverage…)         │
+                            ▼
+                       MeterProviderSdk ──▶ PeriodicMetricReader ──▶ TelemetryMetricExporter
+                       (OpenTelemetry)        (heartbeat)              (OTel MetricData ──▶ DD)
+                                                                          │
+                                                                          ▼
+                                                                     TelemetryExporter
+                                                                     (batch + upload via
+                                                                      api.telemetry)
+
+ exporter/network internals report neutral facts back UP via observer protocols:
+   HTTPClient / DataUploadWorker / FileWriter ── RequestObserver / UploadObserver / PayloadObserver
+        │                                                          │
+        └──────────── observers are adapters that call ───────────▶ Telemetry.metrics.<group>.<metric>
+```
+
+Two rules drive the whole design:
+
+1. **`EventsExporter` is the lower module** — it cannot import `Telemetry`
+   (which lives in `DatadogSDKTesting`). So metrics emitted deep in the
+   network/storage layer are reported via **neutral observer protocols** defined
+   in `EventsExporter`; the `Telemetry`-aware adapters live in
+   `DatadogSDKTesting`. (Dependency inversion, modelled on the existing `Logger`
+   protocol.)
+2. **Metric identity/tags stay next to the metric tree** — `EventsExporter` only
+   reports facts (durations, byte sizes, status codes, counts). Which metric and
+   which tags they map to is decided in `DatadogSDKTesting`.
+
+---
+
+## 2. The metric tree (SDTEST-3775)
+
+`Telemetry` (`Telemetry.swift`) owns an OpenTelemetry `MeterProviderSdk` wired to
+`TelemetryMetricExporter` through a `PeriodicMetricReader`. It exposes every CI
+Visibility metric through a typed, discoverable tree:
+
+```swift
+telemetry.metrics.git.command.add(command: .getRepository)
+telemetry.metrics.endpointPayload.requestsErrors.add(errorType: .timeout, endpoint: .testCycle)
+telemetry.metrics.events.created.add(testFramework: "XCTest", eventType: .test)
+telemetry.metrics.knownTests.responseTests.record(42)
+```
+
+Files:
+- `TelemetryMetrics.swift` — the tree: `Telemetry.Metrics` → groups (`events`,
+  `session`, `codeCoverage`, `endpointPayload`, `git`, `gitRequests`, `itr`,
+  `itrSkippableTests`, `knownTests`, `testManagementTests`, `impactedTests`) →
+  per-metric structs. Also the low-level `Counter` / `Distribution` handles and
+  the `Factory` that builds instruments from the meter.
+- `TelemetryTags.swift` — typed tag-value enums (`EventType`, `Endpoint`,
+  `ErrorType`, `GitCommand`, `RetryReason`, `ShaProvider`, …), conforming to
+  `SpanAttributeConvertible` (so `Bool`/`Int`/enum → wire string uniformly).
+- `Telemetry.swift` — the manager, the meter provider, `flush()` / `shutdown()`.
+
+Metric set = union of the CSV spec and `dd-trace-go` (37 counters + 22
+distributions), all under the `civisibility` telemetry namespace.
+
+### Gotchas
+- **A catch-all `View` must be registered** on the meter provider or the SDK
+  records nothing (`findViews` only consults explicitly-registered views, not the
+  per-instrument defaults). See `Telemetry.init`.
+- `civisibility` had to be added to `TelemetryMetric.Namespace` /
+  `TelemetryDistribution.Namespace` in `EventsExporter`.
+- `TelemetryMetricExporter.getAggregationTemporality` returns **delta** for
+  counters/histograms and **cumulative** for up-down counters.
+
+---
+
+## 3. Lifecycle / wiring (SDTEST-3776)
+
+- `Telemetry` is created **inside `DDTracer`** (convenience init), right after the
+  API client and **before** the `Exporter` — so the exporter can be handed the
+  telemetry observers, and so the feature factories can reach it. See
+  `DDTracer.makeTelemetry(...)`.
+- Gated by `DD_INSTRUMENTATION_TELEMETRY_ENABLED` (default `true`). Heartbeat /
+  export interval is `DD_TELEMETRY_HEARTBEAT_INTERVAL` (seconds, clamped 1…3600,
+  default 60).
+- Exposed as `DDTracer.telemetry`; `SessionConfig.telemetry` is sourced from it
+  (so `DDSession`/`Module`/`Suite`/`Test` and observers all share one instance).
+- The exporter + telemetry share a single `ExporterConfiguration` on the
+  **default** performance preset (changed from `.instantDataDelivery` in 3776).
+
+---
+
+## 4. Observer hooks (the cross-module bridge)
+
+Defined in `EventsExporter/Telemetry/MetricObservers.swift` (neutral, public):
+
+| Protocol | Reported from | Carries |
+|---|---|---|
+| `RequestObserver` | `HTTPClient.perform` (one call site for every request) | `durationMs`, `requestBytes` (pre-deflate), `responseBytes`, `statusCode`, `failed` |
+| `UploadObserver` | `DataUploadWorker` | `uploadAttempt(payloadBytes, durationMs, success, retriable)`, `uploadDropped(payloadBytes)` |
+| `PayloadObserver` | `FileWriter` | `payloadFinalized(eventCount, serializationMs)` per file |
+
+- `ExporterObservers { spans, coverage }`, each a `Feature { request, upload, payload }`,
+  is threaded `Exporter.init` → `SpansExporter`/`CoverageExporter` → their
+  `FileWriter` (payload), upload closure (request), and `FeatureStoreAndUpload`
+  worker (upload). Logs are not instrumented (no `endpoint` value for logs).
+- All hooks are optional and default to `nil`, so the pipeline is a no-op unless
+  an observer is attached. `start`/`encodeStart` timestamps are only taken when
+  an observer is present.
+
+Adapters that turn the neutral callbacks into `Telemetry.metrics.*` live in
+`DatadogSDKTesting/Telemetry/TelemetryObservers.swift`:
+- `RequestMetricsObserver` / `UploadMetricsObserver` / `PayloadMetricsObserver` —
+  generic bridges taking per-family closures. The common
+  `statusCode → error_type` mapping (`Telemetry.errorType(statusCode:)`) lives
+  here so every call site agrees.
+- Per-family request observers: `gitSettingsRequestObserver`,
+  `gitSearchCommitsRequestObserver`, `gitObjectsPackRequestObserver`,
+  `skippableTestsRequestObserver`, `knownTestsRequestObserver`,
+  `testManagementRequestObserver`.
+
+### Important bug fixed in 3776
+The `*ApiService` types now depend on the `HTTPClientType` **protocol** (not the
+concrete `HTTPClient`), so a mock client can be injected. The observer-aware
+methods are the protocol requirements; no-observer convenience methods are
+`@inlinable` protocol-extension defaults.
+
+---
+
+## 5. What is gathered today vs. TODO (SDTEST-3777)
+
+### Gathered (3776)
+- **`endpoint_payload.*`** — `requests`, `requests_ms`, `bytes` (request size),
+  `requests_errors`, `events_count`, `events_serialization_ms`, tagged
+  `test_cycle` (spans) / `code_coverage` (coverage). Wired in
+  `DDTracer.endpointPayloadObservers(...)`. This family has **no feature call
+  site** — the observers are its only home.
+- **API request families** — `git_requests.{settings,search_commits,objects_pack}`
+  (+ `_ms`, `_errors`, and `objects_pack_bytes`), `itr_skippable_tests.{request,
+  request_ms,request_errors,response_bytes}`, `known_tests.{request,request_ms,
+  request_errors,response_bytes}`, `test_management_tests.{…}`. Gathered via the
+  per-family request observers passed into the API calls from `GitUploader`, the
+  TIA / known-tests / test-management factories, and the settings fetch in
+  `DDTestMonitor.getTracerConfig`.
+
+### TODO — SDTEST-3777
+1. **Response item counts** (need the parsed result, not the observer — record at
+   the call site after the await):
+   - `git_requests.objects_pack_files`
+   - `git_requests.settings_response` (the 8 boolean flags from the settings response)
+   - `itr_skippable_tests.response_tests` / `response_suites`
+   - `known_tests.response_tests`
+   - `test_management_tests.response_tests`
+2. **`endpoint_payload.dropped`** — the `UploadObserver.uploadDropped` hook exists
+   but the worker has no retry-exhaustion drop today; failed batches stay on disk
+   and are age-purged by `FilesOrchestrator`. Wire `dropped` from the purge path
+   (or add an explicit drop) — see `DDTracer.endpointPayloadObservers` where
+   `onDropped` is already mapped to `endpointPayload.dropped`.
+3. **Local feature metrics** — emitted directly via `SessionConfig.telemetry` /
+   the feature's injected `Telemetry`, at the feature instrumentation sites:
+   - `events.created` / `events.finished` (+ all their tags: `event_type`,
+     `test_framework`, `is_new`, `is_modified`, `is_retry`, `retry_reason`,
+     `early_flake_detection_abort_reason`, `is_rum`, `browser_driver`, …) —
+     `DDSession`/`Module`/`Suite`/`Test` lifecycle.
+   - `session` (`test_session`) and `events.manualApiEvents` — `DDSession`.
+   - `events.enqueuedForSerialization`.
+   - `git.command` / `git.command_errors` / `git.command_ms` — local `git` CLI in
+     `GitUploader` / git info.
+   - `git.commit_sha_match` / `git.commit_sha_discrepancy` — git info providers.
+   - `itr.skipped` / `itr.unskippable` / `itr.forced_run` — `TestImpactAnalysis`.
+   - `code_coverage.{started,finished,is_empty,errors,files}` — coverage feature.
+4. **`impacted_tests_detection.*`** — no feature/API exists yet; instruments are
+   defined but unused.
+5. **`error_type` granularity** — `Telemetry.errorType(statusCode:)` maps `nil`
+   status to `.network`; it cannot distinguish `timeout` from `network` without
+   the underlying `URLError`. Refine if needed.
+
+---
+
+## 6. File map
+
+EventsExporter:
+- `Telemetry/MetricObservers.swift` — observer protocols + `ExporterObservers`.
+- `Telemetry/TelemetryExporter.swift` / `TelemetryMetricExporter.swift` — DD
+  telemetry intake pipeline (built in SDTEST-3772/3773).
+- `API/HTTPClient.swift` — `RequestObserver` measurement; `HTTPClientType` protocol.
+- `API/*.swift` — `observer:` param on every method + `@inlinable` conveniences.
+- `Upload/DataUploadWorker.swift`, `Utils/Feature.swift` — `UploadObserver`.
+- `Persistence/FileWriter.swift` — `PayloadObserver`.
+- `{Spans,Coverage}Exporter.swift`, `Exporter.swift` — observer plumbing.
+
+DatadogSDKTesting:
+- `Telemetry/Telemetry.swift` — manager + meter provider.
+- `Telemetry/TelemetryMetrics.swift` — typed metric tree.
+- `Telemetry/TelemetryTags.swift` — tag enums.
+- `Telemetry/TelemetryObservers.swift` — observer adapters + per-family observers.
+- `DDTracer.swift` — `Telemetry` creation, `exporterObservers(...)`.
+- `Config.swift` / `Environment/EnvironmentKeys.swift` — the two env flags.
+- `SessionManager.swift` / `Models.swift` (`SessionConfig`) — sharing.
+- `DDTestMonitor.swift`, `KnownTests.swift`, `TestManagement.swift`,
+  `TestImpactAnalysis/*.swift` — `Telemetry` injected into feature factories.

--- a/Sources/DatadogSDKTesting/Telemetry/TelemetryObservers.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/TelemetryObservers.swift
@@ -1,0 +1,144 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+internal import EventsExporter
+
+// MARK: - Adapters bridging EventsExporter observers to the telemetry metrics
+
+/// These adapters conform to the neutral observer protocols `EventsExporter`
+/// reports through (`RequestObserver` / `UploadObserver` / `PayloadObserver`)
+/// and forward the facts to caller-supplied closures. The call site (which
+/// knows the metric family and tags) wires the closures to the relevant
+/// `Telemetry.metrics.*` instruments; the common `statusCode → ErrorType`
+/// mapping lives here so every call site agrees on it.
+extension Telemetry {
+    /// Maps an HTTP status code (or its absence) to the telemetry `error_type`.
+    /// A `nil` status code means a transport failure with no response.
+    static func errorType(statusCode: Int?) -> ErrorType {
+        guard let code = statusCode else { return .network }
+        switch code {
+        case 400 ..< 500: return .statusCode4xx
+        case 500 ..< 600: return .statusCode5xx
+        default: return .network
+        }
+    }
+
+    /// Bridges a single HTTP request's facts to per-family metric closures.
+    /// Each closure is optional so a family only wires the metrics it has.
+    struct RequestMetricsObserver: RequestObserver {
+        /// The request happened (counted regardless of success).
+        var onRequest: (@Sendable () -> Void)? = nil
+        /// Request round-trip duration, in milliseconds.
+        var onDurationMs: (@Sendable (Double) -> Void)? = nil
+        /// Size of the serialized request payload, in bytes.
+        var onRequestBytes: (@Sendable (Int) -> Void)? = nil
+        /// Size of the received response body, in bytes.
+        var onResponseBytes: (@Sendable (Int) -> Void)? = nil
+        /// The request failed; the derived `error_type` is supplied.
+        var onError: (@Sendable (ErrorType) -> Void)? = nil
+
+        func requestFinished(durationMs: Double, requestBytes: Int, responseBytes: Int,
+                             statusCode: Int?, failed: Bool) {
+            onRequest?()
+            onDurationMs?(durationMs)
+            onRequestBytes?(requestBytes)
+            onResponseBytes?(responseBytes)
+            if failed { onError?(Telemetry.errorType(statusCode: statusCode)) }
+        }
+    }
+
+    /// Bridges the background upload pipeline's batch lifecycle to closures.
+    struct UploadMetricsObserver: UploadObserver {
+        var onAttempt: (@Sendable (_ payloadBytes: Int, _ durationMs: Double, _ success: Bool, _ retriable: Bool) -> Void)? = nil
+        var onDropped: (@Sendable (_ payloadBytes: Int) -> Void)? = nil
+
+        func uploadAttempt(payloadBytes: Int, durationMs: Double, success: Bool, retriable: Bool) {
+            onAttempt?(payloadBytes, durationMs, success, retriable)
+        }
+
+        func uploadDropped(payloadBytes: Int) {
+            onDropped?(payloadBytes)
+        }
+    }
+
+    /// Bridges payload serialization facts (`events_count` /
+    /// `events_serialization_ms`) to a closure.
+    struct PayloadMetricsObserver: PayloadObserver {
+        var onFinalized: (@Sendable (_ eventCount: Int, _ serializationMs: Double) -> Void)? = nil
+
+        func payloadFinalized(eventCount: Int, serializationMs: Double) {
+            onFinalized?(eventCount, serializationMs)
+        }
+    }
+}
+
+// MARK: - Per-family request observers
+
+/// Ready-made `RequestObserver`s that map an API request's transport facts to a
+/// metric family (`request` / `*_ms` / `*_errors`, plus `response_bytes` /
+/// request `bytes` where the family has them). Feature call sites pass these
+/// into the API methods. Response item counts (e.g. `response_tests`) come from
+/// the parsed result at the call site, not from these observers.
+extension Telemetry {
+    var gitSettingsRequestObserver: RequestMetricsObserver {
+        let m = metrics.gitRequests
+        return RequestMetricsObserver(
+            onRequest: { m.settings.add() },
+            onDurationMs: { m.settingsMs.record($0) },
+            onError: { m.settingsErrors.add(errorType: $0) }
+        )
+    }
+
+    var gitSearchCommitsRequestObserver: RequestMetricsObserver {
+        let m = metrics.gitRequests
+        return RequestMetricsObserver(
+            onRequest: { m.searchCommits.add() },
+            onDurationMs: { m.searchCommitsMs.record($0) },
+            onError: { m.searchCommitsErrors.add(errorType: $0) }
+        )
+    }
+
+    var gitObjectsPackRequestObserver: RequestMetricsObserver {
+        let m = metrics.gitRequests
+        return RequestMetricsObserver(
+            onRequest: { m.objectsPack.add() },
+            onDurationMs: { m.objectsPackMs.record($0) },
+            onRequestBytes: { m.objectsPackBytes.record(Double($0)) },
+            onError: { m.objectsPackErrors.add(errorType: $0) }
+        )
+    }
+
+    var skippableTestsRequestObserver: RequestMetricsObserver {
+        let m = metrics.itrSkippableTests
+        return RequestMetricsObserver(
+            onRequest: { m.request.add() },
+            onDurationMs: { m.requestMs.record($0) },
+            onResponseBytes: { m.responseBytes.record(Double($0)) },
+            onError: { m.requestErrors.add(errorType: $0) }
+        )
+    }
+
+    var knownTestsRequestObserver: RequestMetricsObserver {
+        let m = metrics.knownTests
+        return RequestMetricsObserver(
+            onRequest: { m.request.add() },
+            onDurationMs: { m.requestMs.record($0) },
+            onResponseBytes: { m.responseBytes.record(Double($0)) },
+            onError: { m.requestErrors.add(errorType: $0) }
+        )
+    }
+
+    var testManagementRequestObserver: RequestMetricsObserver {
+        let m = metrics.testManagementTests
+        return RequestMetricsObserver(
+            onRequest: { m.request.add() },
+            onDurationMs: { m.requestMs.record($0) },
+            onResponseBytes: { m.responseBytes.record(Double($0)) },
+            onError: { m.requestErrors.add(errorType: $0) }
+        )
+    }
+}

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/GitUploader.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/GitUploader.swift
@@ -15,12 +15,14 @@ final class GitUploader {
     private let log: Logger
     private let api: GitUploadApi
     private let unshallowEnabled: Bool
+    private let telemetry: Telemetry?
 
     private let commitFolder: Directory
     private let packFilesDirectory: Directory
 
     init?(log: Logger, api: GitUploadApi, gitDirectory: String,
-          commitFolder: Directory?, unshallowEnabled: Bool = true)
+          commitFolder: Directory?, unshallowEnabled: Bool = true,
+          telemetry: Telemetry? = nil)
     {
         guard !gitDirectory.isEmpty,
               let commitFolder = commitFolder,
@@ -32,6 +34,7 @@ final class GitUploader {
         self.gitDirectory = gitDirectory
         self.api = api
         self.unshallowEnabled = unshallowEnabled
+        self.telemetry = telemetry
         self.packFilesDirectory = packFilesDir
         self.commitFolder = commitFolder
         self.log = log
@@ -108,7 +111,8 @@ final class GitUploader {
             try await log.measure(name: "uploadExistingPackfiles") { () async throws(APICallError) in
                 try await api.uploadPackFiles(directory: directory.url,
                                               commit: commit,
-                                              repositoryURL: repository)
+                                              repositoryURL: repository,
+                                              observer: telemetry?.gitObjectsPackRequestObserver)
             }
         } catch {
             let err = LibraryConfigurationCommunicationError(
@@ -149,7 +153,8 @@ final class GitUploader {
         do {
             existingCommits = try await log.measure(name: "searchRepositoryCommits") { () async throws(APICallError) in
                 try await api.searchCommits(repositoryURL: repositoryURL,
-                                            commits: latestCommits)
+                                            commits: latestCommits,
+                                            observer: telemetry?.gitSearchCommitsRequestObserver)
             }
         } catch {
             let err = LibraryConfigurationCommunicationError(

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysis.swift
@@ -183,6 +183,7 @@ struct TestImpactAnalysisFactory: FeatureFactory {
     let api: TestImpactAnalysisApi
     let skippingEnabled: Bool
     let swiftTestingEnabled: Bool
+    let telemetry: Telemetry?
 
     init(configurations: [String: String],
          custom: [String: String],
@@ -190,7 +191,7 @@ struct TestImpactAnalysisFactory: FeatureFactory {
          service: String, environment: String,
          commit: String, repository: String,
          cache: Directory, skippingEnabled: Bool,
-         swiftTestingEnabled: Bool)
+         swiftTestingEnabled: Bool, telemetry: Telemetry? = nil)
     {
         self.configurations = configurations
         self.customConfigurations = custom
@@ -202,6 +203,7 @@ struct TestImpactAnalysisFactory: FeatureFactory {
         self.commitSha = commit
         self.skippingEnabled = skippingEnabled
         self.swiftTestingEnabled = swiftTestingEnabled
+        self.telemetry = telemetry
     }
 
     static func isEnabled(config: Config, env: Environment, remote: TracerSettings) -> Bool {
@@ -271,7 +273,8 @@ struct TestImpactAnalysisFactory: FeatureFactory {
                                                 environment: environment, service: service,
                                                 testLevel: .test,
                                                 configurations: configurations,
-                                                customConfigurations: customConfigurations)
+                                                customConfigurations: customConfigurations,
+                                                observer: telemetry?.skippableTestsRequestObserver)
         } catch {
             throw LibraryConfigurationCommunicationError(
                 requestName: "SkipTestsRequest",

--- a/Sources/DatadogSDKTesting/TestManagement.swift
+++ b/Sources/DatadogSDKTesting/TestManagement.swift
@@ -192,10 +192,11 @@ struct TestManagementFactory: FeatureFactory {
     let cacheFolder: Directory
     let api: TestManagementApi
     let module: String
+    let telemetry: Telemetry?
 
     init(repository: String, commitSha: String, commitMessage: String?, branch: String?,
          module: String, attemptToFixRetries: UInt,
-         api: TestManagementApi, cache: Directory)
+         api: TestManagementApi, cache: Directory, telemetry: Telemetry? = nil)
     {
         self.cacheFolder = cache
         self.repository = repository
@@ -205,6 +206,7 @@ struct TestManagementFactory: FeatureFactory {
         self.attemptToFixRetries = attemptToFixRetries
         self.api = api
         self.module = module
+        self.telemetry = telemetry
     }
 
     static func isEnabled(config: Config, env: Environment, remote: TracerSettings) -> Bool {
@@ -244,7 +246,8 @@ struct TestManagementFactory: FeatureFactory {
         do {
             tests = try await api.tests(repositoryURL: repository, sha: commitSha,
                                         commitMessage: commitMessage, branch: branch,
-                                        module: module)
+                                        module: module,
+                                        observer: telemetry?.testManagementRequestObserver)
         } catch {
             throw LibraryConfigurationCommunicationError(
                 requestName: "Test Management Tests Request",

--- a/Sources/EventsExporter/API/APITypes.swift
+++ b/Sources/EventsExporter/API/APITypes.swift
@@ -85,7 +85,7 @@ public protocol APIService {
 }
 
 internal protocol APIServiceConstructible: APIService {
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger)
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger)
 }
 
 protocol APIVoidValue {
@@ -426,12 +426,13 @@ extension JSONDecoder {
     }
 }
 
-extension HTTPClient {
+extension HTTPClientType {
     func call<Request, Response>(
         _ call: APICall<Request, Response>.Type,
         url: URL, meta: Request.Meta, data: Request,
         headers: [HTTPHeader]? = nil,
-        coders: (JSONEncoder, JSONDecoder) = (.apiEncoder, .apiDecoder)
+        coders: (JSONEncoder, JSONDecoder) = (.apiEncoder, .apiDecoder),
+        observer: RequestObserver? = nil
     ) async throws(APICallError) -> APIEnvelope<Response>
     where Request: APIRequestData, Response: APIResponseData
     {
@@ -444,7 +445,7 @@ extension HTTPClient {
         }
         request.httpBody = requestData
 
-        let body: Data = try await sendWithResponse(api: request)
+        let body: Data = try await sendWithResponse(api: request, observer: observer)
         return try call.response(from: body, requestId: requestId, coder: coders.1)
     }
 
@@ -452,34 +453,35 @@ extension HTTPClient {
         _ call: APICall<Request, Response>.Type,
         url: URL, data: Request,
         headers: [HTTPHeader]? = nil,
-        coders: (JSONEncoder, JSONDecoder) = (.apiEncoder, .apiDecoder)
+        coders: (JSONEncoder, JSONDecoder) = (.apiEncoder, .apiDecoder),
+        observer: RequestObserver? = nil
     ) async throws(APICallError) -> APIEnvelope<Response>
     where Request: APIRequestData, Response: APIResponseData, Request.Meta: APIVoidValue
     {
-        try await self.call(call, url: url, meta: .void, data: data, headers: headers, coders: coders)
-    }
-    
-    func send(api request: URLRequest) async throws(APICallError) -> HTTPURLResponse {
-        do {
-            return try await send(request: request)
-        } catch {
-            throw APICallError(from: error)
-        }
-    }
-    
-    func sendWithResponse(api request: URLRequest) async throws(APICallError) -> Data {
-        do {
-            return try await sendWithResponse(request: request)
-        } catch {
-            throw APICallError(from: error)
-        }
-    }
-    
-    func send(api request: MultipartFormURLRequest) async throws(APICallError) -> HTTPURLResponse {
-        try await send(api: request.asURLRequest)
+        try await self.call(call, url: url, meta: .void, data: data, headers: headers, coders: coders, observer: observer)
     }
 
-    func sendWithResponse(api request: MultipartFormURLRequest) async throws(APICallError) -> Data {
-        try await sendWithResponse(api: request.asURLRequest)
+    func send(api request: URLRequest, observer: RequestObserver? = nil) async throws(APICallError) -> HTTPURLResponse {
+        do {
+            return try await send(request: request, observer: observer)
+        } catch {
+            throw APICallError(from: error)
+        }
+    }
+
+    func sendWithResponse(api request: URLRequest, observer: RequestObserver? = nil) async throws(APICallError) -> Data {
+        do {
+            return try await sendWithResponse(request: request, observer: observer)
+        } catch {
+            throw APICallError(from: error)
+        }
+    }
+
+    func send(api request: MultipartFormURLRequest, observer: RequestObserver? = nil) async throws(APICallError) -> HTTPURLResponse {
+        try await send(api: request.asURLRequest, observer: observer)
+    }
+
+    func sendWithResponse(api request: MultipartFormURLRequest, observer: RequestObserver? = nil) async throws(APICallError) -> Data {
+        try await sendWithResponse(api: request.asURLRequest, observer: observer)
     }
 }

--- a/Sources/EventsExporter/API/GitUploadApi.swift
+++ b/Sources/EventsExporter/API/GitUploadApi.swift
@@ -7,18 +7,22 @@
 import Foundation
 
 public protocol GitUploadApi: APIService {
-    func searchCommits(repositoryURL: String, commits: [String]) async throws(APICallError) -> [String]
+    func searchCommits(repositoryURL: String, commits: [String],
+                       observer: RequestObserver?) async throws(APICallError) -> [String]
 
-    func uploadPackFile(file: URL, commit: String, repositoryURL: String) async throws(APICallError)
+    func uploadPackFile(file: URL, commit: String, repositoryURL: String,
+                        observer: RequestObserver?) async throws(APICallError)
 
     func uploadPackFile(name: String, data: Data, commit: String,
-                        repositoryURL: String) async throws(APICallError)
+                        repositoryURL: String, observer: RequestObserver?) async throws(APICallError)
 
-    func uploadPackFiles(directory: URL, commit: String, repositoryURL: String) async throws(APICallError)
+    func uploadPackFiles(directory: URL, commit: String, repositoryURL: String,
+                         observer: RequestObserver?) async throws(APICallError)
 }
 
 extension GitUploadApi {
-    public func uploadPackFile(file: URL, commit: String, repositoryURL: String) async throws(APICallError) {
+    public func uploadPackFile(file: URL, commit: String, repositoryURL: String,
+                               observer: RequestObserver?) async throws(APICallError) {
         let data: Data
         do {
             data = try Data(contentsOf: file, options: [.mappedIfSafe])
@@ -26,10 +30,11 @@ extension GitUploadApi {
             throw APICallError.fileSystem(error)
         }
         try await uploadPackFile(name: file.lastPathComponent, data: data,
-                                 commit: commit, repositoryURL: repositoryURL)
+                                 commit: commit, repositoryURL: repositoryURL, observer: observer)
     }
 
-    public func uploadPackFiles(directory: URL, commit: String, repositoryURL: String) async throws(APICallError) {
+    public func uploadPackFiles(directory: URL, commit: String, repositoryURL: String,
+                                observer: RequestObserver?) async throws(APICallError) {
         let files: [URL]
         do {
             files = try FileManager.default
@@ -44,7 +49,7 @@ extension GitUploadApi {
                 for file in files {
                     group.addTask {
                         try await self.uploadPackFile(file: file, commit: commit,
-                                                      repositoryURL: repositoryURL)
+                                                      repositoryURL: repositoryURL, observer: observer)
                     }
                 }
                 while try await group.next() != nil {}
@@ -54,6 +59,30 @@ extension GitUploadApi {
         } catch {
             throw .unknownError(error)
         }
+    }
+
+    // MARK: - Convenience without a telemetry observer
+
+    @inlinable
+    public func searchCommits(repositoryURL: String, commits: [String]) async throws(APICallError) -> [String] {
+        try await searchCommits(repositoryURL: repositoryURL, commits: commits, observer: nil)
+    }
+
+    @inlinable
+    public func uploadPackFile(file: URL, commit: String, repositoryURL: String) async throws(APICallError) {
+        try await uploadPackFile(file: file, commit: commit, repositoryURL: repositoryURL, observer: nil)
+    }
+
+    @inlinable
+    public func uploadPackFile(name: String, data: Data, commit: String,
+                               repositoryURL: String) async throws(APICallError) {
+        try await uploadPackFile(name: name, data: data, commit: commit,
+                                 repositoryURL: repositoryURL, observer: nil)
+    }
+
+    @inlinable
+    public func uploadPackFiles(directory: URL, commit: String, repositoryURL: String) async throws(APICallError) {
+        try await uploadPackFiles(directory: directory, commit: commit, repositoryURL: repositoryURL, observer: nil)
     }
 }
 
@@ -65,10 +94,10 @@ struct GitUploadApiService: GitUploadApi, APIServiceConstructible {
     var encoder: JSONEncoder
     var decoder: JSONDecoder
     let compression: Bool
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClientType
     let log: Logger
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log
@@ -78,7 +107,8 @@ struct GitUploadApiService: GitUploadApi, APIServiceConstructible {
         self.decoder = config.decoder
     }
 
-    func searchCommits(repositoryURL: String, commits: [String]) async throws(APICallError) -> [String] {
+    func searchCommits(repositoryURL: String, commits: [String],
+                       observer: RequestObserver?) async throws(APICallError) -> [String] {
         let meta = CommitRequestMeta(repositoryUrl: repositoryURL)
         let request = commits.map { APIData<CommitRequestMeta, Commit>(id: $0) }
         let log = self.log
@@ -87,13 +117,14 @@ struct GitUploadApiService: GitUploadApi, APIServiceConstructible {
                                                  url: endpoint.searchCommitsURL,
                                                  meta: meta, data: request,
                                                  headers: headers + [.contentTypeHeader(contentType: .applicationJSON)],
-                                                 coders: (encoder, decoder))
+                                                 coders: (encoder, decoder),
+                                                 observer: observer)
         log.debug("Search commits response: \(response.data)")
         return response.data.map { $0.id! }
     }
 
     func uploadPackFile(name: String, data: Data, commit: String,
-                        repositoryURL: String) async throws(APICallError)
+                        repositoryURL: String, observer: RequestObserver?) async throws(APICallError)
     {
         let log = self.log
         let meta = CommitRequestMeta(repositoryUrl: repositoryURL)
@@ -113,7 +144,7 @@ struct GitUploadApiService: GitUploadApi, APIServiceConstructible {
                        fileName: name,
                        contentType: .applicationOctetStream)
         log.debug("Uploading packfile \(name) for commit \(commit)")
-        let _ = try await httpClient.send(api: request)
+        let _ = try await httpClient.send(api: request, observer: observer)
         log.debug("Packfile upload succeeded for \(name)")
     }
 

--- a/Sources/EventsExporter/API/HTTPClient.swift
+++ b/Sources/EventsExporter/API/HTTPClient.swift
@@ -7,10 +7,23 @@
 import Foundation
 
 internal protocol HTTPClientType: AnyObject, Sendable {
-    /// Send the request and return the response (no body).
-    func send(request: URLRequest) async throws(HTTPClient.RequestError) -> HTTPURLResponse
+    /// Send the request and return the response (no body). `observer`, when
+    /// provided, is notified once with the request's transport facts.
+    func send(request: URLRequest, observer: RequestObserver?) async throws(HTTPClient.RequestError) -> HTTPURLResponse
     /// Send the request and return the response body.
-    func sendWithResponse(request: URLRequest) async throws(HTTPClient.RequestError) -> Data
+    func sendWithResponse(request: URLRequest, observer: RequestObserver?) async throws(HTTPClient.RequestError) -> Data
+}
+
+extension HTTPClientType {
+    /// Send the request and return the response (no body).
+    func send(request: URLRequest) async throws(HTTPClient.RequestError) -> HTTPURLResponse {
+        try await send(request: request, observer: nil)
+    }
+
+    /// Send the request and return the response body.
+    func sendWithResponse(request: URLRequest) async throws(HTTPClient.RequestError) -> Data {
+        try await sendWithResponse(request: request, observer: nil)
+    }
 }
 
 /// Client for sending requests over HTTP.
@@ -80,23 +93,38 @@ public final class HTTPClient: HTTPClientType {
     }
 
     /// Send the request and return the response (no body).
-    func send(request: URLRequest) async throws(RequestError) -> HTTPURLResponse {
-        try await perform(request) { httpClientResult(for: $0) }
+    func send(request: URLRequest, observer: RequestObserver?) async throws(RequestError) -> HTTPURLResponse {
+        try await perform(request, observer: observer) { httpClientResult(for: $0) }
     }
 
     /// Send the request and return the response body.
-    func sendWithResponse(request: URLRequest) async throws(RequestError) -> Data {
-        try await perform(request) { httpClientResultWithData(for: $0) }
+    func sendWithResponse(request: URLRequest, observer: RequestObserver?) async throws(RequestError) -> Data {
+        try await perform(request, observer: observer) { httpClientResultWithData(for: $0) }
     }
 
     private func perform<T>(
         _ request: URLRequest,
+        observer: RequestObserver?,
         _ resultMapping: @escaping (_ taskResult: (Data?, URLResponse?, Error?)) -> Result<T, RequestError>
     ) async throws(RequestError) -> T {
+        // Capture the serialized payload size before `deflate` so it reflects
+        // the logical request size rather than the compressed wire size.
+        let requestBytes = request.httpBody?.count ?? 0
         let request = deflate(request)
+        let start = observer != nil ? DispatchTime.now() : nil
         let result: Result<T, RequestError> = await withCheckedContinuation { continuation in
             let task = session.dataTask(with: request) { data, response, error in
                 self.log(request: request, response: (data, response, error))
+                if let observer, let start {
+                    let durationMs = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+                    let statusCode = (response as? HTTPURLResponse)?.statusCode
+                    let success = error == nil && (statusCode.map { (200 ..< 400).contains($0) } ?? false)
+                    observer.requestFinished(durationMs: durationMs,
+                                             requestBytes: requestBytes,
+                                             responseBytes: data?.count ?? 0,
+                                             statusCode: statusCode,
+                                             failed: !success)
+                }
                 continuation.resume(returning: resultMapping((data, response, error)))
             }
             task.resume()

--- a/Sources/EventsExporter/API/KnownTestsApi.swift
+++ b/Sources/EventsExporter/API/KnownTestsApi.swift
@@ -49,14 +49,16 @@ public protocol KnownTestsApi: APIService {
         service: String, env: String, repositoryURL: String,
         configurations: [String: String],
         customConfigurations: [String: String],
-        page: KnownTestsPageInfo
+        page: KnownTestsPageInfo,
+        observer: RequestObserver?
     ) async throws(APICallError) -> KnownTestsResult
 
     /// Fetch all pages of known tests and merge them.
     func tests(
         service: String, env: String, repositoryURL: String,
         configurations: [String: String],
-        customConfigurations: [String: String]
+        customConfigurations: [String: String],
+        observer: RequestObserver?
     ) async throws(APICallError) -> KnownTestsResult
 }
 
@@ -64,7 +66,8 @@ extension KnownTestsApi {
     public func tests(
         service: String, env: String, repositoryURL: String,
         configurations: [String: String],
-        customConfigurations: [String: String]
+        customConfigurations: [String: String],
+        observer: RequestObserver?
     ) async throws(APICallError) -> KnownTestsResult {
         var tests: KnownTestsMap = [:]
         var page: KnownTestsPageInfo = .init()
@@ -73,7 +76,7 @@ extension KnownTestsApi {
             let result = try await self.tests(
                 service: service, env: env, repositoryURL: repositoryURL,
                 configurations: configurations, customConfigurations: customConfigurations,
-                page: page
+                page: page, observer: observer
             )
             tests = tests.merging(result.tests) { (current, new) in
                 current.merging(new) { (current, new) in
@@ -90,6 +93,31 @@ extension KnownTestsApi {
                                                 size: size,
                                                 hasNext: page.hasNext))
     }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func tests(
+        service: String, env: String, repositoryURL: String,
+        configurations: [String: String],
+        customConfigurations: [String: String],
+        page: KnownTestsPageInfo
+    ) async throws(APICallError) -> KnownTestsResult {
+        try await tests(service: service, env: env, repositoryURL: repositoryURL,
+                        configurations: configurations, customConfigurations: customConfigurations,
+                        page: page, observer: nil)
+    }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func tests(
+        service: String, env: String, repositoryURL: String,
+        configurations: [String: String],
+        customConfigurations: [String: String]
+    ) async throws(APICallError) -> KnownTestsResult {
+        try await tests(service: service, env: env, repositoryURL: repositoryURL,
+                        configurations: configurations, customConfigurations: customConfigurations,
+                        observer: nil)
+    }
 }
 
 struct KnownTestsApiService: KnownTestsApi, APIServiceConstructible {
@@ -99,10 +127,10 @@ struct KnownTestsApiService: KnownTestsApi, APIServiceConstructible {
     var headers: [HTTPHeader]
     var encoder: JSONEncoder
     var decoder: JSONDecoder
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClientType
     let log: Logger
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log
@@ -115,7 +143,8 @@ struct KnownTestsApiService: KnownTestsApi, APIServiceConstructible {
                repositoryURL: String,
                configurations: [String: String],
                customConfigurations: [String: String],
-               page: KnownTestsPageInfo) async throws(APICallError) -> KnownTestsResult
+               page: KnownTestsPageInfo,
+               observer: RequestObserver?) async throws(APICallError) -> KnownTestsResult
     {
         var configurations: [String: JSONGeneric] = configurations.mapValues { .string($0) }
         configurations["custom"] = JSONGeneric(customConfigurations)
@@ -129,7 +158,8 @@ struct KnownTestsApiService: KnownTestsApi, APIServiceConstructible {
                                                  url: endpoint.knownTestsURL,
                                                  data: .init(attributes: request),
                                                  headers: headers + [.contentTypeHeader(contentType: .applicationJSON)],
-                                                 coders: (encoder, decoder))
+                                                 coders: (encoder, decoder),
+                                                 observer: observer)
         log.debug("Known tests response: \(response.data.attributes)")
         let attrs = response.data.attributes
         return KnownTestsResult(

--- a/Sources/EventsExporter/API/LogsApi.swift
+++ b/Sources/EventsExporter/API/LogsApi.swift
@@ -7,19 +7,31 @@
 import Foundation
 
 public protocol LogsApi: APIService {
-    func uploadLogs(batch url: URL) async throws(APICallError)
-    func uploadLogs(batch data: Data) async throws(APICallError)
+    func uploadLogs(batch url: URL, observer: RequestObserver?) async throws(APICallError)
+    func uploadLogs(batch data: Data, observer: RequestObserver?) async throws(APICallError)
 }
 
 extension LogsApi {
-    public func uploadLogs(batch url: URL) async throws(APICallError) {
+    public func uploadLogs(batch url: URL, observer: RequestObserver?) async throws(APICallError) {
         let data: Data
         do {
             data = try Data(contentsOf: url, options: [.mappedIfSafe])
         } catch {
             throw .fileSystem(error)
         }
-        try await uploadLogs(batch: data)
+        try await uploadLogs(batch: data, observer: observer)
+    }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func uploadLogs(batch url: URL) async throws(APICallError) {
+        try await uploadLogs(batch: url, observer: nil)
+    }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func uploadLogs(batch data: Data) async throws(APICallError) {
+        try await uploadLogs(batch: data, observer: nil)
     }
 }
 
@@ -28,11 +40,11 @@ struct LogsApiService: LogsApi, APIServiceConstructible {
     var headers: [HTTPHeader]
     var encoder: JSONEncoder
     var decoder: JSONDecoder
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClientType
     let compression: Bool
     let log: Logger
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log
@@ -42,7 +54,7 @@ struct LogsApiService: LogsApi, APIServiceConstructible {
         self.decoder = config.decoder
     }
 
-    func uploadLogs(batch data: Data) async throws(APICallError) {
+    func uploadLogs(batch data: Data, observer: RequestObserver?) async throws(APICallError) {
         var url = endpoint.logsURL
         url.appendQueryItems([
             .ddsource(source: LogQueryValues.ddsource),
@@ -58,7 +70,7 @@ struct LogsApiService: LogsApi, APIServiceConstructible {
         request.httpBody = data
         let log = self.log
         log.debug("Uploading logs...")
-        let _ = try await httpClient.send(api: request)
+        let _ = try await httpClient.send(api: request, observer: observer)
         log.debug("Logs upload succeeded")
     }
 

--- a/Sources/EventsExporter/API/SettingsApi.swift
+++ b/Sources/EventsExporter/API/SettingsApi.swift
@@ -11,7 +11,24 @@ public protocol SettingsApi: APIService {
                         repositoryURL: String, branch: String, sha: String,
                         testLevel: ITRTestLevel,
                         configurations: [String: String],
+                        customConfigurations: [String: String],
+                        observer: RequestObserver?) async throws(APICallError) -> TracerSettings
+}
+
+public extension SettingsApi {
+    /// Convenience without a telemetry observer.
+    @inlinable
+    func tracerSettings(service: String, env: String,
+                        repositoryURL: String, branch: String, sha: String,
+                        testLevel: ITRTestLevel,
+                        configurations: [String: String],
                         customConfigurations: [String: String]) async throws(APICallError) -> TracerSettings
+    {
+        try await tracerSettings(service: service, env: env, repositoryURL: repositoryURL,
+                                 branch: branch, sha: sha, testLevel: testLevel,
+                                 configurations: configurations,
+                                 customConfigurations: customConfigurations, observer: nil)
+    }
 }
 
 public struct TracerSettings {
@@ -147,10 +164,10 @@ struct SettingsApiService: SettingsApi, APIServiceConstructible {
     var headers: [HTTPHeader]
     var encoder: JSONEncoder
     var decoder: JSONDecoder
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClientType
     let log: Logger
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log
@@ -163,7 +180,8 @@ struct SettingsApiService: SettingsApi, APIServiceConstructible {
                         repositoryURL: String, branch: String, sha: String,
                         testLevel: ITRTestLevel,
                         configurations: [String: String],
-                        customConfigurations: [String: String]) async throws(APICallError) -> TracerSettings
+                        customConfigurations: [String: String],
+                        observer: RequestObserver?) async throws(APICallError) -> TracerSettings
     {
         var configurations: [String: JSONGeneric] = configurations.mapValues { .string($0) }
         configurations["custom"] = JSONGeneric(customConfigurations)
@@ -180,7 +198,8 @@ struct SettingsApiService: SettingsApi, APIServiceConstructible {
                                                  url: endpoint.settingsURL,
                                                  data: .init(attributes: request),
                                                  headers: headers + [.contentTypeHeader(contentType: .applicationJSON)],
-                                                 coders: (encoder, decoder))
+                                                 coders: (encoder, decoder),
+                                                 observer: observer)
         log.debug("Tracer settings response: \(response.data.attributes)")
         return TracerSettings(response: response.data.attributes)
     }

--- a/Sources/EventsExporter/API/SpansApi.swift
+++ b/Sources/EventsExporter/API/SpansApi.swift
@@ -7,19 +7,31 @@
 import Foundation
 
 public protocol SpansApi: APIService {
-    func uploadSpans(batch url: URL) async throws(APICallError)
-    func uploadSpans(batch data: Data) async throws(APICallError)
+    func uploadSpans(batch url: URL, observer: RequestObserver?) async throws(APICallError)
+    func uploadSpans(batch data: Data, observer: RequestObserver?) async throws(APICallError)
 }
 
 extension SpansApi {
-    public func uploadSpans(batch url: URL) async throws(APICallError) {
+    public func uploadSpans(batch url: URL, observer: RequestObserver?) async throws(APICallError) {
         let data: Data
         do {
             data = try Data(contentsOf: url, options: [.mappedIfSafe])
         } catch {
             throw .fileSystem(error)
         }
-        try await uploadSpans(batch: data)
+        try await uploadSpans(batch: data, observer: observer)
+    }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func uploadSpans(batch url: URL) async throws(APICallError) {
+        try await uploadSpans(batch: url, observer: nil)
+    }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func uploadSpans(batch data: Data) async throws(APICallError) {
+        try await uploadSpans(batch: data, observer: nil)
     }
 }
 
@@ -29,10 +41,10 @@ struct SpansApiService: SpansApi, APIServiceConstructible {
     var encoder: JSONEncoder
     var decoder: JSONDecoder
     let compression: Bool
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClientType
     let log: Logger
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log
@@ -42,7 +54,7 @@ struct SpansApiService: SpansApi, APIServiceConstructible {
         self.decoder = config.decoder
     }
 
-    func uploadSpans(batch data: Data) async throws(APICallError) {
+    func uploadSpans(batch data: Data, observer: RequestObserver?) async throws(APICallError) {
         var request = URLRequest(url: endpoint.spansURL)
         request.httpMethod = "POST"
         request.httpHeaders = headers
@@ -53,7 +65,7 @@ struct SpansApiService: SpansApi, APIServiceConstructible {
         request.httpBody = data
         let log = self.log
         log.debug("Uploading spans...")
-        let _ = try await httpClient.send(api: request)
+        let _ = try await httpClient.send(api: request, observer: observer)
         log.debug("Spans upload succeeded")
     }
 

--- a/Sources/EventsExporter/API/TelemetryApi.swift
+++ b/Sources/EventsExporter/API/TelemetryApi.swift
@@ -508,7 +508,7 @@ internal struct TelemetryApiService: TelemetryApi {
     var encoder: JSONEncoder
     var decoder: JSONDecoder
     let compression: Bool
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClientType
     let log: Logger
     let dateProvider: DateProvider
 
@@ -522,7 +522,7 @@ internal struct TelemetryApiService: TelemetryApi {
     /// telemetry requests within a runtime.
     private let seq: Synced<UInt64>
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, dateProvider: DateProvider, log: Logger) {
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, dateProvider: DateProvider, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log

--- a/Sources/EventsExporter/API/TestImpactAnalysisApi.swift
+++ b/Sources/EventsExporter/API/TestImpactAnalysisApi.swift
@@ -46,21 +46,47 @@ public protocol TestImpactAnalysisApi: APIService {
     func skippableTests(repositoryURL: String, sha: String,
                         environment: String, service: String,
                         testLevel: ITRTestLevel, configurations: [String: String],
-                        customConfigurations: [String: String]) async throws(APICallError) -> SkipTests
+                        customConfigurations: [String: String],
+                        observer: RequestObserver?) async throws(APICallError) -> SkipTests
 
-    func uploadCoverage(batch url: URL) async throws(APICallError)
-    func uploadCoverage(batch data: Data) async throws(APICallError)
+    func uploadCoverage(batch url: URL, observer: RequestObserver?) async throws(APICallError)
+    func uploadCoverage(batch data: Data, observer: RequestObserver?) async throws(APICallError)
 }
 
 extension TestImpactAnalysisApi {
-    public func uploadCoverage(batch url: URL) async throws(APICallError) {
+    public func uploadCoverage(batch url: URL, observer: RequestObserver?) async throws(APICallError) {
         let data: Data
         do {
             data = try Data(contentsOf: url, options: [.mappedIfSafe])
         } catch {
             throw .fileSystem(error)
         }
-        try await uploadCoverage(batch: data)
+        try await uploadCoverage(batch: data, observer: observer)
+    }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func skippableTests(repositoryURL: String, sha: String,
+                               environment: String, service: String,
+                               testLevel: ITRTestLevel, configurations: [String: String],
+                               customConfigurations: [String: String]) async throws(APICallError) -> SkipTests
+    {
+        try await skippableTests(repositoryURL: repositoryURL, sha: sha,
+                                 environment: environment, service: service,
+                                 testLevel: testLevel, configurations: configurations,
+                                 customConfigurations: customConfigurations, observer: nil)
+    }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func uploadCoverage(batch url: URL) async throws(APICallError) {
+        try await uploadCoverage(batch: url, observer: nil)
+    }
+
+    /// Convenience without a telemetry observer.
+    @inlinable
+    public func uploadCoverage(batch data: Data) async throws(APICallError) {
+        try await uploadCoverage(batch: data, observer: nil)
     }
 }
 
@@ -72,10 +98,10 @@ struct TestImpactAnalysisApiService: TestImpactAnalysisApi, APIServiceConstructi
     var encoder: JSONEncoder
     var decoder: JSONDecoder
     let compression: Bool
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClientType
     let log: Logger
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log
@@ -88,7 +114,8 @@ struct TestImpactAnalysisApiService: TestImpactAnalysisApi, APIServiceConstructi
     func skippableTests(repositoryURL: String, sha: String,
                         environment: String, service: String,
                         testLevel: ITRTestLevel, configurations: [String: String],
-                        customConfigurations: [String: String]) async throws(APICallError) -> SkipTests
+                        customConfigurations: [String: String],
+                        observer: RequestObserver?) async throws(APICallError) -> SkipTests
     {
         var configurations: [String: JSONGeneric] = configurations.mapValues { .string($0) }
         configurations["custom"] = JSONGeneric(customConfigurations)
@@ -103,7 +130,8 @@ struct TestImpactAnalysisApiService: TestImpactAnalysisApi, APIServiceConstructi
                                                  url: endpoint.skippableTestsURL,
                                                  data: .init(attributes: request),
                                                  headers: headers + [.contentTypeHeader(contentType: .applicationJSON)],
-                                                 coders: (encoder, decoder))
+                                                 coders: (encoder, decoder),
+                                                 observer: observer)
         log.debug("Skippable tests response: \(response.data)")
         let correlationId = response.meta.correlationId
         let tests = response.data.attributes.map { test in
@@ -133,7 +161,7 @@ struct TestImpactAnalysisApiService: TestImpactAnalysisApi, APIServiceConstructi
         return SkipTests(correlationId: correlationId, tests: tests)
     }
 
-    func uploadCoverage(batch data: Data) async throws(APICallError) {
+    func uploadCoverage(batch data: Data, observer: RequestObserver?) async throws(APICallError) {
         var request = MultipartFormURLRequest(url: endpoint.coverageURL)
         request.headers = headers
         if compression {
@@ -147,7 +175,7 @@ struct TestImpactAnalysisApiService: TestImpactAnalysisApi, APIServiceConstructi
                        contentType: .applicationJSON)
         let log = self.log
         log.debug("Uploading coverage batch...")
-        let _ = try await httpClient.send(api: request)
+        let _ = try await httpClient.send(api: request, observer: observer)
         log.debug("Coverage batch accepted...")
     }
 

--- a/Sources/EventsExporter/API/TestManagementApi.swift
+++ b/Sources/EventsExporter/API/TestManagementApi.swift
@@ -8,8 +8,20 @@ import Foundation
 
 public protocol TestManagementApi: APIService {
     func tests(
-        repositoryURL: String, sha: String?, commitMessage: String?, branch: String?, module: String?
+        repositoryURL: String, sha: String?, commitMessage: String?, branch: String?, module: String?,
+        observer: RequestObserver?
     ) async throws(APICallError) -> TestManagementTestsInfo
+}
+
+public extension TestManagementApi {
+    /// Convenience without a telemetry observer.
+    @inlinable
+    func tests(
+        repositoryURL: String, sha: String?, commitMessage: String?, branch: String?, module: String?
+    ) async throws(APICallError) -> TestManagementTestsInfo {
+        try await tests(repositoryURL: repositoryURL, sha: sha, commitMessage: commitMessage,
+                        branch: branch, module: module, observer: nil)
+    }
 }
 
 public struct TestManagementTestsInfo: Codable {
@@ -73,10 +85,10 @@ struct TestManagementApiService: TestManagementApi, APIServiceConstructible {
     var headers: [HTTPHeader]
     var encoder: JSONEncoder
     var decoder: JSONDecoder
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClientType
     let log: Logger
 
-    init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger) {
+    init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger) {
         self.endpoint = config.endpoint
         self.httpClient = httpClient
         self.log = log
@@ -86,7 +98,8 @@ struct TestManagementApiService: TestManagementApi, APIServiceConstructible {
     }
 
     func tests(repositoryURL: String, sha: String?, commitMessage: String?,
-               branch: String?, module: String?) async throws(APICallError) -> TestManagementTestsInfo
+               branch: String?, module: String?,
+               observer: RequestObserver?) async throws(APICallError) -> TestManagementTestsInfo
     {
         let request = TestsRequest(repositoryUrl: repositoryURL,
                                    commitMessage: commitMessage,
@@ -99,7 +112,8 @@ struct TestManagementApiService: TestManagementApi, APIServiceConstructible {
                                                  url: endpoint.testManagementTestsURL,
                                                  data: .init(attributes: request),
                                                  headers: headers + [.contentTypeHeader(contentType: .applicationJSON)],
-                                                 coders: (encoder, decoder))
+                                                 coders: (encoder, decoder),
+                                                 observer: observer)
         log.debug("TestManagement tests response: \(response.data.attributes)")
         return TestManagementTestsInfo(modules: response.data.attributes.modules)
     }

--- a/Sources/EventsExporter/API/TestOptimizationApi.swift
+++ b/Sources/EventsExporter/API/TestOptimizationApi.swift
@@ -82,7 +82,7 @@ public struct TestOptimizationApiService: TestOptimizationApi {
     public private(set) var logs: LogsApi
     public private(set) var telemetry: TelemetryApi
 
-    internal init(config: APIServiceConfig, httpClient: HTTPClient, log: Logger,
+    internal init(config: APIServiceConfig, httpClient: any HTTPClientType, log: Logger,
                   dateProvider: DateProvider = SystemDateProvider())
     {
         settings = SettingsApiService(config: config, httpClient: httpClient, log: log)

--- a/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
+++ b/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
@@ -36,7 +36,8 @@ internal final class CoverageExporter: CoverageExporterType {
     let configuration: ExporterConfiguration
     let coverageStorage: FeatureStoreAndUpload
 
-    init(config: ExporterConfiguration, storage: Directory, api: TestImpactAnalysisApi) throws {
+    init(config: ExporterConfiguration, storage: Directory, api: TestImpactAnalysisApi,
+         observers: ExporterObservers.Feature = .init()) throws {
         self.configuration = config
 
         let filesOrchestrator = FilesOrchestrator(
@@ -51,17 +52,20 @@ internal final class CoverageExporter: CoverageExporterType {
         let writer = FileWriter(entity: "coverage",
                                 dataFormat: dataFormat,
                                 orchestrator: filesOrchestrator,
-                                encoder: encoder)
+                                encoder: encoder,
+                                observer: observers.payload)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
+        let requestObserver = observers.request
         let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(APICallError) -> Void in
-            try await api.uploadCoverage(batch: data)
+            try await api.uploadCoverage(batch: data, observer: requestObserver)
         }
         let uploader = ClosureDataUploader(upload: upload)
         self.coverageStorage = FeatureStoreAndUpload(featureName: "coverage",
                                                      reader: reader,
                                                      writer: writer,
                                                      performance: configuration.performancePreset,
-                                                     uploader: uploader)
+                                                     uploader: uploader,
+                                                     observer: observers.upload)
     }
 
     @discardableResult

--- a/Sources/EventsExporter/Exporter.swift
+++ b/Sources/EventsExporter/Exporter.swift
@@ -31,14 +31,16 @@ public final class Exporter: ExporterProtocol {
 
     public init(config: ExporterConfiguration,
                 api: TestOptimizationApi,
-                storage: Directory) throws
+                storage: Directory,
+                observers: ExporterObservers = .init()) throws
     {
         self.configuration = config
         Log.setLogger(config.logger)
 
         let spansExporter = try SpansExporter(config: configuration,
                                               storage: try storage.createSubdirectory(path: "spans"),
-                                              api: api.spans)
+                                              api: api.spans,
+                                              observers: observers.spans)
         let logsExporter = try LogsExporter(config: configuration,
                                             storage: try storage.createSubdirectory(path: "logs"),
                                             api: api.logs)
@@ -46,7 +48,8 @@ public final class Exporter: ExporterProtocol {
         self.logsExporter = logsExporter
         self.coverageExporter = try CoverageExporter(config: configuration,
                                                      storage: try storage.createSubdirectory(path: "coverage"),
-                                                     api: api.tia)
+                                                     api: api.tia,
+                                                     observers: observers.coverage)
         self.spanExporterComposite = OpenTelemetrySdk.MultiSpanExporter(spanExporters: [
             spansExporter,
             SpanEventsLogExporterAdapter(logRecordExporter: logsExporter),

--- a/Sources/EventsExporter/Persistence/FileWriter.swift
+++ b/Sources/EventsExporter/Persistence/FileWriter.swift
@@ -13,17 +13,26 @@ internal final class FileWriter {
     private let orchestrator: FilesOrchestratorType
     /// JSON encoder used to encode data.
     private let encoder: JSONEncoder
+    /// Optional telemetry observer notified about serialization / payload size.
+    private let observer: PayloadObserver?
+    /// Events written to / time spent serializing the currently-open file. Only
+    /// touched on `queue`. Reported as `payloadFinalized` when the file rolls
+    /// over or is explicitly closed.
+    private var pendingEventCount: Int = 0
+    private var pendingSerializationMs: Double = 0
     /// Queue used to synchronize files access (read / write).
     internal let queue: DispatchQueue
 
     init(entity: String,
          dataFormat: DataFormatType,
          orchestrator: FilesOrchestratorType,
-         encoder: JSONEncoder)
+         encoder: JSONEncoder,
+         observer: PayloadObserver? = nil)
     {
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
         self.encoder = encoder
+        self.observer = observer
         self.queue = DispatchQueue(label: "datadogtest.filewriter.\(entity)",
                                    target: .global(qos: .userInteractive))
     }
@@ -32,6 +41,7 @@ internal final class FileWriter {
     /// next write starts a new file with the new header.
     func update(dataFormat: DataFormatType) {
         queue.sync(flags: .barrier) {
+            finalizeCurrentPayload()
             orchestrator.closeWritableFile()
             self.dataFormat = dataFormat
         }
@@ -41,7 +51,19 @@ internal final class FileWriter {
     /// Required before `FileReader.getAllReadableFiles()` so the in-progress
     /// file isn't returned mid-write.
     func closeCurrentFile() {
-        queue.sync(flags: .barrier) { orchestrator.closeWritableFile() }
+        queue.sync(flags: .barrier) {
+            finalizeCurrentPayload()
+            orchestrator.closeWritableFile()
+        }
+    }
+
+    /// Reports the event count and summed serialization time of the file that is
+    /// being closed, if any. Must be called on `queue`.
+    private func finalizeCurrentPayload() {
+        guard pendingEventCount > 0 else { return }
+        observer?.payloadFinalized(eventCount: pendingEventCount, serializationMs: pendingSerializationMs)
+        pendingEventCount = 0
+        pendingSerializationMs = 0
     }
 
     // MARK: - Writing data
@@ -63,12 +85,24 @@ internal final class FileWriter {
     }
 
     private func write<T: Encodable>(value: T, sync: Bool) throws {
+        let encodeStart = observer != nil ? DispatchTime.now() : nil
         let data = try encoder.encode(value)
+        let eventMs = encodeStart.map {
+            Double(DispatchTime.now().uptimeNanoseconds - $0.uptimeNanoseconds) / 1_000_000
+        }
         // `withWritableFile` claims the file for the duration of `body`, so
         // the upload worker's reader cannot list-and-delete the file mid-
         // write. Once the closure returns, the file becomes visible to the
         // reader.
         try orchestrator.withWritableFile(writeSize: UInt64(data.count)) { writable, isNew in
+            // A new file means the previous one is finalized; report its totals
+            // and start accumulating for the new payload. This event's
+            // serialization time belongs to the new payload.
+            if isNew {
+                finalizeCurrentPayload()
+            }
+            pendingEventCount += 1
+            if let eventMs { pendingSerializationMs += eventMs }
             let payload = try isNew ? (dataFormat.prefix + data) : (dataFormat.separator + data)
             try writable.append(data: payload, synchronized: sync)
         }

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -13,7 +13,8 @@ internal final class SpansExporter: SpanExporter {
     let spansStorage: FeatureStoreAndUpload
     private let encoder: JSONEncoder
 
-    init(config: ExporterConfiguration, storage: Directory, api: SpansApi) throws {
+    init(config: ExporterConfiguration, storage: Directory, api: SpansApi,
+         observers: ExporterObservers.Feature = .init()) throws {
         self.configuration = config
 
         let filesOrchestrator = FilesOrchestrator(
@@ -34,17 +35,20 @@ internal final class SpansExporter: SpanExporter {
         let writer = FileWriter(entity: "spans",
                                 dataFormat: dataFormat,
                                 orchestrator: filesOrchestrator,
-                                encoder: encoder)
+                                encoder: encoder,
+                                observer: observers.payload)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
+        let requestObserver = observers.request
         let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(APICallError) -> Void in
-            try await api.uploadSpans(batch: data)
+            try await api.uploadSpans(batch: data, observer: requestObserver)
         }
         let uploader = ClosureDataUploader(upload: upload)
         self.spansStorage = FeatureStoreAndUpload(featureName: "spans",
                                                   reader: reader,
                                                   writer: writer,
                                                   performance: configuration.performancePreset,
-                                                  uploader: uploader)
+                                                  uploader: uploader,
+                                                  observer: observers.upload)
     }
 
     /// Rebuild the file header (which embeds the per-feature `SpanMetadata`)

--- a/Sources/EventsExporter/Telemetry/MetricObservers.swift
+++ b/Sources/EventsExporter/Telemetry/MetricObservers.swift
@@ -1,0 +1,85 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Hooks that let a higher layer (the SDK's telemetry manager) observe the
+/// network/storage internals of `EventsExporter` without this module knowing
+/// anything about telemetry metrics. EventsExporter only reports neutral facts
+/// (durations, byte sizes, status codes, counts); the consumer decides which
+/// metric/tags they map to.
+///
+/// All hooks are optional and default to `nil` at every injection point, so the
+/// exporter behaves identically when no observer is attached.
+
+/// Observes a single HTTP request/response exchange. Reported once per request
+/// from the shared `HTTPClient`, so the measurement (timing, payload sizes,
+/// status) lives in one place and callers only supply identity/tags.
+///
+/// `requestBytes` is the size of the serialized request payload that was sent
+/// (some metrics, e.g. `endpoint_payload.bytes` / `git_requests.objects_pack_bytes`,
+/// track the request size); `responseBytes` is the size of the received body.
+/// `statusCode` is `nil` for transport-level failures (no HTTP response, e.g.
+/// timeout or connection error); `failed` is `true` whenever the request did
+/// not complete successfully.
+public protocol RequestObserver: Sendable {
+    func requestFinished(durationMs: Double, requestBytes: Int, responseBytes: Int,
+                         statusCode: Int?, failed: Bool)
+}
+
+/// Observes the background upload pipeline that drains stored batches to the
+/// intake (one observer per feature store, e.g. spans vs coverage).
+///
+/// This reports what the worker uniquely knows about a stored batch's lifecycle
+/// — the transport-level facts (status code, response size) come from
+/// `RequestObserver` on the underlying upload request. `uploadAttempt` is
+/// reported once per attempt with the batch size, elapsed time and outcome
+/// (`success` = delivered & removed, `retriable` = will be retried);
+/// `uploadDropped` once when a batch is abandoned without being delivered.
+public protocol UploadObserver: Sendable {
+    func uploadAttempt(payloadBytes: Int, durationMs: Double, success: Bool, retriable: Bool)
+    func uploadDropped(payloadBytes: Int)
+}
+
+/// Observes payload serialization at the storage layer (one observer per feature
+/// store). `payloadFinalized` is reported once when a file is closed/rolled,
+/// carrying the number of events that ended up in that payload (`events_count`)
+/// and the summed time spent serializing them (`events_serialization_ms`).
+public protocol PayloadObserver: Sendable {
+    func payloadFinalized(eventCount: Int, serializationMs: Double)
+}
+
+/// Telemetry observers handed to the `Exporter`, grouped per upload feature.
+/// Only the features that map to an `endpoint_payload` namespace (spans →
+/// `test_cycle`, coverage → `code_coverage`) are represented; everything
+/// defaults to `nil`, leaving the pipeline uninstrumented.
+public struct ExporterObservers: Sendable {
+    public struct Feature: Sendable {
+        /// Observes the upload HTTP request itself (size sent, duration, status)
+        /// — the source for `endpoint_payload.requests/_ms/bytes/_errors`.
+        public let request: RequestObserver?
+        /// Observes the background batch lifecycle (attempt outcome, drops).
+        public let upload: UploadObserver?
+        /// Observes payload serialization (`events_count` / `events_serialization_ms`).
+        public let payload: PayloadObserver?
+
+        public init(request: RequestObserver? = nil,
+                    upload: UploadObserver? = nil,
+                    payload: PayloadObserver? = nil) {
+            self.request = request
+            self.upload = upload
+            self.payload = payload
+        }
+    }
+
+    public let spans: Feature
+    public let coverage: Feature
+
+    public init(spans: Feature = .init(), coverage: Feature = .init()) {
+        self.spans = spans
+        self.coverage = coverage
+    }
+}

--- a/Sources/EventsExporter/Upload/DataUploadWorker.swift
+++ b/Sources/EventsExporter/Upload/DataUploadWorker.swift
@@ -35,17 +35,21 @@ internal final class DataUploadWorker: DataUploadWorkerType {
     private var delay: Delay
     /// Upload work scheduled by this worker.
     private var uploadWork: DispatchWorkItem?
+    /// Optional telemetry observer notified about upload attempts / drops.
+    private let observer: UploadObserver?
 
     init(
         fileReader: FileReader,
         dataUploader: DataUploaderType,
         delay: Delay,
         featureName: String,
-        priority: DispatchQoS
+        priority: DispatchQoS,
+        observer: UploadObserver? = nil
     ) {
         self.fileReader = fileReader
         self.dataUploader = dataUploader
         self.delay = delay
+        self.observer = observer
         self.queue = DispatchQueue(label: "datadogtest.datauploadworker.\(featureName)",
                                    target: .global(qos: priority.qosClass))
         self.featureName = featureName
@@ -123,21 +127,29 @@ internal final class DataUploadWorker: DataUploadWorkerType {
     }
 
     private func upload(data: Data) -> UploadResult {
+        let start = observer != nil ? DispatchTime.now() : nil
         let uploadStatus = self.dataUploader.upload(data: data)
+        let result: UploadResult
         if uploadStatus.needsRetry {
             if let waitTime = uploadStatus.waitTime {
-                return delay.set(delay: waitTime) ? .retry : .failed
+                result = delay.set(delay: waitTime) ? .retry : .failed
             } else {
                 delay.increase()
-                return .retry
+                result = .retry
             }
         } else {
             delay.decrease()
-            return .success
+            result = .success
         }
+        if let observer, let start {
+            let durationMs = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+            observer.uploadAttempt(payloadBytes: data.count, durationMs: durationMs,
+                                   success: result == .success, retriable: result == .retry)
+        }
+        return result
     }
 
-    private enum UploadResult {
+    private enum UploadResult: Equatable {
         case success
         case retry
         case failed

--- a/Sources/EventsExporter/Utils/Feature.swift
+++ b/Sources/EventsExporter/Utils/Feature.swift
@@ -18,7 +18,8 @@ internal struct FeatureStoreAndUpload: DataUploadWorkerType {
         reader: FileReader,
         writer: FileWriter,
         performance: UploadPerformancePreset,
-        uploader: DataUploaderType
+        uploader: DataUploaderType,
+        observer: UploadObserver? = nil
     ) {
         self.init(
             uploader: DataUploadWorker(
@@ -26,7 +27,8 @@ internal struct FeatureStoreAndUpload: DataUploadWorkerType {
                 dataUploader: uploader,
                 delay: DataUploadDelay(performance: performance),
                 featureName: featureName,
-                priority: performance.uploadQueuePriority
+                priority: performance.uploadQueuePriority,
+                observer: observer
             ),
             writer: writer
         )

--- a/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
@@ -84,4 +84,47 @@ final class TelemetryTests: XCTestCase {
         let point = try XCTUnwrap(metric.data.points.first as? LongPointData)
         XCTAssertEqual(point.value, 7)
     }
+
+    // MARK: - Observer adapters
+
+    func testErrorTypeMapping() {
+        XCTAssertEqual(Telemetry.errorType(statusCode: nil), .network)
+        XCTAssertEqual(Telemetry.errorType(statusCode: 404), .statusCode4xx)
+        XCTAssertEqual(Telemetry.errorType(statusCode: 503), .statusCode5xx)
+        XCTAssertEqual(Telemetry.errorType(statusCode: 200), .network)
+    }
+
+    func testRequestMetricsObserverForwardsFactsAndDerivesErrorType() {
+        final class Box: @unchecked Sendable {
+            var requests = 0
+            var durationMs: Double?
+            var requestBytes: Int?
+            var responseBytes: Int?
+            var error: Telemetry.ErrorType?
+        }
+        let box = Box()
+        let observer = Telemetry.RequestMetricsObserver(
+            onRequest: { box.requests += 1 },
+            onDurationMs: { box.durationMs = $0 },
+            onRequestBytes: { box.requestBytes = $0 },
+            onResponseBytes: { box.responseBytes = $0 },
+            onError: { box.error = $0 }
+        )
+
+        // A failed request forwards all facts and derives the error type.
+        observer.requestFinished(durationMs: 12, requestBytes: 100, responseBytes: 200,
+                                 statusCode: 503, failed: true)
+        XCTAssertEqual(box.requests, 1)
+        XCTAssertEqual(box.durationMs, 12)
+        XCTAssertEqual(box.requestBytes, 100)
+        XCTAssertEqual(box.responseBytes, 200)
+        XCTAssertEqual(box.error, .statusCode5xx)
+
+        // A successful request does not report an error.
+        box.error = nil
+        observer.requestFinished(durationMs: 1, requestBytes: 1, responseBytes: 1,
+                                 statusCode: 202, failed: false)
+        XCTAssertEqual(box.requests, 2)
+        XCTAssertNil(box.error)
+    }
 }

--- a/Tests/EventsExporter/Helpers/MockHTTPClient.swift
+++ b/Tests/EventsExporter/Helpers/MockHTTPClient.swift
@@ -34,7 +34,7 @@ internal final class MockHTTPClient: HTTPClientType, @unchecked Sendable {
 
     // MARK: HTTPClientType
 
-    func send(request: URLRequest) async throws(HTTPClient.RequestError) -> HTTPURLResponse {
+    func send(request: URLRequest, observer: RequestObserver?) async throws(HTTPClient.RequestError) -> HTTPURLResponse {
         try await Task<Result<HTTPURLResponse, HTTPClient.RequestError>, Never>.detached {
             self.record(request)
             switch self.delivery {
@@ -44,7 +44,7 @@ internal final class MockHTTPClient: HTTPClientType, @unchecked Sendable {
         }.value.get()
     }
 
-    func sendWithResponse(request: URLRequest) async throws(HTTPClient.RequestError) -> Data {
+    func sendWithResponse(request: URLRequest, observer: RequestObserver?) async throws(HTTPClient.RequestError) -> Data {
         try await Task<Result<Data, HTTPClient.RequestError>, Never>.detached {
             self.record(request)
             switch self.delivery {

--- a/Tests/EventsExporter/Persistence/FileWriterTests.swift
+++ b/Tests/EventsExporter/Persistence/FileWriterTests.swift
@@ -46,6 +46,40 @@ class FileWriterTests: XCTestCase {
         )
     }
 
+    func testItReportsSerializationAndPayloadCountsToObserver() throws {
+        let observer = RecordingPayloadObserver()
+        let expectation = self.expectation(description: "write completed")
+        let writer = FileWriter(
+            entity: "testfilewriter-observer",
+            dataFormat: DataFormat(prefix: Data("[".utf8),
+                                   suffix: Data("]".utf8),
+                                   separator: Data(",".utf8)),
+            orchestrator: FilesOrchestrator(
+                directory: temporaryDirectory,
+                performance: StoragePerformanceMock.appendToOneFile,
+                dateProvider: SystemDateProvider()
+            ),
+            encoder: JSONEncoder.apiEncoder,
+            observer: observer
+        )
+
+        writer.write(value: ["key1": "value1"])
+        writer.write(value: ["key2": "value2"])
+        writer.write(value: ["key3": "value3"])
+
+        waitForWritesCompletion(on: writer.queue, thenFulfill: expectation)
+        waitForExpectations(timeout: 1, handler: nil)
+
+        // Nothing finalized while the file is open.
+        XCTAssertEqual(observer.finalized.count, 0)
+
+        // Closing the file finalizes it with the full event count and the summed
+        // serialization time of those events.
+        writer.closeCurrentFile()
+        XCTAssertEqual(observer.finalized.map(\.eventCount), [3])
+        XCTAssertEqual(observer.finalized.first?.serializationMs ?? -1 >= 0, true)
+    }
+
     func testGivenErrorVerbosity_whenIndividualDataExceedsMaxWriteSize_itDropsDataAndPrintsError() throws {
         let expectation1 = self.expectation(description: "write completed")
         let expectation2 = self.expectation(description: "second write completed")
@@ -159,5 +193,18 @@ class FileWriterTests: XCTestCase {
     private var isGithub: Bool {
         ProcessInfo.processInfo.environment["GITHUB_ACTION"] ?? "" != "" ||
         ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] ?? "" != ""
+    }
+}
+
+/// Records `PayloadObserver` callbacks for assertions. Callbacks arrive on the
+/// writer's serial queue; a lock keeps reads from the test thread safe.
+private final class RecordingPayloadObserver: PayloadObserver, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _finalized: [(eventCount: Int, serializationMs: Double)] = []
+
+    var finalized: [(eventCount: Int, serializationMs: Double)] { lock.withLock { _finalized } }
+
+    func payloadFinalized(eventCount: Int, serializationMs: Double) {
+        lock.withLock { _finalized.append((eventCount, serializationMs)) }
     }
 }

--- a/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
@@ -121,6 +121,37 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(try temporaryDirectory.files().count, 1, "When upload finishes with `needsRetry: true`, data should be preserved")
     }
 
+    // MARK: - Telemetry observer
+
+    func testItReportsUploadAttemptToObserver() {
+        let attemptExpectation = expectation(description: "upload attempt reported")
+        attemptExpectation.assertForOverFulfill = false
+        let observer = RecordingUploadObserver { attemptExpectation.fulfill() }
+        let mockDataUploader = DataUploaderMock(uploadStatus: .mockWith(needsRetry: false))
+
+        // Given
+        try? writer.writeSync(value: ["key": "value"])
+
+        // When
+        let worker = DataUploadWorker(
+            fileReader: reader,
+            dataUploader: mockDataUploader,
+            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
+            featureName: .mockAny(),
+            priority: .userInteractive,
+            observer: observer
+        )
+        wait(for: [attemptExpectation], timeout: 5.0)
+        worker.stop()
+
+        // Then
+        let attempts = observer.attempts
+        XCTAssertGreaterThanOrEqual(attempts.count, 1)
+        XCTAssertEqual(attempts.first?.success, true)
+        XCTAssertEqual(attempts.first?.retriable, false)
+        XCTAssertGreaterThan(attempts.first?.payloadBytes ?? 0, 0)
+    }
+
     // MARK: - Upload Interval Changes
 
     func testWhenThereIsNoBatch_thenIntervalIncreases() {
@@ -287,5 +318,32 @@ struct MockDelay: Delay {
         // tests don't exercise server-driven retry delay; treat as "can't accept"
         // so the worker falls through to its default retry/back-off path.
         return false
+    }
+}
+
+/// Records `UploadObserver` callbacks (which arrive on the worker's queue) for
+/// assertions. `onAttempt` fires for each recorded attempt so tests can await it.
+private final class RecordingUploadObserver: UploadObserver, @unchecked Sendable {
+    typealias Attempt = (payloadBytes: Int, durationMs: Double, success: Bool, retriable: Bool)
+
+    private let lock = NSLock()
+    private var _attempts: [Attempt] = []
+    private var _dropped: [Int] = []
+    private let onAttempt: @Sendable () -> Void
+
+    init(onAttempt: @escaping @Sendable () -> Void = {}) {
+        self.onAttempt = onAttempt
+    }
+
+    var attempts: [Attempt] { lock.withLock { _attempts } }
+    var dropped: [Int] { lock.withLock { _dropped } }
+
+    func uploadAttempt(payloadBytes: Int, durationMs: Double, success: Bool, retriable: Bool) {
+        lock.withLock { _attempts.append((payloadBytes, durationMs, success, retriable)) }
+        onAttempt()
+    }
+
+    func uploadDropped(payloadBytes: Int) {
+        lock.withLock { _dropped.append(payloadBytes) }
     }
 }


### PR DESCRIPTION
## What

Implements [SDTEST-3776](https://datadoghq.atlassian.net/browse/SDTEST-3776) — wires the common `Telemetry` manager (added in #271) through the SDK so the network/storage layers and the API-calling features can record CI Visibility metrics. Builds on the typed metric tree from 3775.

## Design — observer hooks (dependency inversion)

`EventsExporter` stays **telemetry-agnostic**: it reports neutral facts through three observer protocols; all metric-name/tag mapping lives next to the `Telemetry` tree in `DatadogSDKTesting`.

- **`RequestObserver`** — one HTTP exchange: duration, request bytes (sent payload), response bytes, status. Measured **once** in `HTTPClient.perform`; threaded as an optional param through every API method (with `@inlinable` no-observer conveniences) and the upload calls.
- **`UploadObserver`** — background batch lifecycle in `DataUploadWorker` (attempt outcome; `dropped`).
- **`PayloadObserver`** — serialization time + event count per payload, in `FileWriter`.
- Bundled as `ExporterObservers`, plumbed through `Exporter` → spans/coverage sub-exporters.

Also fixes a latent bug: the `*ApiService` types depended on the concrete `HTTPClient` instead of the injectable `HTTPClientType` protocol (despite a `MockHTTPClient` existing for it).

## Consumer side (`DatadogSDKTesting`)

- `Telemetry` is created **with the tracer** (before the exporter), exposed as `DDTracer.telemetry`, and `SessionConfig.telemetry` sources from it.
- Observer adapters map the neutral callbacks to `Telemetry.metrics.*`, with a shared `statusCode → error_type` derivation and per-family request observers.
- **Gathered now:**
  - `endpoint_payload.*` — via the exporter observers (the only home for this family), tagged `test_cycle` (spans) / `code_coverage` (coverage).
  - `git_requests.*`, `itr_skippable_tests.*`, `known_tests.*`, `test_management_tests.*` — via per-call request observers threaded into the git uploader, TIA / known-tests / test-management factories and the settings fetch.

## Notable change

The exporter and telemetry now share a single `ExporterConfiguration` on the **default** performance preset (previously the exporter used `.instantDataDelivery`). Flush-on-shutdown still delivers everything; in-run uploads are less eager.

## Out of scope (→ SDTEST-3777)

Response item counts (`response_tests`/`suites`/`files`, `objects_pack_files`, `settings_response`) from parsed results, `endpoint_payload.dropped` wiring, and the local feature metrics (`events.*`, `git.command`, `itr.skipped`, `code_coverage.*`, `test_session`, …).

## Testing

New unit tests for each observer hook (`FileWriter`, `DataUploadWorker`) and the adapters (error-type mapping, request forwarding). Full suites pass: **EventsExporter 132**, DatadogSDKTesting all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDTEST-3776]: https://datadoghq.atlassian.net/browse/SDTEST-3776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ