### PR TITLE
Make retriable and skippable tags public for Swift Testing and XCTest

### DIFF
--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTags.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTags.swift
@@ -9,10 +9,10 @@ import Foundation
 #if canImport(Testing)
 import Testing
 
-extension Tag {
+public extension Tag {
     enum dd {
-        @Tag static var retriable: Tag
-        @Tag static var nonretriable: Tag
+        @Tag public static var retriable: Tag
+        @Tag public static var nonretriable: Tag
     }
 }
 

--- a/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysisSkippabble.swift
+++ b/Sources/DatadogSDKTesting/TestImpactAnalysis/TestImpactAnalysisSkippabble.swift
@@ -52,10 +52,10 @@ extension TIASkippableTag: XCTestTag {
 #if canImport(Testing)
 import Testing
 
-extension Tag.dd {
+public extension Tag.dd {
     enum tia {
-        @Tag static var skippable: Tag
-        @Tag static var unskippable: Tag
+        @Tag public static var skippable: Tag
+        @Tag public static var unskippable: Tag
     }
 }
 


### PR DESCRIPTION
## Summary
- Makes the Swift Testing tag properties `Tag.dd.retriable` / `Tag.dd.nonretriable` and `Tag.dd.tia.skippable` / `Tag.dd.tia.unskippable` `public`, matching their already-public XCTest counterparts (`.retriable`, `.tiaSkippable`) so consumers of the SDK can apply them via `@Test(.tags(...))`.

## Test plan
- [x] `xcodebuild -project DatadogSDKTesting.xcodeproj -scheme DatadogSDKTesting -sdk macosx build` succeeds with no warnings/errors