### PR TITLE
Fix intermittent tvOS crash enumerating Obj-C classes during URLSession instrumentation

### DIFF
--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -147,7 +147,7 @@ internal class DDTestMonitor {
     init() {
         Log.debug("Config:\n\(DDTestMonitor.config)")
         Log.debug("Environment:\n\(DDTestMonitor.env)")
-        Log.debug("Session ID:\n\(DDTestMonitor.sessionId)")
+        Log.debug("Session ID: \(DDTestMonitor.sessionId)")
         maxPayloadSize = DDTestMonitor.config.maxPayloadSize
         messageChannelUUID = DDTestMonitor.config.messageChannelUUID ?? UUID().uuidString
         tracer = DDTracer()

--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/InstrumentationUtils.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/InstrumentationUtils.swift
@@ -11,26 +11,28 @@ import Foundation
 
 enum InstrumentationUtils {
     static func objc_getClassList() -> [AnyClass] {
-        let capacity = Int(ObjectiveC.objc_getClassList(nil, 0))
-        let allClasses = UnsafeMutablePointer<AnyClass>.allocate(capacity: capacity)
-        defer { allClasses.deallocate() }
-        let autoreleasingAllClasses = AutoreleasingUnsafeMutablePointer<AnyClass>(allClasses)
-        // `objc_getClassList` writes at most `capacity` entries but returns the
-        // *total* number of registered classes, which can exceed `capacity` when
-        // another thread registers classes between the two calls (frameworks load
-        // concurrently during app/test launch). Iterating past `capacity` would
-        // read uninitialized memory and hand back garbage pointers, which then
-        // crash intermittently as "Attempt to use unknown class" / bad access the
-        // moment they are dereferenced. Clamp to what we actually allocated.
-        let written = Int(ObjectiveC.objc_getClassList(autoreleasingAllClasses, Int32(capacity)))
-        let count = min(written, capacity)
-
-        var classes = [AnyClass]()
-        classes.reserveCapacity(count)
-        for i in 0 ..< count {
-            classes.append(allClasses[i])
+        // `objc_getClassList(buf, n)` fills at most `n` slots but returns the
+        // *total* number of registered classes. Other threads register classes
+        // concurrently while frameworks load during app/test launch, so that total
+        // can exceed the buffer we sized from an earlier call. Reading past the
+        // buffer yields uninitialized garbage pointers, which crash intermittently
+        // as "Attempt to use unknown class" / bad access the moment they are
+        // dereferenced. Re-query and grow until the returned count fits the buffer:
+        // that way we never read past it and still capture every class. The small
+        // headroom lets it settle in one retry under typical concurrent loading.
+        var capacity: Int32 = ObjectiveC.objc_getClassList(nil, 0) + 32
+        while true {
+            let buffer = UnsafeMutableBufferPointer<AnyClass>.allocate(capacity: Int(capacity))
+            defer { buffer.deallocate() }
+            let autoreleasing = AutoreleasingUnsafeMutablePointer<AnyClass>(buffer.baseAddress)
+            let written = ObjectiveC.objc_getClassList(autoreleasing, capacity)
+            if written <= capacity {
+                // We got all the classes. Convert to array and return
+                return Array(buffer.prefix(upTo: Int(written)))
+            }
+            // More classes appeared than fit; grow to the new total and retry.
+            capacity = written + 32
         }
-        return classes
     }
 
     /// Returns whether `cls` (or any of its superclasses) conforms to `proto`,

--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/InstrumentationUtils.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/InstrumentationUtils.swift
@@ -8,15 +8,6 @@
  */
 
 import Foundation
-#if canImport(os.log)
-  import os.log
-#endif
-
-#if os(iOS) || os(tvOS) || os(visionOS)
-import UIKit
-#elseif os(watchOS)
-import WatchKit
-#endif
 
 enum InstrumentationUtils {
     static func objc_getClassList() -> [AnyClass] {
@@ -33,22 +24,30 @@ enum InstrumentationUtils {
         return classes
     }
     
-    static func objc_getSafeClassList(ignoredPrefixes: [String]? = nil) -> [AnyClass] {
+    /// Returns the registered Objective-C classes that are safe to introspect
+    /// with `class_copyMethodList` / method swizzling.
+    ///
+    /// `objc_getClassList` can return classes whose superclass chain references a
+    /// class that is registered as a stub but never realized — for example
+    /// weak-linked classes from frameworks that aren't loaded, or the
+    /// relative-method-list "stub" classes that newer runtimes emit. Realizing
+    /// such a class, which `class_copyMethodList` does implicitly, makes the
+    /// runtime log "Attempt to use unknown class %p." and abort. We avoid that by
+    /// keeping only the classes whose entire superclass chain is itself present in
+    /// the class list. Reading the superclass pointer with `class_getSuperclass`
+    /// does not realize the class, so the check itself is safe.
+    static func objc_getSafeClassList() -> [AnyClass] {
         let allClasses = objc_getClassList()
-        var safeClasses: [AnyClass] = []
-        
-        for cls in allClasses {
-            let className = NSStringFromClass(cls)
-            if let ignoredPrefixes = ignoredPrefixes {
-                if ignoredPrefixes.contains(where: { className.hasPrefix($0) }) {
-                    continue
-                }
+        let known = Set(allClasses.map { ObjectIdentifier($0) })
+
+        return allClasses.filter { cls in
+            var current: AnyClass? = cls
+            while let c = current {
+                guard known.contains(ObjectIdentifier(c)) else { return false }
+                current = class_getSuperclass(c)
             }
-            safeClasses.append(cls)
+            return true
         }
-        
-        os_log(.info, "failed to initialize network connection status: %ld", safeClasses.count)
-        return safeClasses
     }
     
     /// Returns whether `cls` (or any of its superclasses) conforms to `proto`,

--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/InstrumentationUtils.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/InstrumentationUtils.swift
@@ -11,51 +11,33 @@ import Foundation
 
 enum InstrumentationUtils {
     static func objc_getClassList() -> [AnyClass] {
-        let expectedClassCount = ObjectiveC.objc_getClassList(nil, 0)
-        let allClasses = UnsafeMutablePointer<AnyClass>.allocate(capacity: Int(expectedClassCount))
+        let capacity = Int(ObjectiveC.objc_getClassList(nil, 0))
+        let allClasses = UnsafeMutablePointer<AnyClass>.allocate(capacity: capacity)
+        defer { allClasses.deallocate() }
         let autoreleasingAllClasses = AutoreleasingUnsafeMutablePointer<AnyClass>(allClasses)
-        let actualClassCount: Int32 = ObjectiveC.objc_getClassList(autoreleasingAllClasses, expectedClassCount)
-        
+        // `objc_getClassList` writes at most `capacity` entries but returns the
+        // *total* number of registered classes, which can exceed `capacity` when
+        // another thread registers classes between the two calls (frameworks load
+        // concurrently during app/test launch). Iterating past `capacity` would
+        // read uninitialized memory and hand back garbage pointers, which then
+        // crash intermittently as "Attempt to use unknown class" / bad access the
+        // moment they are dereferenced. Clamp to what we actually allocated.
+        let written = Int(ObjectiveC.objc_getClassList(autoreleasingAllClasses, Int32(capacity)))
+        let count = min(written, capacity)
+
         var classes = [AnyClass]()
-        for i in 0 ..< actualClassCount {
-            classes.append(allClasses[Int(i)])
+        classes.reserveCapacity(count)
+        for i in 0 ..< count {
+            classes.append(allClasses[i])
         }
-        allClasses.deallocate()
         return classes
     }
-    
-    /// Returns the registered Objective-C classes that are safe to introspect
-    /// with `class_copyMethodList` / method swizzling.
-    ///
-    /// `objc_getClassList` can return classes whose superclass chain references a
-    /// class that is registered as a stub but never realized — for example
-    /// weak-linked classes from frameworks that aren't loaded, or the
-    /// relative-method-list "stub" classes that newer runtimes emit. Realizing
-    /// such a class, which `class_copyMethodList` does implicitly, makes the
-    /// runtime log "Attempt to use unknown class %p." and abort. We avoid that by
-    /// keeping only the classes whose entire superclass chain is itself present in
-    /// the class list. Reading the superclass pointer with `class_getSuperclass`
-    /// does not realize the class, so the check itself is safe.
-    static func objc_getSafeClassList() -> [AnyClass] {
-        let allClasses = objc_getClassList()
-        let known = Set(allClasses.map { ObjectIdentifier($0) })
 
-        return allClasses.filter { cls in
-            var current: AnyClass? = cls
-            while let c = current {
-                guard known.contains(ObjectIdentifier(c)) else { return false }
-                current = class_getSuperclass(c)
-            }
-            return true
-        }
-    }
-    
     /// Returns whether `cls` (or any of its superclasses) conforms to `proto`,
     /// using only ObjC runtime metadata. Unlike a Swift `is`/`as?` existential
-    /// cast, this never sends a message to the class, so it is safe to run across
-    /// every class from `objc_getClassList()` — including pathological internal
-    /// classes (`__NSGenericDeallocHandler`, `__NSAtom`, `__NSMessageBuilder`, …)
-    /// that abort with an `NSForwarding` error when messaged.
+    /// cast, this never sends a message to the class. It lets the delegate scan
+    /// skip the expensive `class_copyMethodList` for the thousands of classes
+    /// that don't adopt `URLSessionDelegate`.
     static func classConforms(_ cls: AnyClass, to proto: Protocol) -> Bool {
         var current: AnyClass? = cls
         while let c = current {

--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/URLSessionInstrumentation.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/URLSessionInstrumentation.swift
@@ -97,7 +97,7 @@ class URLSessionInstrumentation {
     ]
     let classes =
       configuration.delegateClassesToInstrument
-        ?? InstrumentationUtils.objc_getClassList()
+        ?? InstrumentationUtils.objc_getSafeClassList()
     let selectorsCount = selectors.count
     // Resolve the protocol once via the ObjC runtime. We check conformance with
     // `class_conformsToProtocol` (below) rather than a Swift `theClass is

--- a/Sources/DatadogSDKTesting/NetworkInstrumentation/URLSessionInstrumentation.swift
+++ b/Sources/DatadogSDKTesting/NetworkInstrumentation/URLSessionInstrumentation.swift
@@ -97,12 +97,13 @@ class URLSessionInstrumentation {
     ]
     let classes =
       configuration.delegateClassesToInstrument
-        ?? InstrumentationUtils.objc_getSafeClassList()
+        ?? InstrumentationUtils.objc_getClassList()
     let selectorsCount = selectors.count
-    // Resolve the protocol once via the ObjC runtime. We check conformance with
-    // `class_conformsToProtocol` (below) rather than a Swift `theClass is
-    // URLSessionDelegate.Type` cast: the cast messages the class, which aborts
-    // on pathological internal classes returned by `objc_getClassList()`.
+    // Only inspect classes that actually adopt URLSessionDelegate, so we skip the
+    // expensive `class_copyMethodList` for the thousands of unrelated runtime
+    // classes. Conformance is checked with `class_conformsToProtocol` rather than
+    // a Swift `theClass is URLSessionDelegate.Type` cast, since the cast messages
+    // the class.
     let urlSessionDelegateProtocol = objc_getProtocol("NSURLSessionDelegate")
     DispatchQueue.concurrentPerform(iterations: classes.count) { iteration in
       let theClass: AnyClass = classes[iteration]


### PR DESCRIPTION
## Summary

Fixes an intermittent crash (`objc[…]: Attempt to use unknown class 0x…` / `Bad pointer dereference at 0xffffffffffffffff`) during `URLSessionInstrumentation` init on tvOS, surfaced on Xcode 26.x.

## Root cause

`InstrumentationUtils.objc_getClassList()` used the classic two-call pattern but iterated to the count returned by the *second* call. `objc_getClassList(buf, n)` fills at most `n` slots but **returns the total number of registered classes**. During app/test launch other threads load frameworks and register classes concurrently, so that total could exceed the buffer sized from the first call. The loop then read **uninitialized memory past the buffer**, producing garbage "class" pointers that crashed the moment they were dereferenced (in the scan, or in the superclass walk). The race is why it failed only intermittently and didn't reproduce on every toolchain/simulator.

## Fix

- `objc_getClassList()` now **grows and retries**: re-query and enlarge the buffer until the returned total fits what we allocated. This captures every class, never reads past the buffer, and settles in a single retry under typical concurrent loading (small headroom).
- Kept the `classConforms` optimization, which skips the expensive `class_copyMethodList` for the thousands of classes that don't adopt `URLSessionDelegate`.
- Removed the dead `objc_getSafeClassList` helper and unused imports; the delegate scan is otherwise back to its original, proven shape.

## Testing

- Builds clean for tvOS.
- `DDNetworkInstrumentationTests` passes on the tvOS 26.5 simulator.
- The original crash could not be reproduced locally (local toolchain is Xcode 26.5 / tvOS 26.5 sim; CI uses 26.2 / 26.4), but the out-of-bounds read fully explains the intermittent failures independent of toolchain. CI integration run is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)