### PR TITLE
Update opentelemetry-swift-core to 2.5.1

### DIFF
--- a/DatadogSDKTesting.xcodeproj/project.pbxproj
+++ b/DatadogSDKTesting.xcodeproj/project.pbxproj
@@ -3633,7 +3633,7 @@
 			repositoryURL = "https://github.com/open-telemetry/opentelemetry-swift-core.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.4.0;
+				minimumVersion = 2.5.1;
 			};
 		};
 		A7D7E64E2D074D9200B49C35 /* XCRemoteSwiftPackageReference "swift-code-coverage" */ = {

--- a/Sources/DatadogSDKTesting/Utils/NoopSpanExporter.swift
+++ b/Sources/DatadogSDKTesting/Utils/NoopSpanExporter.swift
@@ -19,4 +19,14 @@ final class NoopSpanExporter: SpanExporter {
     }
 
     func shutdown(explicitTimeout: TimeInterval? = nil) {}
+
+    func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil) async -> SpanExporterResultCode {
+        .success
+    }
+
+    func flush(explicitTimeout: TimeInterval? = nil) async -> SpanExporterResultCode {
+        .success
+    }
+
+    func shutdown(explicitTimeout: TimeInterval? = nil) async {}
 }

--- a/Sources/EventsExporter/Exporter.swift
+++ b/Sources/EventsExporter/Exporter.swift
@@ -108,4 +108,31 @@ public final class Exporter: ExporterProtocol {
     public func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult {
         logsExporter.forceFlush(explicitTimeout: explicitTimeout)
     }
+
+    public func export(spans: [SpanData], explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        let sampled = spans.filter { $0.traceFlags.sampled }
+        guard !sampled.isEmpty else { return .success }
+        return await spanExporterComposite.export(spans: sampled, explicitTimeout: explicitTimeout)
+    }
+
+    public func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        let logsOK = (try? logsExporter.logsStorage.flush()) ?? false
+        let spansOK = (try? spansExporter.spansStorage.flush()) ?? false
+        let covOK = (try? coverageExporter.coverageStorage.flush()) ?? false
+        return (logsOK && spansOK && covOK) ? .success : .failure
+    }
+
+    public func shutdown(explicitTimeout: TimeInterval?) async {
+        await logsExporter.shutdown(explicitTimeout: explicitTimeout)
+        await spansExporter.shutdown(explicitTimeout: explicitTimeout)
+        coverageExporter.shutdown()
+    }
+
+    public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) async -> ExportResult {
+        await logsExporter.export(logRecords: logRecords, explicitTimeout: explicitTimeout)
+    }
+
+    public func forceFlush(explicitTimeout: TimeInterval?) async -> ExportResult {
+        await logsExporter.forceFlush(explicitTimeout: explicitTimeout)
+    }
 }

--- a/Sources/EventsExporter/Exporter.swift
+++ b/Sources/EventsExporter/Exporter.swift
@@ -116,9 +116,9 @@ public final class Exporter: ExporterProtocol {
     }
 
     public func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
-        let logsOK = (try? logsExporter.logsStorage.flush()) ?? false
-        let spansOK = (try? spansExporter.spansStorage.flush()) ?? false
-        let covOK = (try? coverageExporter.coverageStorage.flush()) ?? false
+        let logsOK = (try? logsExporter.logsStorage.flush(timeout: explicitTimeout)) ?? false
+        let spansOK = (try? spansExporter.spansStorage.flush(timeout: explicitTimeout)) ?? false
+        let covOK = (try? coverageExporter.coverageStorage.flush(timeout: explicitTimeout)) ?? false
         return (logsOK && spansOK && covOK) ? .success : .failure
     }
 

--- a/Sources/EventsExporter/Logs/LogsExporter.swift
+++ b/Sources/EventsExporter/Logs/LogsExporter.swift
@@ -83,4 +83,20 @@ internal final class LogsExporter: LogRecordExporter {
     func shutdown(explicitTimeout: TimeInterval?) {
         logsStorage.stop()
     }
+
+    func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) async -> ExportResult {
+        for record in logRecords {
+            guard let context = record.spanContext else { continue }
+            writeLog(DDLog(log: record, span: context))
+        }
+        return .success
+    }
+
+    func forceFlush(explicitTimeout: TimeInterval?) async -> ExportResult {
+        (try? logsStorage.flush()) == true ? .success : .failure
+    }
+
+    func shutdown(explicitTimeout: TimeInterval?) async {
+        logsStorage.stop()
+    }
 }

