### PR TITLE
[SDTEST-3913] Don't treat non-failing Runtime Issues as test failures

### DIFF
--- a/IntegrationTests/Runner/UnitTests+XCTestSmoke.swift
+++ b/IntegrationTests/Runner/UnitTests+XCTestSmoke.swift
@@ -152,6 +152,30 @@ struct UnitTestsXCTestSmoke: IntergationTestSuite {
         }
     }
     
+    /// SDTEST-3913: an Xcode Runtime Issue (Thread Performance Checker
+    /// priority inversion) is a non-failing `XCTIssue` (`isFailure == false`).
+    /// It must not trigger DD's own retry/suppression handling — the test
+    /// still ends up with a single span, reported as passed, exactly as
+    /// XCTest itself sees it.
+    @Test func runtimeIssueDoesNotFailOrRetry() async throws {
+        try await run(test: "XCRuntimeIssue/testPriorityInversion") { backend, success in
+            let spans = backend.allTestSpans
+            #expect(success == true)
+            #expect(spans.count == 1)
+            let span = try #require(spans.last)
+            let meta = span.meta
+            #expect(meta[DDTestTags.testStatus] == DDTagValues.statusPass)
+            #expect(span.resource == "XCRuntimeIssue.testPriorityInversion")
+            #expect(meta[DDTestTags.testName] == "testPriorityInversion")
+            #expect(meta[DDTestTags.testSuite] == "XCRuntimeIssue")
+            #expect(meta[DDTestTags.testType] == "test")
+            // The issue is still recorded on the span, even though it didn't
+            // fail the test.
+            #expect(meta[DDTags.errorType] != nil)
+            #expect(meta[DDTags.errorMessage] != nil)
+        }
+    }
+
     @Test(
         .disabled(if: XcodeTestRunner.isWatchOSChildSDK,
                   "KSCrash disables signal/mach exception handlers on watchOS (KSCRASH_HAS_SIGNAL = 0, KSCRASH_HAS_MACH = 0), so SIGILL from Swift array bounds traps cannot be captured.")

--- a/IntegrationTests/UnitTests/XCTestSmokeTests.swift
+++ b/IntegrationTests/UnitTests/XCTestSmokeTests.swift
@@ -61,6 +61,30 @@ final class XCNetworkIntegration: XCTestCase {
     }
 }
 
+/// SDTEST-3913: reproduces an Xcode "Runtime Issue" — the Thread Performance
+/// Checker's priority-inversion diagnostic — which XCTest records via
+/// `XCTIssue` with `isFailure == false`. XCTest itself doesn't fail the test
+/// for it, and the SDK must not either (no retry, no failed status).
+final class XCRuntimeIssue: XCTestCase {
+    func testPriorityInversion() {
+        let lock = NSLock()
+        let holderStarted = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global(qos: .background).async {
+            lock.lock()
+            holderStarted.signal()
+            Thread.sleep(forTimeInterval: 1.0)
+            lock.unlock()
+        }
+
+        holderStarted.wait()
+        lock.lock() // main thread (.userInteractive) blocks on a .background holder
+        lock.unlock()
+
+        XCTAssertTrue(true)
+    }
+}
+
 final class XCCrash: XCTestCase {
     func testCrash() {
         let array: [Int] = [1]

--- a/Sources/DatadogSDKTesting/DDTest.swift
+++ b/Sources/DatadogSDKTesting/DDTest.swift
@@ -77,7 +77,12 @@ public final class DDTest: NSObject {
     /// - Parameters:
     ///   - status: the status reported for this test
     @objc public func set(status: TestStatus) {
-        if status == .fail, let error = errorInfo.value {
+        // Applied regardless of `status`: a non-failing issue (e.g. an Xcode
+        // Runtime Issue, or a Swift Testing warning) can still be recorded as
+        // an error on a test that otherwise passes. `applyStatus` only clears
+        // `error.*` tags when the span was previously marked `.fail`, so a
+        // fresh pass/skip status keeps them.
+        if let error = errorInfo.value {
             set(errorTags: error)
         }
         span.applyStatus(status, errorDescription: "Test failed")

--- a/Sources/DatadogSDKTesting/XCTest/DDXCTestObserver.swift
+++ b/Sources/DatadogSDKTesting/XCTest/DDXCTestObserver.swift
@@ -434,7 +434,16 @@ final class DDXCTestObserver: NSObject, XCTestObservation, DDXCTestRetryDelegate
             log.print("testCaseRetry:willRecord: Unknown test run type: \(type(of: testCase.testRun)) for \(testCase)")
             return
         }
-        
+
+        // Non-failing issues (e.g. Xcode Runtime Issues such as QoS priority
+        // inversions) must never be suppressed/retried on: XCTest itself
+        // doesn't count them as a failure, so treating them as one here would
+        // make DD retry a test that XCTest considers passing.
+        guard issue.isFailure else {
+            log.debug("Ignoring non-failing issue \(issue) for test \(testCase)")
+            return
+        }
+
         // Test can fail more than once.
         // We suppress all errors or none.
         guard testRun.ddTotalFailureCount == 0 else {
@@ -468,7 +477,7 @@ final class DDXCTestObserver: NSObject, XCTestObservation, DDXCTestRetryDelegate
             return
         }
         log.debug("testCase:didRecord: \(testCase), issue: \(issue)")
-        
+
         testRun.ddTest.add(error: .init(type: issue.compactDescription.components(separatedBy: " ").first ?? "unknown",
                                         message: issue.description))
     }
@@ -483,7 +492,7 @@ final class DDXCTestObserver: NSObject, XCTestObservation, DDXCTestRetryDelegate
             return
         }
         log.debug("testCase:didRecord: \(testCase), expectedFailure: \(expectedFailure.issue.compactDescription)")
-        
+
         let reason = expectedFailure.failureReason ?? ""
         let type = expectedFailure.issue.compactDescription.components(separatedBy: " ").first ?? "unknown"
         


### PR DESCRIPTION
## Summary
- Fixes #297 — Xcode Runtime Issues (e.g. Thread Performance Checker QoS priority inversions) are delivered as `XCTIssue` with `isFailure == false`, meaning XCTest itself doesn't fail the test for them. `DDXCTestObserver` never checked `isFailure`, so `testCaseRetry(_:willRecord:)` could suppress/retry on these benign diagnostics, causing unnecessary retries and false failures.
- `testCaseRetry(_:willRecord:)` now skips suppression/retry handling when `issue.isFailure == false`.
- `DDTest.set(status:)` no longer strips recorded error tags on a passing/skipped status, so the non-failing issue is still visible as an error on the test span — it just doesn't fail or retry the test.

## Test plan
- [x] Added `XCRuntimeIssue.testPriorityInversion` (`IntegrationTests/UnitTests/XCTestSmokeTests.swift`) — a real QoS priority-inversion repro that triggers Xcode's Thread Performance Checker runtime issue.
- [x] Added `runtimeIssueDoesNotFailOrRetry` (`IntegrationTests/Runner/UnitTests+XCTestSmoke.swift`) — asserts a single span, `testStatus == statusPass`, and `error.type`/`error.message` still present.
- [x] Ran `xcodebuild test -scheme IntegrationTests -only-testing:IntegrationTests/UnitTestsXCTestSmoke` locally — all 12 tests pass, including the new one; debug log confirms the issue is recorded but ignored for retry (`executions: 1, failed: 0`).

Fixes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)