### PR TITLE
[SDTEST-3913] Stabilize CI: deterministic runtime-issue test + CI-proof flush timeout

### DIFF
--- a/IntegrationTests/Runner/UnitTests+XCTestSmoke.swift
+++ b/IntegrationTests/Runner/UnitTests+XCTestSmoke.swift
@@ -152,21 +152,21 @@ struct UnitTestsXCTestSmoke: IntergationTestSuite {
         }
     }
     
-    /// SDTEST-3913: an Xcode Runtime Issue (Thread Performance Checker
-    /// priority inversion) is a non-failing `XCTIssue` (`isFailure == false`).
-    /// It must not trigger DD's own retry/suppression handling — the test
-    /// still ends up with a single span, reported as passed, exactly as
-    /// XCTest itself sees it.
+    /// SDTEST-3913: an Xcode Runtime Issue is a non-failing `XCTIssue`
+    /// (`isFailure == false`). It must not trigger DD's own retry/suppression
+    /// handling — the test still ends up with a single span, reported as
+    /// passed, exactly as XCTest itself sees it, while the issue is still
+    /// recorded on the span.
     @Test func runtimeIssueDoesNotFailOrRetry() async throws {
-        try await run(test: "XCRuntimeIssue/testPriorityInversion") { backend, success in
+        try await run(test: "XCRuntimeIssue/testNonFailingRuntimeIssue") { backend, success in
             let spans = backend.allTestSpans
             #expect(success == true)
             #expect(spans.count == 1)
             let span = try #require(spans.last)
             let meta = span.meta
             #expect(meta[DDTestTags.testStatus] == DDTagValues.statusPass)
-            #expect(span.resource == "XCRuntimeIssue.testPriorityInversion")
-            #expect(meta[DDTestTags.testName] == "testPriorityInversion")
+            #expect(span.resource == "XCRuntimeIssue.testNonFailingRuntimeIssue")
+            #expect(meta[DDTestTags.testName] == "testNonFailingRuntimeIssue")
             #expect(meta[DDTestTags.testSuite] == "XCRuntimeIssue")
             #expect(meta[DDTestTags.testType] == "test")
             // The issue is still recorded on the span, even though it didn't

--- a/IntegrationTests/UnitTests/XCTestSmokeTests.swift
+++ b/IntegrationTests/UnitTests/XCTestSmokeTests.swift
@@ -61,27 +61,24 @@ final class XCNetworkIntegration: XCTestCase {
     }
 }
 
-/// SDTEST-3913: reproduces an Xcode "Runtime Issue" — the Thread Performance
-/// Checker's priority-inversion diagnostic — which XCTest records via
-/// `XCTIssue` with `isFailure == false`. XCTest itself doesn't fail the test
-/// for it, and the SDK must not either (no retry, no failed status).
+/// SDTEST-3913: an Xcode "Runtime Issue" (e.g. the Thread Performance Checker's
+/// priority-inversion diagnostic) is surfaced by XCTest as a *non-failing*
+/// `XCTIssue` — one whose severity is below `.error`, so `isFailure == false`.
+/// XCTest itself doesn't fail the test for it, and the SDK must not either (no
+/// retry, no failed status) while still recording it on the span.
+///
+/// We record a `.warning`-severity `XCTIssue` directly rather than provoking a
+/// real priority inversion: the Thread Performance Checker is a runtime
+/// diagnostic that is not injected into the `test-without-building` launch the
+/// integration runner uses, so a real inversion never fires in CI. A
+/// `.warning`-severity issue reproduces exactly what the SDK observes
+/// (`isFailure == false`) and makes the test deterministic on every platform.
 final class XCRuntimeIssue: XCTestCase {
-    func testPriorityInversion() {
-        let lock = NSLock()
-        let holderStarted = DispatchSemaphore(value: 0)
-
-        DispatchQueue.global(qos: .background).async {
-            lock.lock()
-            holderStarted.signal()
-            Thread.sleep(forTimeInterval: 1.0)
-            lock.unlock()
-        }
-
-        holderStarted.wait()
-        lock.lock() // main thread (.userInteractive) blocks on a .background holder
-        lock.unlock()
-
-        XCTAssertTrue(true)
+    func testNonFailingRuntimeIssue() {
+        let issue = XCTIssue(type: .system,
+                             compactDescription: "RuntimeIssue: simulated non-failing diagnostic",
+                             severity: .warning)
+        record(issue)
     }
 }
 

--- a/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
@@ -288,7 +288,15 @@ class DataUploadWorkerTests: XCTestCase {
             fileReader: reader,
             dataUploader: dataUploader,
             delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
-            uploadTimeout: 5,
+            // `flush(timeout: nil)` uses this as a real wall-clock budget for the
+            // whole drain. The uploads here are instant (in-memory mock), so the
+            // only thing that consumes the budget is the machine itself: on a
+            // heavily loaded CI simulator the previous 5s expired mid-drain and
+            // `flush` gave up with batches still on disk (flaky `2 != 0`). This
+            // test asserts *all* data is flushed, so give it a budget CI load
+            // can't exhaust — the give-up-on-timeout path is covered separately
+            // by `testFlushGivesUpAfterTimeoutInsteadOfHanging`.
+            uploadTimeout: 60,
             featureName: .mockAny(),
             priority: .userInteractive,
             log: Log()


### PR DESCRIPTION
## What & why

Two test-only fixes for failures observed on `main` in the Integration and Unit test workflows. No production code changes.

### 1. Deterministic non-failing runtime-issue test (`179aa45`)

`runtimeIssueDoesNotFailOrRetry` relied on Xcode's Thread Performance Checker firing a real priority-inversion diagnostic in `XCRuntimeIssue/testPriorityInversion`. That runtime diagnostic is **not injected into the `test-without-building` launch** the integration runner uses, so the inversion never fired in CI: the child test passed with zero recorded issues, `error.type`/`error.message` were nil, and the `!= nil` assertions failed on every platform (macOS/watchOS × Xcode 26.2/26.4).

Fix: record a `.warning`-severity `XCTIssue` directly. `isFailure` is false for any severity below `.error`, so this reproduces exactly what the SDK observes for an Xcode Runtime Issue — recorded on the span, but not a failure — deterministically on every platform. Renamed the test to `testNonFailingRuntimeIssue` to reflect what it now does.

### 2. CI-proof flush timeout for `testItFlushesAllData` (`1916586`)

The test built the worker with `uploadTimeout: 5` and called `flush(timeout: nil)`, which uses that as a real wall-clock budget for the whole drain. The uploads are instant (in-memory mock), so only machine load consumes the budget — and on an overloaded CI simulator (observed on visionOS 26.4, the test taking **17.6s** vs ~0.1s normally) the 5s elapsed after the first batch. `flush` then gave up ("flush timed out; leaving remaining batches on disk"), leaving 2 of 3 batches on disk and failing `files().count == 0`.

Fix: raise the budget to 60s so CI load can't exhaust it. Uploads still complete instantly (0.008s locally), so healthy runtime is unchanged. The give-up-on-timeout behaviour stays covered by `testFlushGivesUpAfterTimeoutInsteadOfHanging`.

## Tests

- The child `XCRuntimeIssue/testNonFailingRuntimeIssue` passes locally; both integration targets build.
- Full `DataUploadWorkerTests` suite (10 tests) passes; `testItFlushesAllData` runs in 0.008s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)