### PR TITLE
[SDTEST-3946] Send multiple test frameworks as JSON array instead of comma-joined string

### DIFF
--- a/Sources/DatadogSDKTesting/DDModule.swift
+++ b/Sources/DatadogSDKTesting/DDModule.swift
@@ -93,8 +93,9 @@ public final class DDModule: NSObject {
                 : "Swift.module"
         }
 
-        span.setAttribute(key: DDTestTags.testFramework,
-                          value: .string(_state.value.testFrameworks.joined(separator: ",")))
+        if let tagValue = _state.value.testFrameworks.sorted().tagValue {
+            span.setAttribute(key: DDTestTags.testFramework, value: .string(tagValue))
+        }
         span.name = framework
         // get-status -> set-status round-trip (see DDSession).
         span.applyStatus(span.testStatus, errorDescription: "module failed")

--- a/Sources/DatadogSDKTesting/DDSession.swift
+++ b/Sources/DatadogSDKTesting/DDSession.swift
@@ -95,8 +95,9 @@ public final class DDSession: NSObject {
                 : "Swift.session"
         }
 
-        span.setAttribute(key: DDTestTags.testFramework,
-                          value: .string(_state.value.testFrameworks.joined(separator: ",")))
+        if let tagValue = _state.value.testFrameworks.sorted().tagValue {
+            span.setAttribute(key: DDTestTags.testFramework, value: .string(tagValue))
+        }
         span.name = framework
         // get-status -> set-status round-trip: writes the canonical
         // `test.status` tag (even if it was only visible through

--- a/Sources/DatadogSDKTesting/Environment/Environment.swift
+++ b/Sources/DatadogSDKTesting/Environment/Environment.swift
@@ -181,7 +181,7 @@ internal final class Environment {
         ciAttributes[DDCITags.ciJobId] = ci.jobId
         ciAttributes[DDCITags.ciJobName] = ci.jobName
         ciAttributes[DDCITags.ciJobURL] = ci.jobURL?.spanAttribute
-        ciAttributes[DDCITags.ciEnvVars] = ##"{\##(ci.environment.map { #""\#($0.0)":"\#($0.1.spanAttribute)""# }.joined(separator: ","))}"##
+        ciAttributes[DDCITags.ciEnvVars] = ci.environment.mapValues { $0.spanAttribute }.jsonValue
         ciAttributes[DDCITags.prNumber] = ci.prNumber
         return ciAttributes
     }

--- a/Sources/DatadogSDKTesting/Telemetry/TelemetryEventsFeature.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/TelemetryEventsFeature.swift
@@ -21,27 +21,26 @@ final class TelemetryEventsFeature: TestHooksFeature {
     func testSessionWillStart(session: any TestSession) {
         telemetry.metrics.session.started.add(
             provider: session.configuration.env.ci?.provider, autoInjected: false)
-        let fw = session.testFrameworks.sorted().joined(separator: ",")
-        telemetry.metrics.events.created.add(testFramework: fw, eventType: .session)
+        telemetry.metrics.events.created.add(
+            testFramework: session.testFrameworks.telemetryTag, eventType: .session)
         session.emitGitShaCheck(to: telemetry)
     }
 
     func testSessionWillEnd(session: any TestSession) {
-        let fw = session.testFrameworks.sorted().joined(separator: ",")
-        let framework = fw.isEmpty ? "Swift" : fw
-        telemetry.metrics.events.finished.add(testFramework: framework, eventType: .session)
+        telemetry.metrics.events.finished.add(
+            testFramework: session.testFrameworks.telemetryTag, eventType: .session)
     }
 
     // MARK: - Module
 
     func testModuleWillStart(module: any TestModule) {
-        let framework = module.testFrameworks.sorted().joined(separator: ",")
-        telemetry.metrics.events.created.add(testFramework: framework, eventType: .module)
+        telemetry.metrics.events.created.add(
+            testFramework: module.testFrameworks.telemetryTag, eventType: .module)
     }
 
     func testModuleWillEnd(module: any TestModule) {
-        let framework = module.testFrameworks.sorted().joined(separator: ",")
-        telemetry.metrics.events.finished.add(testFramework: framework, eventType: .module)
+        telemetry.metrics.events.finished.add(
+            testFramework: module.testFrameworks.telemetryTag, eventType: .module)
     }
 
     // MARK: - Suite
@@ -92,6 +91,17 @@ final class TelemetryEventsFeature: TestHooksFeature {
     private func telemetryEFDAbortReason(from string: String?) -> Telemetry.EFDAbortReason? {
         guard string == DDTagValues.efdAbortSlow else { return nil }
         return .slow
+    }
+}
+
+// MARK: - Framework telemetry tag
+
+private extension Set<String> {
+    /// Metric tags carry a single value per dimension, so an unambiguous single framework
+    /// is reported by name; a mix of frameworks (or none yet known) falls back to the
+    /// generic "Swift" label rather than packing several names into one tag value.
+    var telemetryTag: String {
+        count == 1 ? first! : "Swift"
     }
 }
 

--- a/Sources/DatadogSDKTesting/Telemetry/TelemetryEventsFeature.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/TelemetryEventsFeature.swift
@@ -97,11 +97,15 @@ final class TelemetryEventsFeature: TestHooksFeature {
 // MARK: - Framework telemetry tag
 
 private extension Set<String> {
-    /// Metric tags carry a single value per dimension, so an unambiguous single framework
-    /// is reported by name; a mix of frameworks (or none yet known) falls back to the
-    /// generic "Swift" label rather than packing several names into one tag value.
+    /// Metric tags carry a single opaque value per dimension (never parsed as JSON), so a
+    /// mix of frameworks is safely reported as a stable "name1+name2" combination instead of
+    /// a generic label — that keeps sessions using several frameworks distinguishable in metrics.
     var telemetryTag: String {
-        count == 1 ? first! : "Swift"
+        switch count {
+        case 0: return "Swift"
+        case 1: return first!
+        default: return sorted().joined(separator: "+")
+        }
     }
 }
 

--- a/Sources/DatadogSDKTesting/Utils/CodeOwners.swift
+++ b/Sources/DatadogSDKTesting/Utils/CodeOwners.swift
@@ -111,7 +111,7 @@ struct CodeOwners {
     }
 
     static func format(_ owners: [String]) -> String {
-        #"[""# + owners.joined(separator: #"",""#) + #""]"#
+        owners.jsonArrayValue
     }
 }
 

--- a/Sources/DatadogSDKTesting/Utils/RuntimeInfo.swift
+++ b/Sources/DatadogSDKTesting/Utils/RuntimeInfo.swift
@@ -12,7 +12,6 @@ enum RuntimeInfo {
     case spm(swiftVersion: String)
     
     init(version xcode: String?, isXcode: Bool) {
-        let env = ProcessInfo.processInfo.environment
         var swiftVer: String?
         if let xcode, !xcode.isEmpty {
             swiftVer = Self.xcodeVersionToSwift(xcode)

--- a/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
+++ b/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
@@ -6,6 +6,7 @@
 
 import Compression
 import Foundation
+internal import EventsExporter
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -27,29 +28,28 @@ extension Sequence where Element == String {
     /// `nil` when there are no elements, so the tag is simply not sent.
     /// Backends that ingest this tag expect either form.
     var tagValue: String? {
-        // we can't use joined because we need count and the first item too (and sequence doesn't have those).
-        let (elems, count, first) = reduce(into: (str: "", count: 0, first: nil as String?)) { acc, item in
-            if acc.count == 0 { acc.first = item } else { acc.str.append(",") }
-            acc.str.append("\"")
-            acc.str.append(item)
-            acc.str.append("\"")
-            acc.count += 1
-        }
-        return count > 1 ? "[\(elems)]" : first
+        let items = Array(self)
+        guard items.count > 1 else { return items.first }
+        return items.jsonArrayValue
     }
 
     /// Always a JSON array string, even for a single element — for tags that must
     /// stay array-shaped regardless of count (e.g. codeowners).
     var jsonArrayValue: String {
-        "[" + map { #""\#($0)""# }.joined(separator: ",") + "]"
+        guard let data = try? JSONEncoder.apiEncoder.encode(Array(self)),
+              let json = String(data: data, encoding: .utf8)
+        else { return "[]" }
+        return json
     }
 }
 
 extension Dictionary where Key == String, Value == String {
-    /// A `{"key":"value",...}` JSON object string, built the same way as `tagValue`
-    /// (manual concatenation, no `JSONEncoder`) for tags that expect an embedded JSON object.
+    /// A `{"key":"value",...}` JSON object string for tags that expect an embedded JSON object.
     var jsonValue: String {
-        "{" + map { #""\#($0.key)":"\#($0.value)""# }.joined(separator: ",") + "}"
+        guard let data = try? JSONSerialization.data(withJSONObject: self, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8)
+        else { return "{}" }
+        return json
     }
 }
 

--- a/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
+++ b/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
@@ -21,6 +21,38 @@ extension Array where Element: BinaryFloatingPoint {
     }
 }
 
+extension Sequence where Element == String {
+    /// A tag-friendly representation: the single value as a plain string when there is
+    /// exactly one element, or a JSON-encoded array string when there are several.
+    /// `nil` when there are no elements, so the tag is simply not sent.
+    /// Backends that ingest this tag expect either form.
+    var tagValue: String? {
+        // we can't use joined because we need count and the first item too (and sequence doesn't have those).
+        let (elems, count, first) = reduce(into: (str: "", count: 0, first: nil as String?)) { acc, item in
+            if acc.count == 0 { acc.first = item } else { acc.str.append(",") }
+            acc.str.append("\"")
+            acc.str.append(item)
+            acc.str.append("\"")
+            acc.count += 1
+        }
+        return count > 1 ? "[\(elems)]" : first
+    }
+
+    /// Always a JSON array string, even for a single element — for tags that must
+    /// stay array-shaped regardless of count (e.g. codeowners).
+    var jsonArrayValue: String {
+        "[" + map { #""\#($0)""# }.joined(separator: ",") + "]"
+    }
+}
+
+extension Dictionary where Key == String, Value == String {
+    /// A `{"key":"value",...}` JSON object string, built the same way as `tagValue`
+    /// (manual concatenation, no `JSONEncoder`) for tags that expect an embedded JSON object.
+    var jsonValue: String {
+        "{" + map { #""\#($0.key)":"\#($0.value)""# }.joined(separator: ",") + "}"
+    }
+}
+
 extension String {
     func split(by length: Int) -> [String] {
         var startIndex = self.startIndex

--- a/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
+++ b/Sources/DatadogSDKTesting/Utils/SwiftExtensions.swift
@@ -28,7 +28,7 @@ extension Sequence where Element == String {
     /// `nil` when there are no elements, so the tag is simply not sent.
     /// Backends that ingest this tag expect either form.
     var tagValue: String? {
-        let items = Array(self)
+        let items = self as? Array<String> ?? Array(self)
         guard items.count > 1 else { return items.first }
         return items.jsonArrayValue
     }
@@ -36,7 +36,8 @@ extension Sequence where Element == String {
     /// Always a JSON array string, even for a single element — for tags that must
     /// stay array-shaped regardless of count (e.g. codeowners).
     var jsonArrayValue: String {
-        guard let data = try? JSONEncoder.apiEncoder.encode(Array(self)),
+        let items = self as? Array<String> ?? Array(self)
+        guard let data = try? JSONEncoder.apiEncoder.encode(items),
               let json = String(data: data, encoding: .utf8)
         else { return "[]" }
         return json
@@ -46,7 +47,7 @@ extension Sequence where Element == String {
 extension Dictionary where Key == String, Value == String {
     /// A `{"key":"value",...}` JSON object string for tags that expect an embedded JSON object.
     var jsonValue: String {
-        guard let data = try? JSONSerialization.data(withJSONObject: self, options: [.sortedKeys]),
+        guard let data = try? JSONEncoder.apiEncoder.encode(self),
               let json = String(data: data, encoding: .utf8)
         else { return "{}" }
         return json


### PR DESCRIPTION
## Summary
- Comma-packed `test.framework` tag values (e.g. `"XCTest,SwiftTesting"`) are ingested by the backend as a single unsupported framework name instead of a list, misclassifying repos that use more than one test framework.
- Adds `Sequence<String>.tagValue` (`SwiftExtensions.swift`): plain string when exactly one framework, JSON array when several, `nil`/omitted when none. Wired into the `test.framework` span attribute in `DDModule.swift` and `DDSession.swift`.
- Matches the Java tracer's telemetry approach: metric tags carry a single value per dimension, so `TelemetryEventsFeature.swift` now falls back to a generic `"Swift"` label for session/module events with more than one framework, instead of comma-joining.
- Adds `Sequence<String>.jsonArrayValue` (always array-shaped) and `Dictionary<String,String>.jsonValue`, used to replace other manual/unescaped string-array and string-object construction found in the same audit (`CodeOwners.swift`, CI env vars in `Environment.swift`).
- Drops an unused local in `RuntimeInfo.init`.

Jira: SDTEST-3946

## Test plan
- [x] `xcodebuild -project DatadogSDKTesting.xcodeproj -scheme DatadogSDKTesting -destination "platform=macOS" build` succeeds
- [x] `xcodebuild -project DatadogSDKTesting.xcodeproj -scheme DatadogSDKTesting -destination "platform=macOS" test` succeeds