### PR TITLE
Remove XCTest observer on the main thread during framework unload

### DIFF
--- a/Sources/DatadogSDKTesting/XCTest/DDXCTestObserver.swift
+++ b/Sources/DatadogSDKTesting/XCTest/DDXCTestObserver.swift
@@ -67,7 +67,25 @@ final class DDXCTestObserver: NSObject, XCTestObservation, DDXCTestRetryDelegate
     }
 
     private func removeObserver() {
-        XCTestObservationCenter.shared.removeTestObserver(self)
+        // `removeTestObserver` (like `addTestObserver`) is main-thread-only.
+        // This runs from the framework unload destructor (`__AutoUnloadHook`),
+        // whose thread depends on who calls `exit()`: the classic `xctest`
+        // runner exits on the main thread, but the swift-testing runner exits
+        // from a Swift Concurrency continuation on a background thread. Removing
+        // off the main thread raises `NSInternalInconsistencyException`.
+        //
+        // When we're off the main thread, hop *asynchronously*: a synchronous
+        // hop can deadlock during process teardown if the main thread is already
+        // finalizing. If the block never runs because the process exits first,
+        // that's harmless — the observer only needs detaching while the runner
+        // is still alive.
+        if Thread.isMainThread {
+            XCTestObservationCenter.shared.removeTestObserver(self)
+        } else {
+            DispatchQueue.main.async { [self] in
+                XCTestObservationCenter.shared.removeTestObserver(self)
+            }
+        }
         state = .stopped
     }
 


### PR DESCRIPTION
## Problem

`XCTestObservationCenter.removeTestObserver` (like `addTestObserver`) is **main-thread-only**. The SDK's observer lifecycle is asymmetric:

- **Added** from the load-time C constructor `__AutoLoadHook` → `libraryLoaded()` → `start()` → `addTestObserver`. Constructors run at dylib load = main thread → fine.
- **Removed** from the unload-time C destructor `__AutoUnloadHook` → `libraryUnloaded()` → `stop()` → `removeObserver()` → `removeTestObserver`. Nothing hopped to the main thread.

The destructor's thread depends on who calls `exit()`:

| Runner | `exit()` caller | Thread | Result |
|---|---|---|---|
| Classic `xctest` (Xcode / iOS-sim) | after the run loop | main | ✅ fine |
| swift-testing / `swift test` | `Runner.main` async continuation | Swift Concurrency background thread | 💥 crash |

So under the swift-testing runner, teardown raised:
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'Test observers can only be registered and unregistered on the main thread.'
   -[XCTestObservationCenter removeTestObserver:]  ←  __AutoUnloadHook
```

Pre-existing; independent of any OpenTelemetry work.

## Fix

`removeObserver()` now removes on the main thread — directly when already on it, otherwise via `DispatchQueue.main.async`. The hop is **async on purpose**: a synchronous hop can deadlock during process teardown if the main thread is already finalizing, and if the block never runs because the process exits first, that's harmless (the observer only needs detaching while the runner is alive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)