### PR TITLE
Make RequestObserver and PagedRequestObserver async

### DIFF
--- a/Sources/DatadogSDKTesting/Telemetry/TelemetryObservers.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/TelemetryObservers.swift
@@ -35,23 +35,23 @@ extension Telemetry {
     /// Each closure is optional so a family only wires the metrics it has.
     struct RequestMetricsObserver: RequestObserver {
         /// The request happened (counted regardless of success).
-        var onRequest: (@Sendable () -> Void)? = nil
+        var onRequest: (@Sendable () async -> Void)? = nil
         /// Request round-trip duration, in milliseconds.
-        var onDurationMs: (@Sendable (Double) -> Void)? = nil
+        var onDurationMs: (@Sendable (Double) async -> Void)? = nil
         /// Size of the serialized request payload, in bytes.
-        var onRequestBytes: (@Sendable (Int) -> Void)? = nil
+        var onRequestBytes: (@Sendable (Int) async -> Void)? = nil
         /// Size of the received response body, in bytes.
-        var onResponseBytes: (@Sendable (Int) -> Void)? = nil
+        var onResponseBytes: (@Sendable (Int) async -> Void)? = nil
         /// The request failed; the derived `error_type` is supplied.
-        var onError: (@Sendable (ErrorType) -> Void)? = nil
+        var onError: (@Sendable (ErrorType) async -> Void)? = nil
 
         func requestFinished(durationMs: Double, requestBytes: Int, responseBytes: Int,
-                             statusCode: Int?, transportError: (any Error)?, failed: Bool) {
-            onRequest?()
-            onDurationMs?(durationMs)
-            onRequestBytes?(requestBytes)
-            onResponseBytes?(responseBytes)
-            if failed { onError?(Telemetry.errorType(statusCode: statusCode, transportError: transportError)) }
+                             statusCode: Int?, transportError: (any Error)?, failed: Bool) async {
+            await onRequest?()
+            await onDurationMs?(durationMs)
+            await onRequestBytes?(requestBytes)
+            await onResponseBytes?(responseBytes)
+            if failed { await onError?(Telemetry.errorType(statusCode: statusCode, transportError: transportError)) }
         }
     }
 

--- a/Sources/EventsExporter/API/HTTPClient.swift
+++ b/Sources/EventsExporter/API/HTTPClient.swift
@@ -104,32 +104,73 @@ public final class HTTPClient: HTTPClientType {
     
     @discardableResult
     func send(request: URLRequest, observer: RequestObserver?) async throws(RequestError) -> Response {
-        try await withUnsafeContinuation { continuation in
-            let _ = self._send(request: request, observer: observer) {
+        let (result, facts): (Result<Response, RequestError>, ObserverFacts?) = await withUnsafeContinuation { continuation in
+            let _ = self._send(request: request, collectFacts: observer != nil) {
                 continuation.resume(returning: $0)
             }
-        }.get()
+        }
+        // `RequestObserver` is async: invoke it here, in our own async context,
+        // after the (non-async) completion handler has returned.
+        if let observer, let facts {
+            await observer.requestFinished(durationMs: facts.durationMs,
+                                           requestBytes: facts.requestBytes,
+                                           responseBytes: facts.responseBytes,
+                                           statusCode: facts.statusCode,
+                                           transportError: facts.transportError,
+                                           failed: facts.failed)
+        }
+        return try result.get()
     }
-    
+
     @discardableResult
     func send(request: URLRequest, observer: RequestObserver?) throws(RequestError) -> Response {
         let sema = DispatchSemaphore(value: 0)
-        nonisolated(unsafe) var response: Result<Response, RequestError> = .failure(.inconsistentSession)
-        let task = _send(request: request, observer: observer) { result in
-            response = result
+        nonisolated(unsafe) var outcome: (Result<Response, RequestError>, ObserverFacts?) = (.failure(.inconsistentSession), nil)
+        let task = _send(request: request, collectFacts: observer != nil) { result in
+            outcome = result
             sema.signal()
         }
         guard sema.wait(timeout: .now() + request.timeoutInterval) == .success else {
             task.cancel()
             throw .transport(URLError(.timedOut))
         }
-        return try response.get()
+        // This synchronous path runs on the teardown/flush path, where we must not
+        // block on — or depend on — the cooperative executor. `RequestObserver` is
+        // async, so report it fire-and-forget: it records during normal operation
+        // and is simply skipped if the executor is no longer scheduled at process
+        // exit. Telemetry never delays teardown.
+        if let observer, let facts = outcome.1 {
+            Task {
+                await observer.requestFinished(durationMs: facts.durationMs,
+                                               requestBytes: facts.requestBytes,
+                                               responseBytes: facts.responseBytes,
+                                               statusCode: facts.statusCode,
+                                               transportError: facts.transportError,
+                                               failed: facts.failed)
+            }
+        }
+        return try outcome.0.get()
     }
-    
-    
+
+    /// The facts a `RequestObserver` needs, captured inside the (non-async)
+    /// `URLSessionDataTask` completion handler so the (async) observer can be
+    /// invoked afterwards, outside that closure.
+    ///
+    /// `@unchecked Sendable`: an immutable snapshot whose only non-`Sendable`
+    /// member (`transportError`) is read-only, so it is safe to hand to the
+    /// observer across a concurrency boundary.
+    private struct ObserverFacts: @unchecked Sendable {
+        let durationMs: Double
+        let requestBytes: Int
+        let responseBytes: Int
+        let statusCode: Int?
+        let transportError: (any Error)?
+        let failed: Bool
+    }
+
     private func _send(request: URLRequest,
-                       observer: (any RequestObserver)?,
-                       result: @escaping @Sendable (Result<Response, RequestError>) -> Void) -> URLSessionTask
+                       collectFacts: Bool,
+                       result: @escaping @Sendable ((Result<Response, RequestError>, ObserverFacts?)) -> Void) -> URLSessionTask
     {
         // Capture the serialized payload size before `deflate` so it reflects
         // the logical request size rather than the compressed wire size.
@@ -144,22 +185,23 @@ public final class HTTPClient: HTTPClientType {
             Log.debug("Sending request to \(url).....")
         }
         let request = _deflate(request)
-        let start = observer != nil ? DispatchTime.now() : nil
+        let start = collectFacts ? DispatchTime.now() : nil
         let task = session.dataTask(with: request) { data, response, error in
             // Log request and response
             self._log(request: logFields, response: (data, response, error))
-            if let observer, let start {
+            var facts: ObserverFacts? = nil
+            if let start {
                 let durationMs = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
                 let statusCode = (response as? HTTPURLResponse)?.statusCode
                 let success = error == nil && (statusCode.map { (200 ..< 400).contains($0) } ?? false)
-                observer.requestFinished(durationMs: durationMs,
-                                         requestBytes: requestBytes,
-                                         responseBytes: data?.count ?? 0,
-                                         statusCode: statusCode,
-                                         transportError: statusCode == nil ? error : nil,
-                                         failed: !success)
+                facts = ObserverFacts(durationMs: durationMs,
+                                      requestBytes: requestBytes,
+                                      responseBytes: data?.count ?? 0,
+                                      statusCode: statusCode,
+                                      transportError: statusCode == nil ? error : nil,
+                                      failed: !success)
             }
-            result(.init(data: data, response: response, error: error))
+            result((.init(data: data, response: response, error: error), facts))
         }
         task.resume()
         return task

--- a/Sources/EventsExporter/API/KnownTestsApi.swift
+++ b/Sources/EventsExporter/API/KnownTestsApi.swift
@@ -107,7 +107,7 @@ extension KnownTestsApi {
         } while page != nil
 
         let totalFetchMs = Date().timeIntervalSince1970 * 1000 - startTime
-        observer?.finished(totalFetchMs: totalFetchMs)
+        await observer?.finished(totalFetchMs: totalFetchMs)
 
         return tests
     }

--- a/Sources/EventsExporter/Telemetry/MetricObservers.swift
+++ b/Sources/EventsExporter/Telemetry/MetricObservers.swift
@@ -28,7 +28,7 @@ import Foundation
 /// `failed` is `true` whenever the request did not complete successfully.
 public protocol RequestObserver: Sendable {
     func requestFinished(durationMs: Double, requestBytes: Int, responseBytes: Int,
-                         statusCode: Int?, transportError: (any Error)?, failed: Bool)
+                         statusCode: Int?, transportError: (any Error)?, failed: Bool) async
 }
 
 /// Observes a sequence of paginated requests (e.g. Known Tests). Conforms to
@@ -38,34 +38,32 @@ public protocol RequestObserver: Sendable {
 /// cost wall-clock time) and counting only the succeeded pages, so the caller
 /// never times a page itself. Call `finished(totalFetchMs:)` once, after the
 /// last page, to report the pagination-level aggregate.
-public final class PagedRequestObserver: RequestObserver, Sendable {
+public actor PagedRequestObserver: RequestObserver {
     private let wrapped: RequestObserver?
-    private let onPagesFetched: (@Sendable (_ count: Int, _ totalFetchMs: Double, _ totalRequestMs: Double) -> Void)?
-    private let accumulated = Synced<(pageCount: Int, totalRequestMs: Double)>((0, 0))
+    private let onPagesFetched: (@Sendable (_ count: Int, _ totalFetchMs: Double, _ totalRequestMs: Double) async -> Void)?
+    private var pageCount = 0
+    private var totalRequestMs: Double = 0
 
     public init(wrapping observer: RequestObserver? = nil,
-               onPagesFetched: (@Sendable (_ count: Int, _ totalFetchMs: Double, _ totalRequestMs: Double) -> Void)? = nil) {
+               onPagesFetched: (@Sendable (_ count: Int, _ totalFetchMs: Double, _ totalRequestMs: Double) async -> Void)? = nil) {
         self.wrapped = observer
         self.onPagesFetched = onPagesFetched
     }
 
     public func requestFinished(durationMs: Double, requestBytes: Int, responseBytes: Int,
-                                statusCode: Int?, transportError: (any Error)?, failed: Bool) {
-        accumulated.update { state in
-            state.totalRequestMs += durationMs
-            if !failed { state.pageCount += 1 }
-        }
-        wrapped?.requestFinished(durationMs: durationMs, requestBytes: requestBytes,
-                                 responseBytes: responseBytes, statusCode: statusCode,
-                                 transportError: transportError, failed: failed)
+                                statusCode: Int?, transportError: (any Error)?, failed: Bool) async {
+        totalRequestMs += durationMs
+        if !failed { pageCount += 1 }
+        await wrapped?.requestFinished(durationMs: durationMs, requestBytes: requestBytes,
+                                       responseBytes: responseBytes, statusCode: statusCode,
+                                       transportError: transportError, failed: failed)
     }
 
     /// Reports the pagination-level aggregate; call once after the last page.
     /// `totalFetchMs` is the wall-clock time from the first page request to
     /// the last, supplied by the caller since only it spans the whole loop.
-    public func finished(totalFetchMs: Double) {
-        let (pageCount, totalRequestMs) = accumulated.value
-        onPagesFetched?(pageCount, totalFetchMs, totalRequestMs)
+    public func finished(totalFetchMs: Double) async {
+        await onPagesFetched?(pageCount, totalFetchMs, totalRequestMs)
     }
 }
 

--- a/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
@@ -134,7 +134,7 @@ final class TelemetryTests: XCTestCase {
         XCTAssertEqual(Telemetry.errorType(statusCode: 200), .network)
     }
 
-    func testRequestMetricsObserverForwardsFactsAndDerivesErrorType() {
+    func testRequestMetricsObserverForwardsFactsAndDerivesErrorType() async {
         final class Box: @unchecked Sendable {
             var requests = 0
             var durationMs: Double?
@@ -152,8 +152,8 @@ final class TelemetryTests: XCTestCase {
         )
 
         // A failed request forwards all facts and derives the error type.
-        observer.requestFinished(durationMs: 12, requestBytes: 100, responseBytes: 200,
-                                 statusCode: 503, transportError: nil, failed: true)
+        await observer.requestFinished(durationMs: 12, requestBytes: 100, responseBytes: 200,
+                                       statusCode: 503, transportError: nil, failed: true)
         XCTAssertEqual(box.requests, 1)
         XCTAssertEqual(box.durationMs, 12)
         XCTAssertEqual(box.requestBytes, 100)
@@ -162,8 +162,8 @@ final class TelemetryTests: XCTestCase {
 
         // A successful request does not report an error.
         box.error = nil
-        observer.requestFinished(durationMs: 1, requestBytes: 1, responseBytes: 1,
-                                 statusCode: 202, transportError: nil, failed: false)
+        await observer.requestFinished(durationMs: 1, requestBytes: 1, responseBytes: 1,
+                                       statusCode: 202, transportError: nil, failed: false)
         XCTAssertEqual(box.requests, 2)
         XCTAssertNil(box.error)
     }


### PR DESCRIPTION
## Summary
- `RequestObserver.requestFinished` is now `async`, and its callback closures on `Telemetry.RequestMetricsObserver` (`onRequest`, `onDurationMs`, `onRequestBytes`, `onResponseBytes`, `onError`) are async too.
- `PagedRequestObserver` is now an `actor` (dropping the `Synced`-lock-based accumulator) and its `onPagesFetched` closure is async.
- `HTTPClient.perform` now captures the observed request facts inside the `URLSessionDataTask` completion handler and awaits the actual `observer.requestFinished(...)` call afterward, in its own async context, instead of calling it synchronously from inside the non-async completion closure.
- `UploadObserver`/`PayloadObserver` were intentionally left synchronous — out of scope for this change.

## Test plan
- [x] `xcodebuild -scheme EventsExporter test` — 104 tests pass
- [x] `xcodebuild -scheme DatadogSDKTesting -only-testing:DatadogSDKTestingTests/TelemetryTests test` — 7 tests pass
- [x] `xcodebuild -scheme EventsExporter build` / `-scheme DatadogSDKTesting build` — both succeed