### PR TITLE
[SDTEST-3909] Log "waiting for X" before each teardown step to diagnose hangs

### DIFF
--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -216,13 +216,13 @@ internal class DDTestMonitor {
     func stop() {
         guard !isStopped else { return }
         isStopped = true
-        efd?.stop()
-        atr?.stop()
-        tia?.stop()
-        coverage?.stop()
-        knownTests?.stop()
-        testManagement?.stop()
-        tracer.shutdown()
+        Log.measure(name: "efd stop") { efd?.stop() }
+        Log.measure(name: "atr stop") { atr?.stop() }
+        Log.measure(name: "tia stop") { tia?.stop() }
+        Log.measure(name: "coverage stop") { coverage?.stop() }
+        Log.measure(name: "knownTests stop") { knownTests?.stop() }
+        Log.measure(name: "testManagement stop") { testManagement?.stop() }
+        Log.measure(name: "tracer shutdown") { tracer.shutdown() }
         Log.measure(name: "gitUploadQueue drain") {
             gitUploadQueue.waitUntilAllOperationsAreFinished()
         }

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -601,10 +601,10 @@ internal class DDTracer {
     }
 
     func flush() {
-        flushRUM()
-        self.tracerProviderSdk.forceFlush()
-        _ = self.logProcessor.forceFlush()
-        self.telemetry?.flush()
+        Log.measure(name: "flushRUM") { flushRUM() }
+        Log.measure(name: "tracerProviderSdk forceFlush") { self.tracerProviderSdk.forceFlush() }
+        _ = Log.measure(name: "logProcessor forceFlush") { self.logProcessor.forceFlush() }
+        _ = Log.measure(name: "telemetry flush") { self.telemetry?.flush() }
         Log.debug("Tracer flush finished")
     }
 
@@ -614,10 +614,10 @@ internal class DDTracer {
         // sealed `FileWriter.stop()`. A pre-shutdown flush would be redundant
         // and could skip a span still being written. We only forward the
         // cross-process RUM flush, which provider shutdown doesn't cover.
-        flushRUM()
-        self.tracerProviderSdk.shutdown()
-        _ = self.logProcessor.shutdown()
-        self.telemetry?.shutdown()
+        Log.measure(name: "flushRUM") { flushRUM() }
+        Log.measure(name: "tracerProviderSdk shutdown") { self.tracerProviderSdk.shutdown() }
+        _ = Log.measure(name: "logProcessor shutdown") { self.logProcessor.shutdown() }
+        Log.measure(name: "telemetry shutdown") { self.telemetry?.shutdown() }
         Log.debug("Tracer shutdown")
     }
 

--- a/Sources/DatadogSDKTesting/Utils/Log.swift
+++ b/Sources/DatadogSDKTesting/Utils/Log.swift
@@ -37,6 +37,7 @@ final class Log: Logger, @unchecked Sendable {
     
     func measure<T, E: Error>(name: String, _ operation: () throws(E) -> T) throws(E) -> T {
         if isDebug {
+            print(prefix: "[Debug][DatadogSDKTesting] ", message: "Waiting for \(name)...")
             let startTime = CFAbsoluteTimeGetCurrent()
             defer {
                 print(name: name, time: CFAbsoluteTimeGetCurrent() - startTime)
@@ -46,9 +47,10 @@ final class Log: Logger, @unchecked Sendable {
             return try operation()
         }
     }
-    
+
     func measure<T, E: Error>(name: String, _ operation: @Sendable () async throws(E) -> T) async throws(E) -> T {
         if isDebug {
+            print(prefix: "[Debug][DatadogSDKTesting] ", message: "Waiting for \(name)...")
             let startTime = CFAbsoluteTimeGetCurrent()
             defer {
                 print(name: name, time: CFAbsoluteTimeGetCurrent() - startTime)


### PR DESCRIPTION
### What and why?

We're investigating a deadlock reported on SDK/framework unload (SDTEST-3909). `DDTracer.flush()`/`shutdown()` and `DDTestMonitor.stop()` run several sequential steps (feature stops, tracer provider/log/telemetry shutdown, git upload queue drain), but `Log.measure` only logged how long a step took *after* it finished. On a genuine hang that leaves zero signal pointing to which step is actually stuck, making field reports hard to diagnose from logs alone.

### How?

- `Log.measure` now prints `Waiting for <name>...` right before starting the timed operation (still gated behind the existing debug-log flag, so default log verbosity is unchanged), in addition to the existing post-hoc `Time elapsed for <name>: Ns.` line.
- Wrapped the previously-unwrapped teardown steps in `Log.measure` so the full sequence is traceable: each feature `stop()` call in `DDTestMonitor.stop()` (including `coverage?.stop()`, which does real synchronous work parsing/uploading coverage), and the `flushRUM()` / provider / log processor / telemetry sub-steps inside `DDTracer.flush()` and `shutdown()`.

With this, on a future hang the last `Waiting for <name>...` line with no matching `Time elapsed for <name>...` line pinpoints exactly which step stalled (e.g. coverage flush vs. git upload queue drain vs. tracer shutdown).

This is diagnostic logging only — no behavior change to the teardown sequence itself.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration) — logging-only change, verified via local build; no behavior change to test
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference