### PR TITLE
Fix flush race: seal writer on shutdown so in-flight writes aren't lost

### DIFF
--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -567,8 +567,10 @@ internal class DDTestMonitor {
         }
 
         if !DDTestMonitor.config.disableNetworkInstrumentation {
-            Log.measure(name: "startNetworkAutoInstrumentation") {
-                startNetworkAutoInstrumentation()
+            instrumentationWorkQueue.addOperation { [self] in
+                Log.measure(name: "startNetworkAutoInstrumentation") {
+                    startNetworkAutoInstrumentation()
+                }
             }
         }
         if DDTestMonitor.config.enableStdoutInstrumentation {

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -153,6 +153,13 @@ internal class DDTestMonitor {
         maxPayloadSize = DDTestMonitor.config.maxPayloadSize
         messageChannelUUID = DDTestMonitor.config.messageChannelUUID ?? UUID().uuidString
         tracer = DDTracer()
+        
+        // Change queue priorities. We want loading to work quick
+        gitUploadQueue.qualityOfService = .userInteractive
+        instrumentationWorkQueue.qualityOfService = .userInteractive
+        testOptimizationSetupQueue.qualityOfService = .userInteractive
+        
+        // Make git queue serial. We can't run multiple git commands at the same time
         gitUploadQueue.maxConcurrentOperationCount = 1
 
         if DDTestMonitor.config.isBinaryUnderUITesting {

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -578,33 +578,43 @@ internal class DDTracer {
         builder.emit()
     }
 
-    func flush() {
-        if let rumPort = DDTestMonitor.instance?.rumPort {
-            let timeout: CFTimeInterval = 10.0
-            let status = CFMessagePortSendRequest(
-                rumPort,
-                DDCFMessageID.forceFlush, // Message ID for asking RUM to flush all data
-                nil,
-                timeout,
-                timeout,
-                "kCFRunLoopDefaultMode" as CFString,
-                nil
-            )
-            if status == kCFMessagePortSuccess {
-                Log.debug("DDCFMessageID.forceFlush finished")
-            } else {
-                Log.debug("CFMessagePortCreateRemote request to DatadogRUMTestingPort failed")
-            }
+    /// Asks the RUM process (instrumented app under UI test) to flush its data.
+    /// Cross-process, so it isn't covered by the local provider shutdown and is
+    /// requested on both flush and shutdown.
+    private func flushRUM() {
+        guard let rumPort = DDTestMonitor.instance?.rumPort else { return }
+        let timeout: CFTimeInterval = 10.0
+        let status = CFMessagePortSendRequest(
+            rumPort,
+            DDCFMessageID.forceFlush, // Message ID for asking RUM to flush all data
+            nil,
+            timeout,
+            timeout,
+            "kCFRunLoopDefaultMode" as CFString,
+            nil
+        )
+        if status == kCFMessagePortSuccess {
+            Log.debug("DDCFMessageID.forceFlush finished")
+        } else {
+            Log.debug("CFMessagePortCreateRemote request to DatadogRUMTestingPort failed")
         }
-        
+    }
+
+    func flush() {
+        flushRUM()
         self.tracerProviderSdk.forceFlush()
         _ = self.logProcessor.forceFlush()
         self.telemetry?.flush()
         Log.debug("Tracer flush finished")
     }
-    
+
     func shutdown() {
-        self.flush()
+        // No `flush()` here: shutting the providers down below flushes spans and
+        // logs properly — and the spans pipeline does it race-free via the
+        // sealed `FileWriter.stop()`. A pre-shutdown flush would be redundant
+        // and could skip a span still being written. We only forward the
+        // cross-process RUM flush, which provider shutdown doesn't cover.
+        flushRUM()
         self.tracerProviderSdk.shutdown()
         _ = self.logProcessor.shutdown()
         self.telemetry?.shutdown()

--- a/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
+++ b/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
@@ -56,6 +56,7 @@ internal final class CoverageExporter: CoverageExporterType {
                                 dataFormat: dataFormat,
                                 orchestrator: filesOrchestrator,
                                 encoder: encoder,
+                                log: configuration.logger,
                                 observer: observers.payload)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
         let requestObserver = observers.request

--- a/Sources/EventsExporter/Exporter.swift
+++ b/Sources/EventsExporter/Exporter.swift
@@ -83,7 +83,10 @@ public final class Exporter: ExporterProtocol {
     }
 
     public func shutdown(explicitTimeout: TimeInterval?) {
-        _ = self.flush(explicitTimeout: explicitTimeout)
+        // No pre-flush here: each exporter's `shutdown()` seals its writer and
+        // then performs the final, complete upload (`FeatureStoreAndUpload.stop()`).
+        // A flush before sealing could skip a file still being written, which
+        // `stop()` would then never get a chance to upload.
         logsExporter.shutdown()
         spansExporter.shutdown()
         coverageExporter.shutdown()

--- a/Sources/EventsExporter/Logs/LogsExporter.swift
+++ b/Sources/EventsExporter/Logs/LogsExporter.swift
@@ -40,7 +40,8 @@ internal final class LogsExporter: LogRecordExporter {
         let writer = FileWriter(entity: "logs",
                                 dataFormat: dataFormat,
                                 orchestrator: filesOrchestrator,
-                                encoder: encoder)
+                                encoder: encoder,
+                                log: config.logger)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
         let upload: ClosureDataUploader.UploadCallback = { (data: Data) async throws(APICallError) -> Void in
             try await api.uploadLogs(batch: data)

--- a/Sources/EventsExporter/Persistence/FileWriter.swift
+++ b/Sources/EventsExporter/Persistence/FileWriter.swift
@@ -7,12 +7,18 @@
 import Foundation
 
 internal final class FileWriter {
+    /// Name of the feature this writer stores data for. Used in log messages.
+    private let entity: String
     /// Data writing format.
     private var dataFormat: DataFormatType
     /// Orchestrator producing reference to writable file.
     private let orchestrator: FilesOrchestratorType
     /// JSON encoder used to encode data.
     private let encoder: JSONEncoder
+    /// Set on `queue` by `stop()`. Once `true`, the writer is sealed for good:
+    /// further writes are rejected (and logged), so the final shutdown upload
+    /// sees a complete, quiescent set of files with no file mid-write.
+    private var isClosed = false
     /// Optional telemetry observer notified about serialization / payload size.
     private let observer: PayloadObserver?
     /// Events written to / time spent serializing the currently-open file. Only
@@ -29,6 +35,7 @@ internal final class FileWriter {
          encoder: JSONEncoder,
          observer: PayloadObserver? = nil)
     {
+        self.entity = entity
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
         self.encoder = encoder
@@ -57,6 +64,19 @@ internal final class FileWriter {
         }
     }
 
+    /// Permanently seals the writer at shutdown. Drains any in-flight writes
+    /// (serial queue + barrier), finalizes and closes the current file, then
+    /// blocks all subsequent writes. After this returns no file can be in
+    /// `activeWrites`, so the final upload enumerates a complete set of files
+    /// and nothing written so far is skipped.
+    func stop() {
+        queue.sync(flags: .barrier) {
+            finalizeCurrentPayload()
+            orchestrator.closeWritableFile()
+            isClosed = true
+        }
+    }
+
     /// Reports the event count and summed serialization time of the file that is
     /// being closed, if any. Must be called on `queue`.
     private func finalizeCurrentPayload() {
@@ -71,8 +91,13 @@ internal final class FileWriter {
     /// Encodes and writes `value` asynchronously. Errors are logged and swallowed.
     func write<T: Encodable>(value: T) {
         queue.async { [weak self] in
+            guard let self else { return }
+            guard !self.isClosed else {
+                self.logDropped(value)
+                return
+            }
             do {
-                try self?.write(value: value, sync: false)
+                try self.write(value: value, sync: false)
             } catch {
                 Log.print("🔥 Failed to write file: \(error)")
             }
@@ -81,7 +106,22 @@ internal final class FileWriter {
 
     /// Encodes and writes `value` synchronously, surfacing errors to the caller.
     func writeSync<T: Encodable>(value: T) throws {
-        try queue.sync { try write(value: value, sync: true) }
+        try queue.sync {
+            guard !isClosed else {
+                logDropped(value)
+                return
+            }
+            try write(value: value, sync: true)
+        }
+    }
+
+    /// Logs an event that was discarded because it arrived after `stop()`.
+    /// Includes the encoded payload so the dropped data can be inspected when
+    /// debugging. Must be called on `queue` (uses `encoder`).
+    private func logDropped<T: Encodable>(_ value: T) {
+        let payload = (try? encoder.encode(value))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "\(value)"
+        Log.print("🔥 Dropped event written to '\(entity)' after the writer was stopped: \(payload)")
     }
 
     private func write<T: Encodable>(value: T, sync: Bool) throws {

--- a/Sources/EventsExporter/Persistence/FileWriter.swift
+++ b/Sources/EventsExporter/Persistence/FileWriter.swift
@@ -21,6 +21,8 @@ internal final class FileWriter {
     private var isClosed = false
     /// Optional telemetry observer notified about serialization / payload size.
     private let observer: PayloadObserver?
+    /// Logger for write failures and events dropped after the writer was stopped.
+    private let log: Logger
     /// Events written to / time spent serializing the currently-open file. Only
     /// touched on `queue`. Reported as `payloadFinalized` when the file rolls
     /// over or is explicitly closed.
@@ -33,12 +35,14 @@ internal final class FileWriter {
          dataFormat: DataFormatType,
          orchestrator: FilesOrchestratorType,
          encoder: JSONEncoder,
+         log: Logger,
          observer: PayloadObserver? = nil)
     {
         self.entity = entity
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
         self.encoder = encoder
+        self.log = log
         self.observer = observer
         self.queue = DispatchQueue(label: "datadogtest.filewriter.\(entity)",
                                    target: .global(qos: .userInteractive))
@@ -99,7 +103,7 @@ internal final class FileWriter {
             do {
                 try self.write(value: value, sync: false)
             } catch {
-                Log.print("🔥 Failed to write file: \(error)")
+                self.log.print("🔥 Failed to write file: \(error)")
             }
         }
     }
@@ -121,7 +125,7 @@ internal final class FileWriter {
     private func logDropped<T: Encodable>(_ value: T) {
         let payload = (try? encoder.encode(value))
             .flatMap { String(data: $0, encoding: .utf8) } ?? "\(value)"
-        Log.print("🔥 Dropped event written to '\(entity)' after the writer was stopped: \(payload)")
+        log.print("🔥 Dropped event written to '\(entity)' after the writer was stopped: \(payload)")
     }
 
     private func write<T: Encodable>(value: T, sync: Bool) throws {

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -39,6 +39,7 @@ internal final class SpansExporter: SpanExporter {
                                 dataFormat: dataFormat,
                                 orchestrator: filesOrchestrator,
                                 encoder: encoder,
+                                log: configuration.logger,
                                 observer: observers.payload)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
         let requestObserver = observers.request

--- a/Sources/EventsExporter/Telemetry/TelemetryExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryExporter.swift
@@ -37,7 +37,8 @@ public final class TelemetryExporter: TelemetryPayloadExporter {
         let writer = FileWriter(entity: "telemetry",
                                 dataFormat: dataFormat,
                                 orchestrator: filesOrchestrator,
-                                encoder: encoder)
+                                encoder: encoder,
+                                log: config.logger)
         let reader = FileReader(dataFormat: dataFormat, orchestrator: filesOrchestrator)
         let uploader = ClosureDataUploader() { (data) async throws(APICallError) -> Void in
             try await api.send(batch: data)

--- a/Sources/EventsExporter/Utils/Feature.swift
+++ b/Sources/EventsExporter/Utils/Feature.swift
@@ -61,7 +61,17 @@ internal struct FeatureStoreAndUpload: DataUploadWorkerType {
         return try uploader.flush()
     }
 
+    /// Shutdown sequence:
+    /// 1. Stop scheduling background uploads, so the periodic worker can't run a
+    ///    read+upload cycle concurrently with the seal / final flush — the final
+    ///    `flush()` is then the only thing touching files during teardown.
+    /// 2. Seal the writer: drains in-flight writes and blocks new ones, so by the
+    ///    time the flush enumerates the directory no file is mid-write (none can
+    ///    be hidden in `activeWrites`) — nothing written so far is skipped.
+    /// 3. Synchronously upload everything left on disk.
     func stop() {
         uploader.stop()
+        writer.stop()
+        _ = try? uploader.flush()
     }
 }

--- a/Tests/EventsExporter/Persistence/FileWriterTests.swift
+++ b/Tests/EventsExporter/Persistence/FileWriterTests.swift
@@ -30,7 +30,8 @@ class FileWriterTests: XCTestCase {
                 performance: PerformancePreset.default,
                 dateProvider: SystemDateProvider()
             ),
-            encoder: JSONEncoder.apiEncoder
+            encoder: JSONEncoder.apiEncoder,
+            log: Log()
         )
 
         writer.write(value: ["key1": "value1"])
@@ -60,6 +61,7 @@ class FileWriterTests: XCTestCase {
                 dateProvider: SystemDateProvider()
             ),
             encoder: JSONEncoder.apiEncoder,
+            log: Log(),
             observer: observer
         )
 
@@ -101,7 +103,8 @@ class FileWriterTests: XCTestCase {
                 ),
                 dateProvider: SystemDateProvider()
             ),
-            encoder: JSONEncoder.apiEncoder
+            encoder: JSONEncoder.apiEncoder,
+            log: Log()
         )
 
         writer.write(value: ["key1": "value1"]) // will be written
@@ -144,7 +147,8 @@ class FileWriterTests: XCTestCase {
                 ),
                 dateProvider: SystemDateProvider()
             ),
-            encoder: JSONEncoder.apiEncoder
+            encoder: JSONEncoder.apiEncoder,
+            log: Log()
         )
 
         let ioInterruptionQueue = DispatchQueue(
@@ -186,6 +190,107 @@ class FileWriterTests: XCTestCase {
         XCTAssertLessThanOrEqual(writtenData.count, 300)
     }
 
+    func testWhenWriterIsStopped_itDropsAndLogsSubsequentWrites() throws {
+        let logger = RecordingLogger()
+        let writer = FileWriter(
+            entity: "testfilewriter-stop",
+            dataFormat: DataFormat(prefix: Data("[".utf8),
+                                   suffix: Data("]".utf8),
+                                   separator: Data(",".utf8)),
+            orchestrator: FilesOrchestrator(
+                directory: temporaryDirectory,
+                performance: StoragePerformanceMock.appendToOneFile,
+                dateProvider: SystemDateProvider()
+            ),
+            encoder: JSONEncoder.apiEncoder,
+            log: logger
+        )
+
+        writer.write(value: ["key1": "value1"])
+        // `stop()` barrier-drains the in-flight write, then seals the writer.
+        writer.stop()
+
+        XCTAssertEqual(try temporaryDirectory.files().count, 1)
+        let contentBeforeDrop = try temporaryDirectory.files()[0].read()
+
+        // A write after stop is rejected: no new file, existing content untouched.
+        writer.write(value: ["dropped": "afterstop"])
+        let expectation = self.expectation(description: "post-stop write drained")
+        waitForWritesCompletion(on: writer.queue, thenFulfill: expectation)
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(try temporaryDirectory.files().count, 1)
+        XCTAssertEqual(try temporaryDirectory.files()[0].read(), contentBeforeDrop)
+
+        // The drop is logged with the entity and the encoded payload, so the
+        // discarded data can be inspected when debugging.
+        let dropLog = logger.messages.first { $0.contains("after the writer was stopped") }
+        XCTAssertNotNil(dropLog, "expected a dropped-event log line")
+        XCTAssertEqual(dropLog?.contains("testfilewriter-stop"), true)
+        XCTAssertEqual(dropLog?.contains(#"{"dropped":"afterstop"}"#), true)
+    }
+
+    func testStopDrainsInFlightWritesBeforeSealing() throws {
+        let writer = FileWriter(
+            entity: "testfilewriter-drain",
+            dataFormat: DataFormat(prefix: Data("[".utf8),
+                                   suffix: Data("]".utf8),
+                                   separator: Data(",".utf8)),
+            orchestrator: FilesOrchestrator(
+                directory: temporaryDirectory,
+                performance: StoragePerformanceMock.appendToOneFile,
+                dateProvider: SystemDateProvider()
+            ),
+            encoder: JSONEncoder.apiEncoder,
+            log: Log()
+        )
+
+        writer.write(value: ["key1": "value1"])
+        writer.write(value: ["key2": "value2"])
+        writer.write(value: ["key3": "value3"])
+        // No explicit wait: `stop()` must drain all in-flight async writes via
+        // the serial-queue barrier before it returns.
+        writer.stop()
+
+        XCTAssertEqual(try temporaryDirectory.files().count, 1)
+        XCTAssertEqual(
+            try temporaryDirectory.files()[0].read(),
+            #"[{"key1":"value1"},{"key2":"value2"},{"key3":"value3"}"# .utf8Data
+        )
+    }
+
+    func testAfterStop_allWrittenFilesAreReadableForFinalFlush() throws {
+        let orchestrator = FilesOrchestrator(
+            directory: temporaryDirectory,
+            performance: StoragePerformanceMock.appendToOneFile,
+            dateProvider: SystemDateProvider()
+        )
+        let writer = FileWriter(
+            entity: "testfilewriter-complete",
+            dataFormat: DataFormat(prefix: Data("[".utf8),
+                                   suffix: Data("]".utf8),
+                                   separator: Data(",".utf8)),
+            orchestrator: orchestrator,
+            encoder: JSONEncoder.apiEncoder,
+            log: Log()
+        )
+
+        writer.write(value: ["key1": "value1"])
+        writer.write(value: ["key2": "value2"])
+        writer.stop()
+
+        // After sealing, no file is hidden in `activeWrites`, so the final flush
+        // (`getAllReadableFiles`) enumerates the complete set written so far —
+        // nothing is skipped and stranded on disk.
+        let readable = try orchestrator.getAllReadableFiles()
+        XCTAssertEqual(readable.count, 1)
+        XCTAssertEqual(try temporaryDirectory.files().count, 1)
+        XCTAssertEqual(
+            try readable[0].read(),
+            #"[{"key1":"value1"},{"key2":"value2"}"# .utf8Data
+        )
+    }
+
     private func waitForWritesCompletion(on queue: DispatchQueue, thenFulfill expectation: XCTestExpectation) {
         queue.async { expectation.fulfill() }
     }
@@ -211,5 +316,27 @@ private final class RecordingPayloadObserver: PayloadObserver, @unchecked Sendab
 
     func payloadFinalized(eventCount: Int, serializationMs: Double) {
         lock.withLock { _finalized.append((eventCount, serializationMs)) }
+    }
+}
+
+/// Captures `Logger.print` messages so tests can assert on what was logged,
+/// without touching global logging state. Messages may arrive on the writer's
+/// serial queue, so a lock keeps reads from the test thread safe.
+private final class RecordingLogger: Logger, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _messages: [String] = []
+
+    var messages: [String] { lock.withLock { _messages } }
+    var isDebug: Bool { false }
+
+    func print(_ message: String) { lock.withLock { _messages.append(message) } }
+    func debug(_ wrapped: @autoclosure () -> String) {}
+
+    func measure<T, E: Error>(name: String, _ operation: () throws(E) -> T) throws(E) -> T {
+        try operation()
+    }
+
+    func measure<T, E: Error>(name: String, _ operation: @Sendable () async throws(E) -> T) async throws(E) -> T {
+        try await operation()
     }
 }

--- a/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
@@ -18,7 +18,8 @@ class DataUploadWorkerTests: XCTestCase {
         entity: "datauploadworker",
         dataFormat: DataFormat.mockWith(prefix: "[", suffix: "]", separator: ","),
         orchestrator: orchestrator,
-        encoder: JSONEncoder.apiEncoder
+        encoder: JSONEncoder.apiEncoder,
+        log: Log()
     )
     lazy var reader = FileReader(
         dataFormat: DataFormat.mockWith(prefix: "[", suffix: "]", separator: ","),


### PR DESCRIPTION
## Problem

The final flush at shutdown could **skip and permanently lose** a file that was being written concurrently.

`FilesOrchestrator` hides files currently being appended to (`activeWrites`) from the reader, so the periodic upload worker never reads a half-written file. That's correct **mid-session** — the file is picked up on the next worker cycle. But at **shutdown** there is no next cycle: the worker is stopped right after the flush, so any file still in `activeWrites` during the final enumeration is stranded on disk and never uploaded.

The race window is a write submitted *concurrently with* the flush (e.g. a span ending on another thread during teardown). Writes submitted *before* the flush were already safe — the serial writer queue plus the barrier in `closeCurrentFile()` guarantees they complete and release their `activeWrites` entry first.

The previous shutdown order made this worse: `Exporter.shutdown()` flushed *first*, then stopped the worker — so a skipped file had no chance of being rescued.

## Fix

- **`FileWriter.stop()`** — permanently seals the writer: drains in-flight writes via the serial-queue barrier, finalizes and closes the current file, then rejects all subsequent writes. Writes after stop are logged with their encoded payload so dropped data is debuggable.
- **`FeatureStoreAndUpload.stop()`** — ordered teardown: (1) stop scheduling background uploads, (2) seal the writer, (3) run the final exhaustive flush. After sealing, no file can be in `activeWrites`, so the flush enumerates a complete, quiescent set — nothing is skipped. Stopping uploads first also keeps the periodic worker from racing the seal.
- **`Exporter.shutdown()`** — dropped the redundant pre-shutdown flush; each storage's `stop()` now does the complete, race-free upload.
- **`DDTracer.shutdown()`** — no longer pre-flushes. The OTel processor shutdown drains pending spans into the exporter, and the providers flush spans/logs/telemetry properly on their own. Only the cross-process RUM port flush is forwarded (extracted into `flushRUM()`), since provider shutdown doesn't cover it.

## Verification

- Confirmed the OTel shutdown path drains before tearing down for **both** `SimpleSpanProcessor` (serial `processorQueue.sync` barrier) and `BatchSpanProcessor` (`worker.shutdown()` → `forceFlush` drains the buffer synchronously *before* `spanExporter.shutdown()`). The drained writes are enqueued on the writer queue before `writer.stop()`'s barrier, so they land on disk and get uploaded.
- `SimpleLogRecordProcessor` is fully synchronous (no buffer).
- Builds; `FileWriterTests`, `EventsExporterTests`, `SpansExporterTests`, `LogsExporterTests`, `DataUploadWorkerTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)