--- a/Sources/EventsExporter/Logs/LogsExporter.swift
+++ b/Sources/EventsExporter/Logs/LogsExporter.swift
@@ -93,7 +93,7 @@ internal final class LogsExporter: LogRecordExporter {
     }
 
     func forceFlush(explicitTimeout: TimeInterval?) async -> ExportResult {
-        (try? logsStorage.flush()) == true ? .success : .failure
+        (try? logsStorage.flush(timeout: explicitTimeout)) == true ? .success : .failure
     }
 
     func shutdown(explicitTimeout: TimeInterval?) async {

--- a/Sources/EventsExporter/Spans/SpanEventsLog.swift
+++ b/Sources/EventsExporter/Spans/SpanEventsLog.swift
@@ -23,26 +23,7 @@ internal final class SpanEventsLogExporterAdapter: SpanExporter {
     }
 
     func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
-        var records: [ReadableLogRecord] = []
-        for span in spans {
-            for event in span.events {
-                records.append(ReadableLogRecord(
-                    resource: span.resource,
-                    instrumentationScopeInfo: span.instrumentationScope,
-                    timestamp: event.timestamp,
-                    spanContext: SpanContext.create(
-                        traceId: span.traceId,
-                        spanId: span.spanId,
-                        traceFlags: span.traceFlags,
-                        traceState: span.traceState
-                    ),
-                    severity: Self.severity(from: event.attributes["status"]?.description),
-                    body: nil,
-                    attributes: event.attributes,
-                    eventName: event.name
-                ))
-            }
-        }
+        let records = Self.logRecords(from: spans)
         guard !records.isEmpty else { return .success }
         return logRecordExporter.export(logRecords: records,
                                         explicitTimeout: explicitTimeout) == .success ? .success : .failure
@@ -56,6 +37,43 @@ internal final class SpanEventsLogExporterAdapter: SpanExporter {
 
     func shutdown(explicitTimeout: TimeInterval?) {
         // Same — the log exporter is shut down directly via the EventsExporter.
+    }
+
+    func export(spans: [SpanData], explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        let records = Self.logRecords(from: spans)
+        guard !records.isEmpty else { return .success }
+        return await logRecordExporter.export(logRecords: records,
+                                              explicitTimeout: explicitTimeout) == .success ? .success : .failure
+    }
+
+    func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        .success
+    }
+
+    func shutdown(explicitTimeout: TimeInterval?) async {}
+
+    private static func logRecords(from spans: [SpanData]) -> [ReadableLogRecord] {
+        var records: [ReadableLogRecord] = []
+        for span in spans {
+            for event in span.events {
+                records.append(ReadableLogRecord(
+                    resource: span.resource,
+                    instrumentationScopeInfo: span.instrumentationScope,
+                    timestamp: event.timestamp,
+                    spanContext: SpanContext.create(
+                        traceId: span.traceId,
+                        spanId: span.spanId,
+                        traceFlags: span.traceFlags,
+                        traceState: span.traceState
+                    ),
+                    severity: severity(from: event.attributes["status"]?.description),
+                    body: nil,
+                    attributes: event.attributes,
+                    eventName: event.name
+                ))
+            }
+        }
+        return records
     }
 
     /// Map a `status` attribute (set by `DDTracer.logString` / `.logErrorString`)

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -107,6 +107,21 @@ internal final class SpansExporter: SpanExporter {
     func shutdown(explicitTimeout: TimeInterval?) {
         spansStorage.stop()
     }
+
+    func export(spans: [SpanData], explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        for span in spans {
+            exportSpan(span: span)
+        }
+        return .success
+    }
+
+    func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
+        (try? spansStorage.flush()) == true ? .success : .failure
+    }
+
+    func shutdown(explicitTimeout: TimeInterval?) async {
+        spansStorage.stop()
+    }
 }
 
 extension SpansExporter {

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -116,7 +116,7 @@ internal final class SpansExporter: SpanExporter {
     }
 
     func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
-        (try? spansStorage.flush()) == true ? .success : .failure
+        (try? spansStorage.flush(timeout: explicitTimeout)) == true ? .success : .failure
     }
 
     func shutdown(explicitTimeout: TimeInterval?) async {


### PR DESCRIPTION
## Summary
- Bump `opentelemetry-swift-core` dependency requirement from 2.4.0 to 2.5.1.
- 2.5.0 added async overloads to `SpanExporter`/`LogRecordExporter` (`export`/`flush`/`forceFlush`/`shutdown`); their default protocol implementations call `assertionFailure` when not overridden. Implemented real async versions on our own conformers (`SpansExporter`, `LogsExporter`, `SpanEventsLogExporterAdapter`, `Exporter`, `NoopSpanExporter`) so those defaults can never be hit if something starts awaiting them.

## Test plan
- [x] `xcodebuild ... build` succeeds
- [x] `xcodebuild ... test` succeeds (macOS destination)