### PR TITLE
[SDTEST-3908] Fix Swift Testing thrown errors not failing the test run

### DIFF
--- a/IntegrationTests/Runner/UnitTests+SwiftTestingSmoke.swift
+++ b/IntegrationTests/Runner/UnitTests+SwiftTestingSmoke.swift
@@ -109,6 +109,59 @@ struct UnitTestsSwiftTestingSmoke: IntergationTestSuite {
         }
     }
 
+    // Regression coverage for issue #280: a test that fails by *throwing* must
+    // make the test process exit non-zero (`success == false`) and be reported
+    // as failed — not silently pass.
+    @Test func basicThrow() async throws {
+        try await run(test: "STBasicThrow/basicThrow()") { backend, success in
+            let spans = backend.allTestSpans
+            #expect(success == false)
+            #expect(spans.count == 1)
+            let span = try #require(spans.last)
+            let meta = span.meta
+            #expect(meta[DDTestTags.testStatus] == DDTagValues.statusFail)
+            #expect(span.resource == "STBasicThrow.basicThrow")
+            #expect(meta[DDTestTags.testName] == "basicThrow")
+            #expect(meta[DDTestTags.testSuite] == "STBasicThrow")
+            #expect(meta[DDTestTags.testType] == "test")
+            #expect(meta[DDTags.errorType] != nil)
+            #expect(meta[DDTags.errorMessage] != nil)
+        }
+    }
+
+    @Test func asynchronousThrow() async throws {
+        try await run(test: "STAsynchronousThrow/asynchronousThrow()") { backend, success in
+            let spans = backend.allTestSpans
+            #expect(success == false)
+            #expect(spans.count == 1)
+            let span = try #require(spans.last)
+            let meta = span.meta
+            #expect(meta[DDTestTags.testStatus] == DDTagValues.statusFail)
+            #expect(span.resource == "STAsynchronousThrow.asynchronousThrow")
+            #expect(meta[DDTestTags.testName] == "asynchronousThrow")
+            #expect(meta[DDTestTags.testSuite] == "STAsynchronousThrow")
+            #expect(meta[DDTestTags.testType] == "test")
+            #expect(meta[DDTags.errorType] != nil)
+        }
+    }
+
+    // Parameterized + throwing: the exact reported shape. Cases value=2 and
+    // value=3 throw; value=1 passes. The process must exit non-zero and the two
+    // throwing cases must be reported as failed.
+    @Test func parameterizedThrow() async throws {
+        try await run(test: "STParameterizedThrow/parameterizedThrow(value:)") { backend, success in
+            let spans = backend.allTestSpans
+            #expect(success == false)
+            #expect(spans.count == 3)
+            let statuses = spans.compactMap { $0.meta[DDTestTags.testStatus] }.sorted()
+            #expect(statuses == [DDTagValues.statusFail, DDTagValues.statusFail, DDTagValues.statusPass])
+            for span in spans {
+                #expect(span.resource == "STParameterizedThrow.parameterizedThrow(value:)")
+                #expect(span.meta[DDTestTags.testSuite] == "STParameterizedThrow")
+            }
+        }
+    }
+
     @Test func nestedSuitePass() async throws {
         try await run(test: "STNestedSuite/Inner/nestedPass()") { backend, success in
             let spans = backend.allTestSpans

--- a/IntegrationTests/Runner/UnitTests+XCTestSmoke.swift
+++ b/IntegrationTests/Runner/UnitTests+XCTestSmoke.swift
@@ -73,6 +73,44 @@ struct UnitTestsXCTestSmoke: IntergationTestSuite {
         }
     }
 
+    // Parity with the Swift Testing `basicThrow`/`asynchronousThrow` coverage
+    // for issue #280: an XCTest that fails by *throwing* (not via `XCTAssert`)
+    // must make the test process exit non-zero (`success == false`) and be
+    // reported as failed, carrying the thrown error's type/message.
+    @Test func basicThrow() async throws {
+        try await run(test: "XCBasicThrow/testBasicThrow") { backend, success in
+            let spans = backend.allTestSpans
+            #expect(success == false)
+            #expect(spans.count == 1)
+            let span = try #require(spans.last)
+            let meta = span.meta
+            #expect(meta[DDTestTags.testStatus] == DDTagValues.statusFail)
+            #expect(span.resource == "XCBasicThrow.testBasicThrow")
+            #expect(meta[DDTestTags.testName] == "testBasicThrow")
+            #expect(meta[DDTestTags.testSuite] == "XCBasicThrow")
+            #expect(meta[DDTestTags.testType] == "test")
+            #expect(meta[DDTags.errorType] != nil)
+            #expect(meta[DDTags.errorMessage] != nil)
+        }
+    }
+
+    @Test func asynchronousThrow() async throws {
+        try await run(test: "XCAsynchronousThrow/testAsynchronousThrow") { backend, success in
+            let spans = backend.allTestSpans
+            #expect(success == false)
+            #expect(spans.count == 1)
+            let span = try #require(spans.last)
+            let meta = span.meta
+            #expect(meta[DDTestTags.testStatus] == DDTagValues.statusFail)
+            #expect(span.resource == "XCAsynchronousThrow.testAsynchronousThrow")
+            #expect(meta[DDTestTags.testName] == "testAsynchronousThrow")
+            #expect(meta[DDTestTags.testSuite] == "XCAsynchronousThrow")
+            #expect(meta[DDTestTags.testType] == "test")
+            #expect(meta[DDTags.errorType] != nil)
+            #expect(meta[DDTags.errorMessage] != nil)
+        }
+    }
+
     @Test func asynchronousPass() async throws {
         try await run(test: "XCAsynchronousPass/testAsynchronousPass") { backend, success in
             let spans = backend.allTestSpans

--- a/IntegrationTests/UnitTests/SwiftTestingSmokeTests.swift
+++ b/IntegrationTests/UnitTests/SwiftTestingSmokeTests.swift
@@ -79,6 +79,36 @@ import DatadogSDKTesting
     }
 }
 
+/// Regression coverage for https://github.com/DataDog/dd-sdk-swift-testing/issues/280
+/// A Swift Testing test that fails by *throwing* an error (not via `#expect`).
+/// Before the fix the SDK swallowed the throw and the process exited 0, so CI
+/// stayed green while the Datadog UI showed the test as failed.
+enum STThrownError: Error { case boom(String) }
+
+@Suite(.datadogTesting) struct STBasicThrow {
+    @Test func basicThrow() throws {
+        throw STThrownError.boom("basicThrow")
+    }
+}
+
+@Suite(.datadogTesting) struct STAsynchronousThrow {
+    @Test func asynchronousThrow() async throws {
+        try? await Task.sleep(nanoseconds: 1_000_000)
+        throw STThrownError.boom("asynchronousThrow")
+    }
+}
+
+/// The exact shape from the issue report: a *parameterized* test that throws
+/// for some arguments.
+@Suite(.datadogTesting) struct STParameterizedThrow {
+    @Test(arguments: [1, 2, 3])
+    func parameterizedThrow(value: Int) throws {
+        if value != 1 {
+            throw STThrownError.boom("parameterizedThrow-\(value)")
+        }
+    }
+}
+
 @Suite(.datadogTesting) struct STCrash {
     @Test func crash() {
         let array: [Int] = [1]

--- a/IntegrationTests/UnitTests/XCTestSmokeTests.swift
+++ b/IntegrationTests/UnitTests/XCTestSmokeTests.swift
@@ -46,6 +46,24 @@ final class XCAsynchronousError: XCTestCase {
     }
 }
 
+/// Parity with issue #280 (Swift Testing `STBasicThrow`/`STAsynchronousThrow`):
+/// an XCTest that fails by *throwing* an error — rather than via `XCTAssert` —
+/// must make the test process exit non-zero and be reported as failed.
+enum XCThrownError: Error { case boom(String) }
+
+final class XCBasicThrow: XCTestCase {
+    func testBasicThrow() throws {
+        throw XCThrownError.boom("basicThrow")
+    }
+}
+
+final class XCAsynchronousThrow: XCTestCase {
+    func testAsynchronousThrow() async throws {
+        try? await Task.sleep(nanoseconds: 1_000_000)
+        throw XCThrownError.boom("asynchronousThrow")
+    }
+}
+
 final class XCBenchmark: XCTestCase {
     func testBenchmark() {
         measure {

--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingContext.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingContext.swift
@@ -406,6 +406,16 @@ struct SwiftTestingRetryGroupContext: Sendable {
             case .issues(.suppressed(let issues)):
                 errors = .init(catched: nil, issues: issues)
                 status = status.asUnsuppressed
+            case .catched(error: let err, suppressed: false, issues: _):
+                // A thrown error that was NOT suppressed. `withKnownIssue`
+                // rethrew it (it is not a "known issue"), so our `provideScope`
+                // catch swallowed it and Swift Testing recorded nothing — the
+                // run would pass despite throwing (issue #280). Any in-body
+                // issues here were unsuppressed and are already recorded by
+                // Swift Testing, so re-record only the thrown error to actually
+                // fail the run. `errorsWereRecorded` already reports true for
+                // this status, so `endAction` stays consistent.
+                errors = .init(catched: err, issues: [])
             default: errors = nil
             }
         } else {

--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingContext.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingContext.swift
@@ -137,16 +137,21 @@ enum SwiftTestingTestStatus: Sendable {
             }
         }
         
-        mutating func catched(error: any Error) {
+        /// Records a thrown error, keeping the suppression state derived from
+        /// the issues collected so far. Returns whether the error is
+        /// suppressed, mirroring `add(issue:)`.
+        mutating func catched(error: any Error) -> Bool {
             guard case .issues(let issues) = self else {
                 // can't happen. We can't have double throw
-                return
+                return false
             }
             switch issues {
             case .suppressed(let issues):
                 self = .catched(error: error, suppressed: true, issues: issues)
+                return true
             case .unsuppressed(let issues):
                 self = .catched(error: error, suppressed: false, issues: issues)
+                return false
             }
         }
         
@@ -406,16 +411,6 @@ struct SwiftTestingRetryGroupContext: Sendable {
             case .issues(.suppressed(let issues)):
                 errors = .init(catched: nil, issues: issues)
                 status = status.asUnsuppressed
-            case .catched(error: let err, suppressed: false, issues: _):
-                // A thrown error that was NOT suppressed. `withKnownIssue`
-                // rethrew it (it is not a "known issue"), so our `provideScope`
-                // catch swallowed it and Swift Testing recorded nothing — the
-                // run would pass despite throwing (issue #280). Any in-body
-                // issues here were unsuppressed and are already recorded by
-                // Swift Testing, so re-record only the thrown error to actually
-                // fail the run. `errorsWereRecorded` already reports true for
-                // this status, so `endAction` stays consistent.
-                errors = .init(catched: err, issues: [])
             default: errors = nil
             }
         } else {
@@ -802,13 +797,16 @@ extension Optional where Wrapped == SwiftTestingTestStatus.Errors {
         }
     }
     
-    mutating func catched(error: any Error, suppress: @autoclosure () -> Bool) {
+    mutating func catched(error: any Error, suppress: @autoclosure () -> Bool) -> Bool {
         switch self {
         case .none:
-            self = .some(.catched(error: error, suppressed: suppress(), issues: []))
+            let res = suppress()
+            self = .some(.catched(error: error, suppressed: res, issues: []))
+            return res
         case .some(var errors):
-            errors.catched(error: error)
+            let res = errors.catched(error: error)
             self = .some(errors)
+            return res
         }
     }
 }

--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTrait.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTrait.swift
@@ -139,10 +139,14 @@ public struct DatadogSwiftTestingScopeProvider: TestScoping {
                             // by `withKnownIssue` (it's not a known issue) and
                             // recorded nothing, so the run would pass despite
                             // throwing (issue #280). Record it now to fail the
-                            // run. Suppressed errors are held back and restored
-                            // on the retry path.
+                            // run. Goes through `_actions` (not `Issue.record`
+                            // directly) so the unit-test harness — which drives
+                            // `provideScope` outside a live Swift Testing test —
+                            // can stub it; a direct `Issue.record` traps there.
+                            // Suppressed errors are held back and restored on the
+                            // retry path.
                             if !suppressed {
-                                Issue.record(error, sourceLocation: run.info.location.asSwift)
+                                _actions.record(error: error, location: run.info.location)
                             }
                         }
                     }
@@ -177,6 +181,7 @@ public struct DatadogSwiftTestingScopeProvider: TestScoping {
 protocol DatadogSwiftTestingTestActions: Sendable {
     func cancel(reason: String, location: SwiftTestingSourceLocation) throws
     func fail(reason: String, location: SwiftTestingSourceLocation)
+    func record(error: any Error, location: SwiftTestingSourceLocation)
 }
 
 extension Testing.Trait where Self == DatadogSwiftTestingTrait {
@@ -246,6 +251,10 @@ extension DatadogSwiftTestingScopeProvider {
         
         func fail(reason: String, location: SwiftTestingSourceLocation) {
             Issue.record(Comment(rawValue: reason), sourceLocation: location.asSwift)
+        }
+
+        func record(error: any Error, location: SwiftTestingSourceLocation) {
+            Issue.record(error, sourceLocation: location.asSwift)
         }
     }
     

--- a/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTrait.swift
+++ b/Sources/DatadogSDKTesting/SwiftTesting/SwiftTestingTrait.swift
@@ -131,9 +131,18 @@ public struct DatadogSwiftTestingScopeProvider: TestScoping {
                         if error.isSwiftTestingSkip {
                             return .cancelled(error: error, issues: errors.value?.issues)
                         } else {
-                            errors.update {
+                            let suppressed = errors.update {
                                 $0.catched(error: error,
                                            suppress: run.shouldSuppressError(info: runInfo))
+                            }
+                            // A thrown error that is NOT suppressed was rethrown
+                            // by `withKnownIssue` (it's not a known issue) and
+                            // recorded nothing, so the run would pass despite
+                            // throwing (issue #280). Record it now to fail the
+                            // run. Suppressed errors are held back and restored
+                            // on the retry path.
+                            if !suppressed {
+                                Issue.record(error, sourceLocation: run.info.location.asSwift)
                             }
                         }
                     }

--- a/Tests/DatadogSDKTesting/MockSwiftTesting.swift
+++ b/Tests/DatadogSDKTesting/MockSwiftTesting.swift
@@ -14,6 +14,7 @@ extension Mocks {
             throw STSkipError(reason: reason)
         }
         func fail(reason: String, location: SwiftTestingSourceLocation) {}
+        func record(error: any Error, location: SwiftTestingSourceLocation) {}
     }
     
     struct STSuite: SwiftTestingTestInfoType {


### PR DESCRIPTION
## What & why

Fixes GitHub issue #280 (SDTEST-3908). A Swift Testing test that fails by *throwing* an error (rather than via `#expect`) was reported as failed in the Datadog UI, but the test process still exited `0` — so CI stayed green on a genuinely failing test.

In `provideScope(run:)` the body runs inside `withKnownIssue`. When it throws and the error is not suppressed, `withKnownIssue` rethrows and records nothing; our `catch` stored it as `.catched(suppressed: false)` but nothing re-recorded it, so `endAction` stayed `.none` and the run never failed.

## How

The fix is symmetric with how in-body issues are already handled:

- `Errors.catched(error:)` (and the `Optional<Errors>.catched(error:suppress:)` extension) now **return whether the error was suppressed**, mirroring `add(issue:)`.
- In the trait's `catch`, when the thrown error is **not** suppressed we record it immediately — the same moment `withKnownIssue` records unsuppressed in-body issues. Suppressed errors still flow through the retry/restore path unchanged.
- This removed the need for a dedicated `.catched(suppressed: false)` branch in `SwiftTestingRetryGroupContext.with(run:)`.

Recording goes through the injectable `_actions` seam (`record(error:location:)`), **not** `Testing.Issue.record` directly. The mock unit-test harness drives the real `provideScope` *outside* a live Swift Testing test and stubs all Testing side-effects (`cancel`/`fail`/`record`) to no-ops; a direct `Issue.record` traps there (no current test) and crashed `TestManagementSwiftTestingTests`. Production `Actions.record` calls `Issue.record` as before.

## Tests

- **Swift Testing** end-to-end coverage: `STBasicThrow`, `STAsynchronousThrow`, `STParameterizedThrow` assert the child test process exits non-zero and the throwing cases are reported failed. These fail on the unfixed SDK and pass with the fix.
- **XCTest** parity coverage added: `XCBasicThrow` / `XCAsynchronousThrow` — a `throws` test that fails by throwing (not via `XCTAssert`) must exit non-zero with a failed span carrying the thrown error's type/message. (XCTest was never affected by this bug — it doesn't wrap bodies in `withKnownIssue` — so these are regression guards.)
- Full mock-driven Swift Testing unit suites (`SwiftTestingTraitTests`, `TestManagementSwiftTestingTests`, `AutoTestRetriesSwiftTestingTests`, `EarlyFlakeDetectionSwiftTestingTests`, `TestImpactAnalysisSwiftTestingTests`) pass — including `testTMAttemptToFixWorks`, which the earlier revision crashed.

The unit meta-tests can't catch the original #280 bug because `ObserverTesterTrait` wraps the body in a cooperating outer `withKnownIssue` that absorbs the error; the integration tests are the real guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)