### PR TITLE
[SDTEST-3944] Fix async test methods losing source-line attribution

### DIFF
--- a/Sources/DatadogSDKTesting/Utils/FileLocator.swift
+++ b/Sources/DatadogSDKTesting/Utils/FileLocator.swift
@@ -22,116 +22,118 @@ typealias FunctionName = String
 typealias FunctionMap = [FunctionName: FunctionInfo]
 
 enum FileLocator {
-    enum State {
-        case skipping
-        case started(function: FunctionName, module: String?)
-        case parsing(function: FunctionName, module: String, info: FunctionInfo)
-        case continuing(mapKey: String)  // same function split into closure/wrapper blocks
-
-        var isParsing: Bool {
-            switch self {
-            case .skipping: return false
-            case .parsing, .started, .continuing: return true
-            }
-        }
-    }
-    
     static func extractFunctions(_ symbolsOutput: URL) throws -> FunctionMap {
-        var state: State = .skipping
         var map = FunctionMap()
+
+        // Keys of functions we know are real declarations (an EXT/OBJC-tagged header was seen
+        // for them), so later chunks belonging to the same function that carry no EXT/OBJC tag
+        // of their own — async continuations, `@objc` thunks, generic `specialized` clones,
+        // closures, partial applies — can still be matched back by name and contribute their
+        // source lines, no matter where in the file they land.
+        var trackedKeys: Set<String> = []
+        // The key currently receiving source-line records, if any.
+        var activeKey: String? = nil
+        // Set right after an EXT header whose name had no module prefix (e.g. a bare global
+        // function): the key can't be known until the first real source line reveals the file,
+        // from which the synthetic module name is derived.
+        var pendingModuleless: FunctionName? = nil
+
         let file = DDFileReader(fileURL: symbolsOutput)
         try file.open()
         defer { file.close() }
-        
+
         // A function name is either an ObjC method (`-[Class selector:]`, may contain
         // spaces) or a Swift symbol. A Swift Testing function name can be backtick-quoted
         // and contain spaces (e.g. ``failing parameterized test``(_:)), so a plain `\S+`
         // truncates it at the first space — match backtick-quoted segments as a unit.
         let funcNamePattern = #"(?:-\[[\w \:\$#]+\])|(?:(?:`[^`]*`|[^\s`])+)"#
         let funcRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(\#(funcNamePattern))\s+\[FUNC,\s+((?:EXT)|(?:OBJC))[\w\s,]+\] $"#)
-        let anyFuncRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(\#(funcNamePattern))\s+\[FUNC,"#)
+        // Looser match used only to attribute a wrapper/continuation chunk (no EXT/OBJC tag)
+        // back to an already-tracked function. Unlike `funcNamePattern`, it captures the whole
+        // name verbatim — including any embedded spaces from a compiler-added prefix — so it
+        // can be stripped by `stripWrapperPrefixes` below.
+        let anyFuncRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(.+?)\s+\[FUNC,"#)
         let lineRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(.*?)\:(\d+)$"#)
+        // Compiler-generated wrapper layers around a function's real body carry the original
+        // name plus a leading label (`@objc `, `specialized `, `closure #1 in `, `partial apply
+        // for `, or a combination of those). Stripping them lets a wrapper/continuation DWARF
+        // entry — which never carries its own EXT/OBJC tag — be matched back to the tracked
+        // function it belongs to, however far from it it landed in the binary.
+        let wrapperPrefixRegex = try NSRegularExpression(
+            pattern: #"^(?:partial apply for |@objc |specialized |closure #\d+ in )"#
+        )
         let trimCharacters = CharacterSet(charactersIn: "-[]")
-        
+
         // Find function region
         while let line = try file.readLine() {
             if line.contains(" __TEXT __text") {
                 break
             }
         }
-        
+
         while let line = try file.readLine() {
             if line.hasSuffix("] \n") {
-                var previousFunctionKey: String? = nil
-                switch state {
-                case .parsing(function: let name, module: let mod, info: let info):
-                    map["\(mod).\(name)"] = info
-                    previousFunctionKey = "\(mod).\(name)"
-                case .continuing(mapKey: let key):
-                    previousFunctionKey = key
-                case .started, .skipping: break
-                }
-                state = .skipping
+                activeKey = nil
+                pendingModuleless = nil
                 if let match = funcRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) {
                     let name = line[Range(match.range(at: 1), in: line)!]
                     let type = line[Range(match.range(at: 2), in: line)!]
                     switch type {
                     case "EXT":
                         let info = Self.swiftTestName(function: String(name))
-                        state = .started(function: info.test, module: info.module)
+                        if let module = info.module {
+                            let key = "\(module).\(info.test)"
+                            trackedKeys.insert(key)
+                            activeKey = key
+                        } else {
+                            pendingModuleless = info.test
+                        }
                     case "OBJC":
                         let parts = name.trimmingCharacters(in: trimCharacters).components(separatedBy: " ")
                         guard parts.count == 2, parts[1].hasPrefix("test") else { continue }
-                        state = .started(function: parts[1], module: parts[0])
+                        let key = "\(parts[0]).\(parts[1])"
+                        trackedKeys.insert(key)
+                        activeKey = key
                     default: continue
                     }
-                } else if let prevKey = previousFunctionKey, map[prevKey] != nil,
-                          let anyMatch = anyFuncRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) {
+                } else if let anyMatch = anyFuncRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) {
                     let rawName = String(line[Range(anyMatch.range(at: 1), in: line)!])
-                    let info = Self.swiftTestName(function: rawName)
-                    let currentMethod = info.module == nil ? info.test : "\(info.module!).\(info.test)"
-                    if currentMethod == prevKey {
-                        state = .continuing(mapKey: prevKey)
+                    let info = Self.swiftTestName(function: Self.stripWrapperPrefixes(rawName, using: wrapperPrefixRegex))
+                    let key = info.module == nil ? info.test : "\(info.module!).\(info.test)"
+                    if trackedKeys.contains(key) {
+                        activeKey = key
                     }
                 }
             } else if line.hasSuffix(":0\n") { // ignoring zero addresses
                 continue
-            } else if state.isParsing,
-                      let match = lineRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line) )
-            {
+            } else if let match = lineRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) {
                 let filePath = String(line[Range(match.range(at: 1), in: line)!])
                 guard let lineNumber = Int(line[Range(match.range(at: 2), in: line)!]) else {
                     continue
                 }
-                switch state {
-                case .started(function: let name, module: var mod):
-                    if mod == nil {
-                        let url = URL(fileURLWithPath: filePath, isDirectory: false)
-                        mod = "[\(url.deletingPathExtension().lastPathComponent)]"
+                if let function = pendingModuleless {
+                    let url = URL(fileURLWithPath: filePath, isDirectory: false)
+                    let module = "[\(url.deletingPathExtension().lastPathComponent)]"
+                    let key = "\(module).\(function)"
+                    trackedKeys.insert(key)
+                    map[key] = FunctionInfo(file: filePath, startLine: lineNumber, endLine: lineNumber)
+                    activeKey = key
+                    pendingModuleless = nil
+                } else if let key = activeKey {
+                    if var info = map[key] {
+                        if info.file == filePath {
+                            info.updateWithLine(lineNumber)
+                            map[key] = info
+                        }
+                    } else {
+                        map[key] = FunctionInfo(file: filePath, startLine: lineNumber, endLine: lineNumber)
                     }
-                    state = .parsing(function: name,
-                                     module: mod!,
-                                     info: FunctionInfo(file: filePath,
-                                                        startLine: lineNumber,
-                                                        endLine: lineNumber))
-                case .parsing(function: let name, module: let mod, info: var info):
-                    if info.file == filePath {
-                        info.updateWithLine(lineNumber)
-                    }
-                    state = .parsing(function: name, module: mod, info: info)
-                case .continuing(mapKey: let key):
-                    map[key]?.updateWithLine(lineNumber)
-                default: throw InternalError(description: "Function parsing failed. Parser in wrong state \(state)")
                 }
             } else if line.hasSuffix("__TEXT __stubs\n") {
                 break
             }
         }
-        
-        if case .parsing(let function, let module, let info) = state {
-            map["\(module).\(function)"] = info
-        }
-        
+
         return map
     }
 
@@ -143,7 +145,7 @@ enum FileLocator {
 
         return try extractFunctions(symbolsFile)
     }
-    
+
     private static func swiftTestName(function name: String) -> (test: String, module: String?) {
         var function: String
         let module: String?
@@ -162,5 +164,13 @@ enum FileLocator {
             function = String(function[..<function.index(function.endIndex, offsetBy: -2)])
         }
         return (test: function, module: module)
+    }
+
+    private static func stripWrapperPrefixes(_ name: String, using wrapperPrefixRegex: NSRegularExpression) -> String {
+        var result = name
+        while let match = wrapperPrefixRegex.firstMatch(in: result, range: NSRange(result.startIndex..., in: result)) {
+            result.removeSubrange(Range(match.range, in: result)!)
+        }
+        return result
     }
 }

--- a/Sources/DatadogSDKTesting/Utils/FileLocator.swift
+++ b/Sources/DatadogSDKTesting/Utils/FileLocator.swift
@@ -8,10 +8,13 @@ import Foundation
 
 struct FunctionInfo: Sendable {
     let file: String
-    let startLine: Int
+    private(set) var startLine: Int
     private(set) var endLine: Int
 
     mutating func updateWithLine(_ line: Int) {
+        if startLine > line {
+            startLine = line
+        }
         if endLine < line {
             endLine = line
         }
@@ -22,138 +25,129 @@ typealias FunctionName = String
 typealias FunctionMap = [FunctionName: FunctionInfo]
 
 enum FileLocator {
-    private enum DeclKind { case ext, objc }
-
     static func extractFunctions(_ symbolsOutput: URL) throws -> FunctionMap {
         var map = FunctionMap()
+
+        // Keys of functions we know are real declarations (an EXT/OBJC-tagged header was seen
+        // for them), so later chunks belonging to the same function that carry no EXT/OBJC tag
+        // of their own — async continuations, `@objc` thunks, generic `specialized` clones,
+        // closures, partial applies — can still be matched back by name and contribute their
+        // source lines, no matter where in the file they land.
         var trackedKeys: Set<String> = []
+        // The key currently receiving source-line records, if any.
         var activeKey: String? = nil
-        /// True while the active key's own declaration chunk is still supplying its first
-        /// source line — that line replaces any previously recorded range (last-wins).
+        // True until the declaration's own chunk has supplied its first source line. That line
+        // replaces any range recorded by an earlier same-named declaration rather than widening
+        // it: a generic function can be emitted as several distinct declarations, and merging
+        // them would report a span covering two different bodies.
         var activeIsFreshDeclaration = false
-        var pendingModuleless: String? = nil
+        // Set right after an EXT header whose name had no module prefix (e.g. a bare global
+        // function): the key can't be known until the first real source line reveals the file,
+        // from which the synthetic module name is derived.
+        var pendingModuleless: FunctionName? = nil
 
         let file = DDFileReader(fileURL: symbolsOutput)
         try file.open()
         defer { file.close() }
 
+        // A function name is either an ObjC method (`-[Class selector:]`, may contain
+        // spaces) or a Swift symbol. A Swift Testing function name can be backtick-quoted
+        // and contain spaces (e.g. ``failing parameterized test``(_:)), so a plain `\S+`
+        // truncates it at the first space — match backtick-quoted segments as a unit.
+        // These stay regexes on purpose: `\w`/`\s` carry ICU's Unicode semantics, and Swift
+        // (and ObjC) identifiers may be non-ASCII.
+        let funcNamePattern = #"(?:-\[[\w \:\$#]+\])|(?:(?:`[^`]*`|[^\s`])+)"#
+        let funcRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(\#(funcNamePattern))\s+\[FUNC,\s+((?:EXT)|(?:OBJC))[\w\s,]+\] $"#)
+        // Looser match used only to attribute a wrapper/continuation chunk (no EXT/OBJC tag)
+        // back to an already-tracked function. Unlike `funcNamePattern`, it captures the whole
+        // name verbatim — including any embedded spaces from a compiler-added prefix — so it
+        // can be stripped by `strippingWrapperPrefixes` below.
+        let anyFuncRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(.+?)\s+\[FUNC,"#)
+        let trimCharacters = CharacterSet(charactersIn: "-[]")
+
+        // Find function region
         while let line = try file.readLine() {
-            if line.contains(" __TEXT __text") { break }
+            if line.contains(" __TEXT __text") {
+                break
+            }
         }
 
         while var line = try file.readLine() {
-            let reachedStubs: Bool = line.withUTF8 { buf in
-                var end = buf.count
-                let hasNewline = end > 0 && buf[end - 1] == UInt8(ascii: "\n")
-                if hasNewline { end -= 1 }
-                guard end > 0 else { return false }
-
-                // Symbol header: "<indent>0xADDR (<pad>0xSIZE) <name> [FLAGS] "
-                if hasNewline, end >= 2,
-                   buf[end - 1] == UInt8(ascii: " "), buf[end - 2] == UInt8(ascii: "]")
-                {
-                    activeKey = nil
-                    activeIsFreshDeclaration = false
-                    pendingModuleless = nil
-                    guard let nameStart = Self.indexAfterPrefix(buf, end),
-                          let funcAt = Self.find(buf, from: nameStart, to: end, needle: "[FUNC,"),
-                          case let flagsStart = funcAt + 6,
-                          case let flagsEnd = end - 2, // index of the closing "]"
-                          flagsStart <= flagsEnd,
-                          buf[funcAt - 1] == UInt8(ascii: " ")
-                    else { return false }
-                    var nameEnd = funcAt
-                    while nameEnd > nameStart, buf[nameEnd - 1] == UInt8(ascii: " ") { nameEnd -= 1 }
-                    guard nameEnd > nameStart else { return false }
-
-                    if let kind = Self.declKind(buf, flagsStart, flagsEnd),
-                       Self.isDeclarationName(buf, nameStart, nameEnd)
-                    {
-                        switch kind {
-                        case .ext:
-                            // key == name with any trailing "()" removed; the module prefix is
-                            // present iff a "." occurs before the first backtick.
-                            let keyEnd = Self.droppingCallParens(buf, nameStart, nameEnd)
-                            if Self.hasModulePrefix(buf, nameStart, keyEnd) {
-                                let key = Self.string(buf, nameStart, keyEnd)
-                                trackedKeys.insert(key)
-                                activeKey = key
-                                activeIsFreshDeclaration = true
-                            } else {
-                                pendingModuleless = Self.string(buf, nameStart, keyEnd)
-                            }
-                        case .objc:
-                            // "-[Class selector]" -> "Class.selector"
-                            let innerStart = nameStart + 2, innerEnd = nameEnd - 1
-                            guard let sep = Self.firstIndex(buf, innerStart, innerEnd, UInt8(ascii: " ")),
-                                  sep > innerStart, sep + 1 < innerEnd,
-                                  Self.firstIndex(buf, sep + 1, innerEnd, UInt8(ascii: " ")) == nil,
-                                  Self.hasPrefix(buf, sep + 1, innerEnd, "test")
-                            else { return false }
-                            let key = Self.string(buf, innerStart, sep) + "."
-                                + Self.string(buf, sep + 1, innerEnd)
+            if line.hasSuffix("] \n") {
+                activeKey = nil
+                activeIsFreshDeclaration = false
+                pendingModuleless = nil
+                // Computed once and shared by both header regexes below.
+                let range = NSRange(line.startIndex..., in: line)
+                if let match = funcRegex.firstMatch(in: line, range: range) {
+                    let name = line[Range(match.range(at: 1), in: line)!]
+                    let type = line[Range(match.range(at: 2), in: line)!]
+                    switch type {
+                    case "EXT":
+                        let info = Self.swiftTestName(function: String(name))
+                        if let module = info.module {
+                            let key = "\(module).\(info.test)"
                             trackedKeys.insert(key)
                             activeKey = key
                             activeIsFreshDeclaration = true
+                        } else {
+                            pendingModuleless = info.test
                         }
-                    } else if !trackedKeys.isEmpty {
-                        // A compiler-generated layer over some function's body (`@objc `,
-                        // `specialized `, `closure #N in `, `partial apply for `, or none at
-                        // all). If it names a function we track, it continues that function.
-                        let bodyStart = Self.skippingWrapperPrefixes(buf, nameStart, nameEnd)
-                        let keyEnd = Self.droppingCallParens(buf, bodyStart, nameEnd)
-                        guard keyEnd > bodyStart else { return false }
-                        let candidate = Self.string(buf, bodyStart, keyEnd)
-                        if trackedKeys.contains(candidate) { activeKey = candidate }
-                    }
-                    return false
-                }
-
-                // Zero addresses carry no usable line information.
-                if hasNewline, end >= 2,
-                   buf[end - 2] == UInt8(ascii: ":"), buf[end - 1] == UInt8(ascii: "0")
-                { return false }
-
-                if activeKey != nil || pendingModuleless != nil,
-                   let source = Self.sourceLine(buf, end)
-                {
-                    let lineNumber = source.line
-                    if let function = pendingModuleless {
-                        let filePath = Self.string(buf, source.fileStart, source.fileEnd)
-                        let url = URL(fileURLWithPath: filePath, isDirectory: false)
-                        let key = "[\(url.deletingPathExtension().lastPathComponent)].\(function)"
+                    case "OBJC":
+                        let parts = name.trimmingCharacters(in: trimCharacters).components(separatedBy: " ")
+                        guard parts.count == 2, parts[1].hasPrefix("test") else { continue }
+                        let key = "\(parts[0]).\(parts[1])"
                         trackedKeys.insert(key)
-                        map[key] = FunctionInfo(file: filePath, startLine: lineNumber, endLine: lineNumber)
                         activeKey = key
-                        activeIsFreshDeclaration = false
-                        pendingModuleless = nil
-                    } else if let key = activeKey {
-                        if activeIsFreshDeclaration {
-                            // A fresh declaration replaces whatever an earlier same-named
-                            // declaration recorded, rather than widening its range.
-                            map[key] = FunctionInfo(file: Self.string(buf, source.fileStart, source.fileEnd),
-                                                    startLine: lineNumber, endLine: lineNumber)
-                            activeIsFreshDeclaration = false
-                        } else if var info = map[key] {
-                            if Self.matches(buf, source.fileStart, source.fileEnd, info.file) {
-                                info.updateWithLine(lineNumber)
-                                map[key] = info
-                            }
-                        } else if !Self.isSyntheticSource(buf, source.fileStart, source.fileEnd) {
-                            // Only a continuation chunk pointing at real source may establish
-                            // the function's file: compiler-generated and macro-expansion
-                            // buffers would otherwise be reported as the test's location.
-                            map[key] = FunctionInfo(file: Self.string(buf, source.fileStart, source.fileEnd),
-                                                    startLine: lineNumber, endLine: lineNumber)
-                        }
+                        activeIsFreshDeclaration = true
+                    default: continue
                     }
-                    return false
+                } else if !trackedKeys.isEmpty,
+                          let anyMatch = anyFuncRegex.firstMatch(in: line, range: range)
+                {
+                    // The key of a Swift function is its name minus any trailing "()", so the
+                    // candidate can be compared without splitting off the module prefix.
+                    let rawName = line[Range(anyMatch.range(at: 1), in: line)!]
+                    var candidate = Self.strippingWrapperPrefixes(rawName)
+                    if candidate.hasSuffix("()") { candidate = candidate.dropLast(2) }
+                    if !candidate.isEmpty, trackedKeys.contains(String(candidate)) {
+                        activeKey = String(candidate)
+                    }
                 }
-
-                if hasNewline, Self.hasSuffix(buf, end, "__TEXT __stubs") { return true }
-                return false
+            } else if line.hasSuffix(":0\n") { // ignoring zero addresses
+                continue
+            } else if activeKey != nil || pendingModuleless != nil,
+                      let source = Self.sourceLine(&line)
+            {
+                let filePath = source.file
+                let lineNumber = source.line
+                if let function = pendingModuleless {
+                    let url = URL(fileURLWithPath: filePath, isDirectory: false)
+                    let key = "[\(url.deletingPathExtension().lastPathComponent)].\(function)"
+                    trackedKeys.insert(key)
+                    map[key] = FunctionInfo(file: filePath, startLine: lineNumber, endLine: lineNumber)
+                    activeKey = key
+                    activeIsFreshDeclaration = false
+                    pendingModuleless = nil
+                } else if let key = activeKey {
+                    if activeIsFreshDeclaration {
+                        map[key] = FunctionInfo(file: filePath, startLine: lineNumber, endLine: lineNumber)
+                        activeIsFreshDeclaration = false
+                    } else if var info = map[key] {
+                        if info.file == filePath {
+                            info.updateWithLine(lineNumber)
+                            map[key] = info
+                        }
+                    } else if !Self.isSyntheticSource(filePath) {
+                        // Only a continuation chunk pointing at real source may establish the
+                        // function's location: compiler-generated and macro-expansion buffers
+                        // would otherwise be reported as the test's source file.
+                        map[key] = FunctionInfo(file: filePath, startLine: lineNumber, endLine: lineNumber)
+                    }
+                }
+            } else if line.hasSuffix("__TEXT __stubs\n") {
+                break
             }
-            if reachedStubs { break }
         }
 
         return map
@@ -168,213 +162,103 @@ enum FileLocator {
         return try extractFunctions(symbolsFile)
     }
 
-    // MARK: - Byte-level parsing helpers
-    //
-    // `symbols` emits a rigid ASCII layout, and this runs over every line of a dump that can
-    // reach tens of megabytes, so the scanning is done on UTF-8 bytes. Swift's `Character`
-    // view performs grapheme breaking, which dominates the runtime of the naive spelling.
-
-    /// Index just past the first `") "`, which always terminates the address/size prefix
-    /// (neither field can contain a parenthesis).
-    private static func indexAfterPrefix(_ b: UnsafeBufferPointer<UInt8>, _ end: Int) -> Int? {
-        var i = 0
-        while i + 1 < end {
-            if b[i] == UInt8(ascii: ")"), b[i + 1] == UInt8(ascii: " ") { return i + 2 }
-            i += 1
-        }
-        return nil
-    }
-
-    private static func find(_ b: UnsafeBufferPointer<UInt8>, from: Int, to: Int, needle: StaticString) -> Int? {
-        let n = needle.utf8CodeUnitCount
-        guard n > 0, to - from >= n else { return nil }
-        let first = needle.utf8Start[0]
-        var i = from
-        while i + n <= to {
-            if b[i] == first {
-                var k = 1
-                while k < n, b[i + k] == needle.utf8Start[k] { k += 1 }
-                if k == n { return i }
+    /// Splits a source-location line — `<indent>0xADDR (<pad>0xSIZE) <path>:<line>` — into its
+    /// path and line number.
+    ///
+    /// This one is scanned over UTF-8 bytes rather than matched with a regex: it is the only
+    /// form that occurs on *every* line of a dump that can reach tens of megabytes, and the
+    /// equivalent `NSRegularExpression` costs ~2.7µs per line (112ms over this repo's own
+    /// 41k-line fixture, roughly 90% of the total parse). Nothing here is Unicode-sensitive —
+    /// the delimiters and digits are ASCII, and UTF-8 never encodes an ASCII byte inside a
+    /// multi-byte character — so the path is carried through verbatim.
+    private static func sourceLine(_ line: inout String) -> (file: String, line: Int)? {
+        line.withUTF8 { buf -> (file: String, line: Int)? in
+            var end = buf.count
+            if end > 0, buf[end - 1] == UInt8(ascii: "\n") { end -= 1 }
+            // The address and size fields cannot contain a parenthesis, so the first ") "
+            // always terminates the prefix.
+            var start = 0
+            while start + 1 < end,
+                  !(buf[start] == UInt8(ascii: ")") && buf[start + 1] == UInt8(ascii: " "))
+            {
+                start += 1
             }
-            i += 1
-        }
-        return nil
-    }
-
-    private static func firstIndex(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int, _ byte: UInt8) -> Int? {
-        var i = from
-        while i < to {
-            if b[i] == byte { return i }
-            i += 1
-        }
-        return nil
-    }
-
-    private static func hasPrefix(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int, _ p: StaticString) -> Bool {
-        let n = p.utf8CodeUnitCount
-        guard to - from >= n else { return false }
-        var k = 0
-        while k < n {
-            if b[from + k] != p.utf8Start[k] { return false }
-            k += 1
-        }
-        return true
-    }
-
-    private static func hasSuffix(_ b: UnsafeBufferPointer<UInt8>, _ end: Int, _ s: StaticString) -> Bool {
-        let n = s.utf8CodeUnitCount
-        guard end >= n else { return false }
-        return hasPrefix(b, end - n, end, s)
-    }
-
-    private static func string(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> String {
-        String(decoding: UnsafeBufferPointer(rebasing: b[from..<to]), as: UTF8.self)
-    }
-
-    private static func matches(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int, _ s: String) -> Bool {
-        var s = s
-        return s.withUTF8 { other in
-            guard other.count == to - from else { return false }
-            var k = 0
-            while k < other.count {
-                if b[from + k] != other[k] { return false }
-                k += 1
+            guard start + 1 < end else { return nil }
+            start += 2
+            while start < end, buf[start] == UInt8(ascii: " ") { start += 1 }
+            // The line number follows the last ":" and must be all ASCII digits.
+            var colon = end
+            var i = end - 1
+            while i >= start {
+                if buf[i] == UInt8(ascii: ":") { colon = i; break }
+                i -= 1
             }
-            return true
-        }
-    }
-
-    /// `EXT`/`OBJC` must be the first flag after `FUNC`, and the remaining flags must be a
-    /// non-empty run of word/space/comma bytes (so `OMIT-FP` disqualifies the entry).
-    private static func declKind(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> DeclKind? {
-        var i = from
-        while i < to, b[i] == UInt8(ascii: " ") { i += 1 }
-        guard i > from else { return nil } // whitespace is required after "FUNC,"
-        let kind: DeclKind
-        if hasPrefix(b, i, to, "EXT") {
-            kind = .ext
-            i += 3
-        } else if hasPrefix(b, i, to, "OBJC") {
-            kind = .objc
-            i += 4
-        } else {
-            return nil
-        }
-        guard i < to else { return nil }
-        while i < to {
-            let c = b[i]
-            let isWord = (c >= UInt8(ascii: "a") && c <= UInt8(ascii: "z"))
-                || (c >= UInt8(ascii: "A") && c <= UInt8(ascii: "Z"))
-                || (c >= UInt8(ascii: "0") && c <= UInt8(ascii: "9"))
-                || c == UInt8(ascii: "_")
-            guard isWord || c == UInt8(ascii: ",") || c == UInt8(ascii: " ") else { return nil }
-            i += 1
-        }
-        return kind
-    }
-
-    /// A declaration is named either as an ObjC method (`-[Class selector:]`) or as a Swift
-    /// symbol with no whitespace outside backtick-quoted segments. Anything else (`static
-    /// Foo.bar.getter`, `variable initialization expression of …`) is not a declaration.
-    private static func isDeclarationName(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Bool {
-        if to - from > 3, b[from] == UInt8(ascii: "-"), b[from + 1] == UInt8(ascii: "["),
-           b[to - 1] == UInt8(ascii: "]")
-        {
-            var i = from + 2
-            while i < to - 1 {
-                let c = b[i]
-                let ok = (c >= UInt8(ascii: "a") && c <= UInt8(ascii: "z"))
-                    || (c >= UInt8(ascii: "A") && c <= UInt8(ascii: "Z"))
-                    || (c >= UInt8(ascii: "0") && c <= UInt8(ascii: "9"))
-                    || c == UInt8(ascii: "_") || c == UInt8(ascii: " ") || c == UInt8(ascii: ":")
-                    || c == UInt8(ascii: "$") || c == UInt8(ascii: "#")
-                guard ok else { return false }
-                i += 1
+            guard colon < end, colon + 1 < end else { return nil }
+            var value = 0
+            var d = colon + 1
+            while d < end {
+                let digit = buf[d]
+                guard digit >= UInt8(ascii: "0"), digit <= UInt8(ascii: "9") else { return nil }
+                value = value * 10 + Int(digit - UInt8(ascii: "0"))
+                d += 1
             }
-            return true
+            let path = String(decoding: UnsafeBufferPointer(rebasing: buf[start..<colon]), as: UTF8.self)
+            return (file: path, line: value)
         }
-        var insideBackticks = false
-        var i = from
-        while i < to {
-            let c = b[i]
-            if c == UInt8(ascii: "`") {
-                insideBackticks = !insideBackticks
-            } else if !insideBackticks, c == UInt8(ascii: " ") || c == UInt8(ascii: "\t") {
-                return false
-            }
-            i += 1
-        }
-        return !insideBackticks
-    }
-
-    /// A module/type prefix is present iff a "." occurs before the first backtick (a
-    /// backtick-quoted name may itself contain dots, e.g. ``test 3.0 behavior``).
-    private static func hasModulePrefix(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Bool {
-        var i = from
-        while i < to, b[i] != UInt8(ascii: "`") {
-            if b[i] == UInt8(ascii: ".") { return true }
-            i += 1
-        }
-        return false
-    }
-
-    private static func droppingCallParens(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Int {
-        if to - from >= 2, b[to - 2] == UInt8(ascii: "("), b[to - 1] == UInt8(ascii: ")") { return to - 2 }
-        return to
-    }
-
-    private static func skippingWrapperPrefixes(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Int {
-        var i = from
-        while i < to {
-            if hasPrefix(b, i, to, "@objc ") { i += 6; continue }
-            if hasPrefix(b, i, to, "specialized ") { i += 12; continue }
-            if hasPrefix(b, i, to, "partial apply for ") { i += 18; continue }
-            if hasPrefix(b, i, to, "closure #") {
-                var j = i + 9
-                let digitsStart = j
-                while j < to, b[j] >= UInt8(ascii: "0"), b[j] <= UInt8(ascii: "9") { j += 1 }
-                if j > digitsStart, hasPrefix(b, j, to, " in ") { i = j + 4; continue }
-            }
-            break
-        }
-        return i
-    }
-
-    /// Splits a source-location line into its file-path byte range and line number.
-    private static func sourceLine(_ b: UnsafeBufferPointer<UInt8>, _ end: Int)
-        -> (fileStart: Int, fileEnd: Int, line: Int)?
-    {
-        guard var i = indexAfterPrefix(b, end) else { return nil }
-        while i < end, b[i] == UInt8(ascii: " ") { i += 1 }
-        // The line number follows the last ":" and must be all digits.
-        var colon = -1
-        var k = end - 1
-        while k >= i {
-            if b[k] == UInt8(ascii: ":") { colon = k; break }
-            k -= 1
-        }
-        guard colon > 0, colon + 1 < end else { return nil }
-        var value = 0
-        var d = colon + 1
-        while d < end {
-            let c = b[d]
-            guard c >= UInt8(ascii: "0"), c <= UInt8(ascii: "9") else { return nil }
-            value = value * 10 + Int(c - UInt8(ascii: "0"))
-            d += 1
-        }
-        return (fileStart: i, fileEnd: colon, line: value)
     }
 
     /// `/<compiler-generated>`, `<stdin>` and macro-expansion buffers under
-    /// `swift-generated-sources` are not real source locations.
-    private static func isSyntheticSource(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Bool {
-        var basename = from
-        var i = from
-        while i < to {
-            if b[i] == UInt8(ascii: "/") { basename = i + 1 }
-            i += 1
+    /// `swift-generated-sources` are not source locations a user can navigate to.
+    private static func isSyntheticSource(_ path: String) -> Bool {
+        let basename = path.lastIndex(of: "/").map { path[path.index(after: $0)...] } ?? path[...]
+        return basename.hasPrefix("<") || path.contains("swift-generated-sources")
+    }
+
+    private static func swiftTestName(function name: String) -> (test: String, module: String?) {
+        var function: String
+        let module: String?
+        // The module/type prefix carries no backticks, but a backtick-quoted function
+        // name may contain dots (e.g. ``test 3.0``). Split on the last dot that precedes
+        // the first backtick, so such a dot isn't mistaken for the module separator.
+        let searchEnd = name.firstIndex(of: "`") ?? name.endIndex
+        if let dotPos = name[..<searchEnd].lastIndex(of: ".") {
+            function = String(name[name.index(after: dotPos)...])
+            module = String(name[..<dotPos])
+        } else {
+            function = String(name)
+            module = nil
         }
-        if basename < to, b[basename] == UInt8(ascii: "<") { return true }
-        return find(b, from: from, to: to, needle: "swift-generated-sources") != nil
+        if function.hasSuffix("()") {
+            function = String(function[..<function.index(function.endIndex, offsetBy: -2)])
+        }
+        return (test: function, module: module)
+    }
+
+    private static let wrapperPrefixes = ["partial apply for ", "@objc ", "specialized "]
+
+    /// Compiler-generated wrapper layers around a function's real body carry the original
+    /// name plus a leading label (`@objc `, `specialized `, `closure #1 in `, `partial apply
+    /// for `, or a combination of those). Stripping them lets a wrapper/continuation entry —
+    /// which never carries its own EXT/OBJC tag — be matched back to the tracked function it
+    /// belongs to, however far from it it landed in the binary.
+    private static func strippingWrapperPrefixes(_ name: Substring) -> Substring {
+        var result = name
+        outer: while !result.isEmpty {
+            for prefix in Self.wrapperPrefixes where result.hasPrefix(prefix) {
+                result = result.dropFirst(prefix.count)
+                continue outer
+            }
+            if result.hasPrefix("closure #") {
+                let afterHash = result.dropFirst(9)
+                let digits = afterHash.prefix(while: { $0.isNumber })
+                let afterDigits = afterHash.dropFirst(digits.count)
+                if !digits.isEmpty, afterDigits.hasPrefix(" in ") {
+                    result = afterDigits.dropFirst(4)
+                    continue outer
+                }
+            }
+            break
+        }
+        return result
     }
 }

--- a/Sources/DatadogSDKTesting/Utils/FileLocator.swift
+++ b/Sources/DatadogSDKTesting/Utils/FileLocator.swift
@@ -22,116 +22,138 @@ typealias FunctionName = String
 typealias FunctionMap = [FunctionName: FunctionInfo]
 
 enum FileLocator {
+    private enum DeclKind { case ext, objc }
+
     static func extractFunctions(_ symbolsOutput: URL) throws -> FunctionMap {
         var map = FunctionMap()
-
-        // Keys of functions we know are real declarations (an EXT/OBJC-tagged header was seen
-        // for them), so later chunks belonging to the same function that carry no EXT/OBJC tag
-        // of their own — async continuations, `@objc` thunks, generic `specialized` clones,
-        // closures, partial applies — can still be matched back by name and contribute their
-        // source lines, no matter where in the file they land.
         var trackedKeys: Set<String> = []
-        // The key currently receiving source-line records, if any.
         var activeKey: String? = nil
-        // Set right after an EXT header whose name had no module prefix (e.g. a bare global
-        // function): the key can't be known until the first real source line reveals the file,
-        // from which the synthetic module name is derived.
-        var pendingModuleless: FunctionName? = nil
+        /// True while the active key's own declaration chunk is still supplying its first
+        /// source line — that line replaces any previously recorded range (last-wins).
+        var activeIsFreshDeclaration = false
+        var pendingModuleless: String? = nil
 
         let file = DDFileReader(fileURL: symbolsOutput)
         try file.open()
         defer { file.close() }
 
-        // A function name is either an ObjC method (`-[Class selector:]`, may contain
-        // spaces) or a Swift symbol. A Swift Testing function name can be backtick-quoted
-        // and contain spaces (e.g. ``failing parameterized test``(_:)), so a plain `\S+`
-        // truncates it at the first space — match backtick-quoted segments as a unit.
-        let funcNamePattern = #"(?:-\[[\w \:\$#]+\])|(?:(?:`[^`]*`|[^\s`])+)"#
-        let funcRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(\#(funcNamePattern))\s+\[FUNC,\s+((?:EXT)|(?:OBJC))[\w\s,]+\] $"#)
-        // Looser match used only to attribute a wrapper/continuation chunk (no EXT/OBJC tag)
-        // back to an already-tracked function. Unlike `funcNamePattern`, it captures the whole
-        // name verbatim — including any embedded spaces from a compiler-added prefix — so it
-        // can be stripped by `stripWrapperPrefixes` below.
-        let anyFuncRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(.+?)\s+\[FUNC,"#)
-        let lineRegex = try NSRegularExpression(pattern: #"^\s+[0-9a-fA-FxX]+\s+\([0-9a-fA-FxX\ ]+\)\s+(.*?)\:(\d+)$"#)
-        // Compiler-generated wrapper layers around a function's real body carry the original
-        // name plus a leading label (`@objc `, `specialized `, `closure #1 in `, `partial apply
-        // for `, or a combination of those). Stripping them lets a wrapper/continuation DWARF
-        // entry — which never carries its own EXT/OBJC tag — be matched back to the tracked
-        // function it belongs to, however far from it it landed in the binary.
-        let wrapperPrefixRegex = try NSRegularExpression(
-            pattern: #"^(?:partial apply for |@objc |specialized |closure #\d+ in )"#
-        )
-        let trimCharacters = CharacterSet(charactersIn: "-[]")
-
-        // Find function region
         while let line = try file.readLine() {
-            if line.contains(" __TEXT __text") {
-                break
-            }
+            if line.contains(" __TEXT __text") { break }
         }
 
-        while let line = try file.readLine() {
-            if line.hasSuffix("] \n") {
-                activeKey = nil
-                pendingModuleless = nil
-                if let match = funcRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) {
-                    let name = line[Range(match.range(at: 1), in: line)!]
-                    let type = line[Range(match.range(at: 2), in: line)!]
-                    switch type {
-                    case "EXT":
-                        let info = Self.swiftTestName(function: String(name))
-                        if let module = info.module {
-                            let key = "\(module).\(info.test)"
+        while var line = try file.readLine() {
+            let reachedStubs: Bool = line.withUTF8 { buf in
+                var end = buf.count
+                let hasNewline = end > 0 && buf[end - 1] == UInt8(ascii: "\n")
+                if hasNewline { end -= 1 }
+                guard end > 0 else { return false }
+
+                // Symbol header: "<indent>0xADDR (<pad>0xSIZE) <name> [FLAGS] "
+                if hasNewline, end >= 2,
+                   buf[end - 1] == UInt8(ascii: " "), buf[end - 2] == UInt8(ascii: "]")
+                {
+                    activeKey = nil
+                    activeIsFreshDeclaration = false
+                    pendingModuleless = nil
+                    guard let nameStart = Self.indexAfterPrefix(buf, end),
+                          let funcAt = Self.find(buf, from: nameStart, to: end, needle: "[FUNC,"),
+                          case let flagsStart = funcAt + 6,
+                          case let flagsEnd = end - 2, // index of the closing "]"
+                          flagsStart <= flagsEnd,
+                          buf[funcAt - 1] == UInt8(ascii: " ")
+                    else { return false }
+                    var nameEnd = funcAt
+                    while nameEnd > nameStart, buf[nameEnd - 1] == UInt8(ascii: " ") { nameEnd -= 1 }
+                    guard nameEnd > nameStart else { return false }
+
+                    if let kind = Self.declKind(buf, flagsStart, flagsEnd),
+                       Self.isDeclarationName(buf, nameStart, nameEnd)
+                    {
+                        switch kind {
+                        case .ext:
+                            // key == name with any trailing "()" removed; the module prefix is
+                            // present iff a "." occurs before the first backtick.
+                            let keyEnd = Self.droppingCallParens(buf, nameStart, nameEnd)
+                            if Self.hasModulePrefix(buf, nameStart, keyEnd) {
+                                let key = Self.string(buf, nameStart, keyEnd)
+                                trackedKeys.insert(key)
+                                activeKey = key
+                                activeIsFreshDeclaration = true
+                            } else {
+                                pendingModuleless = Self.string(buf, nameStart, keyEnd)
+                            }
+                        case .objc:
+                            // "-[Class selector]" -> "Class.selector"
+                            let innerStart = nameStart + 2, innerEnd = nameEnd - 1
+                            guard let sep = Self.firstIndex(buf, innerStart, innerEnd, UInt8(ascii: " ")),
+                                  sep > innerStart, sep + 1 < innerEnd,
+                                  Self.firstIndex(buf, sep + 1, innerEnd, UInt8(ascii: " ")) == nil,
+                                  Self.hasPrefix(buf, sep + 1, innerEnd, "test")
+                            else { return false }
+                            let key = Self.string(buf, innerStart, sep) + "."
+                                + Self.string(buf, sep + 1, innerEnd)
                             trackedKeys.insert(key)
                             activeKey = key
-                        } else {
-                            pendingModuleless = info.test
+                            activeIsFreshDeclaration = true
                         }
-                    case "OBJC":
-                        let parts = name.trimmingCharacters(in: trimCharacters).components(separatedBy: " ")
-                        guard parts.count == 2, parts[1].hasPrefix("test") else { continue }
-                        let key = "\(parts[0]).\(parts[1])"
+                    } else if !trackedKeys.isEmpty {
+                        // A compiler-generated layer over some function's body (`@objc `,
+                        // `specialized `, `closure #N in `, `partial apply for `, or none at
+                        // all). If it names a function we track, it continues that function.
+                        let bodyStart = Self.skippingWrapperPrefixes(buf, nameStart, nameEnd)
+                        let keyEnd = Self.droppingCallParens(buf, bodyStart, nameEnd)
+                        guard keyEnd > bodyStart else { return false }
+                        let candidate = Self.string(buf, bodyStart, keyEnd)
+                        if trackedKeys.contains(candidate) { activeKey = candidate }
+                    }
+                    return false
+                }
+
+                // Zero addresses carry no usable line information.
+                if hasNewline, end >= 2,
+                   buf[end - 2] == UInt8(ascii: ":"), buf[end - 1] == UInt8(ascii: "0")
+                { return false }
+
+                if activeKey != nil || pendingModuleless != nil,
+                   let source = Self.sourceLine(buf, end)
+                {
+                    let lineNumber = source.line
+                    if let function = pendingModuleless {
+                        let filePath = Self.string(buf, source.fileStart, source.fileEnd)
+                        let url = URL(fileURLWithPath: filePath, isDirectory: false)
+                        let key = "[\(url.deletingPathExtension().lastPathComponent)].\(function)"
                         trackedKeys.insert(key)
-                        activeKey = key
-                    default: continue
-                    }
-                } else if let anyMatch = anyFuncRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) {
-                    let rawName = String(line[Range(anyMatch.range(at: 1), in: line)!])
-                    let info = Self.swiftTestName(function: Self.stripWrapperPrefixes(rawName, using: wrapperPrefixRegex))
-                    let key = info.module == nil ? info.test : "\(info.module!).\(info.test)"
-                    if trackedKeys.contains(key) {
-                        activeKey = key
-                    }
-                }
-            } else if line.hasSuffix(":0\n") { // ignoring zero addresses
-                continue
-            } else if let match = lineRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) {
-                let filePath = String(line[Range(match.range(at: 1), in: line)!])
-                guard let lineNumber = Int(line[Range(match.range(at: 2), in: line)!]) else {
-                    continue
-                }
-                if let function = pendingModuleless {
-                    let url = URL(fileURLWithPath: filePath, isDirectory: false)
-                    let module = "[\(url.deletingPathExtension().lastPathComponent)]"
-                    let key = "\(module).\(function)"
-                    trackedKeys.insert(key)
-                    map[key] = FunctionInfo(file: filePath, startLine: lineNumber, endLine: lineNumber)
-                    activeKey = key
-                    pendingModuleless = nil
-                } else if let key = activeKey {
-                    if var info = map[key] {
-                        if info.file == filePath {
-                            info.updateWithLine(lineNumber)
-                            map[key] = info
-                        }
-                    } else {
                         map[key] = FunctionInfo(file: filePath, startLine: lineNumber, endLine: lineNumber)
+                        activeKey = key
+                        activeIsFreshDeclaration = false
+                        pendingModuleless = nil
+                    } else if let key = activeKey {
+                        if activeIsFreshDeclaration {
+                            // A fresh declaration replaces whatever an earlier same-named
+                            // declaration recorded, rather than widening its range.
+                            map[key] = FunctionInfo(file: Self.string(buf, source.fileStart, source.fileEnd),
+                                                    startLine: lineNumber, endLine: lineNumber)
+                            activeIsFreshDeclaration = false
+                        } else if var info = map[key] {
+                            if Self.matches(buf, source.fileStart, source.fileEnd, info.file) {
+                                info.updateWithLine(lineNumber)
+                                map[key] = info
+                            }
+                        } else if !Self.isSyntheticSource(buf, source.fileStart, source.fileEnd) {
+                            // Only a continuation chunk pointing at real source may establish
+                            // the function's file: compiler-generated and macro-expansion
+                            // buffers would otherwise be reported as the test's location.
+                            map[key] = FunctionInfo(file: Self.string(buf, source.fileStart, source.fileEnd),
+                                                    startLine: lineNumber, endLine: lineNumber)
+                        }
                     }
+                    return false
                 }
-            } else if line.hasSuffix("__TEXT __stubs\n") {
-                break
+
+                if hasNewline, Self.hasSuffix(buf, end, "__TEXT __stubs") { return true }
+                return false
             }
+            if reachedStubs { break }
         }
 
         return map
@@ -146,31 +168,213 @@ enum FileLocator {
         return try extractFunctions(symbolsFile)
     }
 
-    private static func swiftTestName(function name: String) -> (test: String, module: String?) {
-        var function: String
-        let module: String?
-        // The module/type prefix carries no backticks, but a backtick-quoted function
-        // name may contain dots (e.g. ``test 3.0``). Split on the last dot that precedes
-        // the first backtick, so such a dot isn't mistaken for the module separator.
-        let searchEnd = name.firstIndex(of: "`") ?? name.endIndex
-        if let dotPos = name[..<searchEnd].lastIndex(of: ".") {
-            function = String(name[name.index(after: dotPos)...])
-            module = String(name[..<dotPos])
-        } else {
-            function = String(name)
-            module = nil
+    // MARK: - Byte-level parsing helpers
+    //
+    // `symbols` emits a rigid ASCII layout, and this runs over every line of a dump that can
+    // reach tens of megabytes, so the scanning is done on UTF-8 bytes. Swift's `Character`
+    // view performs grapheme breaking, which dominates the runtime of the naive spelling.
+
+    /// Index just past the first `") "`, which always terminates the address/size prefix
+    /// (neither field can contain a parenthesis).
+    private static func indexAfterPrefix(_ b: UnsafeBufferPointer<UInt8>, _ end: Int) -> Int? {
+        var i = 0
+        while i + 1 < end {
+            if b[i] == UInt8(ascii: ")"), b[i + 1] == UInt8(ascii: " ") { return i + 2 }
+            i += 1
         }
-        if function.hasSuffix("()") {
-            function = String(function[..<function.index(function.endIndex, offsetBy: -2)])
-        }
-        return (test: function, module: module)
+        return nil
     }
 
-    private static func stripWrapperPrefixes(_ name: String, using wrapperPrefixRegex: NSRegularExpression) -> String {
-        var result = name
-        while let match = wrapperPrefixRegex.firstMatch(in: result, range: NSRange(result.startIndex..., in: result)) {
-            result.removeSubrange(Range(match.range, in: result)!)
+    private static func find(_ b: UnsafeBufferPointer<UInt8>, from: Int, to: Int, needle: StaticString) -> Int? {
+        let n = needle.utf8CodeUnitCount
+        guard n > 0, to - from >= n else { return nil }
+        let first = needle.utf8Start[0]
+        var i = from
+        while i + n <= to {
+            if b[i] == first {
+                var k = 1
+                while k < n, b[i + k] == needle.utf8Start[k] { k += 1 }
+                if k == n { return i }
+            }
+            i += 1
         }
-        return result
+        return nil
+    }
+
+    private static func firstIndex(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int, _ byte: UInt8) -> Int? {
+        var i = from
+        while i < to {
+            if b[i] == byte { return i }
+            i += 1
+        }
+        return nil
+    }
+
+    private static func hasPrefix(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int, _ p: StaticString) -> Bool {
+        let n = p.utf8CodeUnitCount
+        guard to - from >= n else { return false }
+        var k = 0
+        while k < n {
+            if b[from + k] != p.utf8Start[k] { return false }
+            k += 1
+        }
+        return true
+    }
+
+    private static func hasSuffix(_ b: UnsafeBufferPointer<UInt8>, _ end: Int, _ s: StaticString) -> Bool {
+        let n = s.utf8CodeUnitCount
+        guard end >= n else { return false }
+        return hasPrefix(b, end - n, end, s)
+    }
+
+    private static func string(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> String {
+        String(decoding: UnsafeBufferPointer(rebasing: b[from..<to]), as: UTF8.self)
+    }
+
+    private static func matches(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int, _ s: String) -> Bool {
+        var s = s
+        return s.withUTF8 { other in
+            guard other.count == to - from else { return false }
+            var k = 0
+            while k < other.count {
+                if b[from + k] != other[k] { return false }
+                k += 1
+            }
+            return true
+        }
+    }
+
+    /// `EXT`/`OBJC` must be the first flag after `FUNC`, and the remaining flags must be a
+    /// non-empty run of word/space/comma bytes (so `OMIT-FP` disqualifies the entry).
+    private static func declKind(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> DeclKind? {
+        var i = from
+        while i < to, b[i] == UInt8(ascii: " ") { i += 1 }
+        guard i > from else { return nil } // whitespace is required after "FUNC,"
+        let kind: DeclKind
+        if hasPrefix(b, i, to, "EXT") {
+            kind = .ext
+            i += 3
+        } else if hasPrefix(b, i, to, "OBJC") {
+            kind = .objc
+            i += 4
+        } else {
+            return nil
+        }
+        guard i < to else { return nil }
+        while i < to {
+            let c = b[i]
+            let isWord = (c >= UInt8(ascii: "a") && c <= UInt8(ascii: "z"))
+                || (c >= UInt8(ascii: "A") && c <= UInt8(ascii: "Z"))
+                || (c >= UInt8(ascii: "0") && c <= UInt8(ascii: "9"))
+                || c == UInt8(ascii: "_")
+            guard isWord || c == UInt8(ascii: ",") || c == UInt8(ascii: " ") else { return nil }
+            i += 1
+        }
+        return kind
+    }
+
+    /// A declaration is named either as an ObjC method (`-[Class selector:]`) or as a Swift
+    /// symbol with no whitespace outside backtick-quoted segments. Anything else (`static
+    /// Foo.bar.getter`, `variable initialization expression of …`) is not a declaration.
+    private static func isDeclarationName(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Bool {
+        if to - from > 3, b[from] == UInt8(ascii: "-"), b[from + 1] == UInt8(ascii: "["),
+           b[to - 1] == UInt8(ascii: "]")
+        {
+            var i = from + 2
+            while i < to - 1 {
+                let c = b[i]
+                let ok = (c >= UInt8(ascii: "a") && c <= UInt8(ascii: "z"))
+                    || (c >= UInt8(ascii: "A") && c <= UInt8(ascii: "Z"))
+                    || (c >= UInt8(ascii: "0") && c <= UInt8(ascii: "9"))
+                    || c == UInt8(ascii: "_") || c == UInt8(ascii: " ") || c == UInt8(ascii: ":")
+                    || c == UInt8(ascii: "$") || c == UInt8(ascii: "#")
+                guard ok else { return false }
+                i += 1
+            }
+            return true
+        }
+        var insideBackticks = false
+        var i = from
+        while i < to {
+            let c = b[i]
+            if c == UInt8(ascii: "`") {
+                insideBackticks = !insideBackticks
+            } else if !insideBackticks, c == UInt8(ascii: " ") || c == UInt8(ascii: "\t") {
+                return false
+            }
+            i += 1
+        }
+        return !insideBackticks
+    }
+
+    /// A module/type prefix is present iff a "." occurs before the first backtick (a
+    /// backtick-quoted name may itself contain dots, e.g. ``test 3.0 behavior``).
+    private static func hasModulePrefix(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Bool {
+        var i = from
+        while i < to, b[i] != UInt8(ascii: "`") {
+            if b[i] == UInt8(ascii: ".") { return true }
+            i += 1
+        }
+        return false
+    }
+
+    private static func droppingCallParens(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Int {
+        if to - from >= 2, b[to - 2] == UInt8(ascii: "("), b[to - 1] == UInt8(ascii: ")") { return to - 2 }
+        return to
+    }
+
+    private static func skippingWrapperPrefixes(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Int {
+        var i = from
+        while i < to {
+            if hasPrefix(b, i, to, "@objc ") { i += 6; continue }
+            if hasPrefix(b, i, to, "specialized ") { i += 12; continue }
+            if hasPrefix(b, i, to, "partial apply for ") { i += 18; continue }
+            if hasPrefix(b, i, to, "closure #") {
+                var j = i + 9
+                let digitsStart = j
+                while j < to, b[j] >= UInt8(ascii: "0"), b[j] <= UInt8(ascii: "9") { j += 1 }
+                if j > digitsStart, hasPrefix(b, j, to, " in ") { i = j + 4; continue }
+            }
+            break
+        }
+        return i
+    }
+
+    /// Splits a source-location line into its file-path byte range and line number.
+    private static func sourceLine(_ b: UnsafeBufferPointer<UInt8>, _ end: Int)
+        -> (fileStart: Int, fileEnd: Int, line: Int)?
+    {
+        guard var i = indexAfterPrefix(b, end) else { return nil }
+        while i < end, b[i] == UInt8(ascii: " ") { i += 1 }
+        // The line number follows the last ":" and must be all digits.
+        var colon = -1
+        var k = end - 1
+        while k >= i {
+            if b[k] == UInt8(ascii: ":") { colon = k; break }
+            k -= 1
+        }
+        guard colon > 0, colon + 1 < end else { return nil }
+        var value = 0
+        var d = colon + 1
+        while d < end {
+            let c = b[d]
+            guard c >= UInt8(ascii: "0"), c <= UInt8(ascii: "9") else { return nil }
+            value = value * 10 + Int(c - UInt8(ascii: "0"))
+            d += 1
+        }
+        return (fileStart: i, fileEnd: colon, line: value)
+    }
+
+    /// `/<compiler-generated>`, `<stdin>` and macro-expansion buffers under
+    /// `swift-generated-sources` are not real source locations.
+    private static func isSyntheticSource(_ b: UnsafeBufferPointer<UInt8>, _ from: Int, _ to: Int) -> Bool {
+        var basename = from
+        var i = from
+        while i < to {
+            if b[i] == UInt8(ascii: "/") { basename = i + 1 }
+            i += 1
+        }
+        if basename < to, b[basename] == UInt8(ascii: "<") { return true }
+        return find(b, from: from, to: to, needle: "swift-generated-sources") != nil
     }
 }

--- a/Tests/DatadogSDKTesting/Utils/FileLocatorTests.swift
+++ b/Tests/DatadogSDKTesting/Utils/FileLocatorTests.swift
@@ -504,6 +504,60 @@ internal class FileLocatorEdgeCaseTests: XCTestCase {
         XCTAssertEqual(14, info.endLine)
     }
 
+    func testUnicodeFunctionNames() throws {
+        // Swift and ObjC identifiers may be non-ASCII, and Swift Testing names are arbitrary
+        // text inside backticks. Names must survive verbatim, and a continuation chunk of a
+        // non-ASCII function must still be matched back to it.
+        let body = """
+                    0x0100 (0x0020) MyTests.testПривет() [FUNC, EXT, LENGTH, NameNList, Merged, NList, Dwarf]\(" ")
+                        0x0100 (0x0010) /путь/к/Файл.swift:10
+                    0x0120 (0x0020) MyTests.测试方法() [FUNC, EXT, LENGTH, NameNList, Merged, NList, Dwarf]\(" ")
+                        0x0120 (0x0010) /path/to/CJK.swift:20
+                    0x0140 (0x0020) MyTests.`тест с пробелами`() [FUNC, EXT, LENGTH, NameNList, Merged, NList, Dwarf]\(" ")
+                        0x0140 (0x0010) /path/to/Back.swift:30
+                    0x0160 (0x0020) MyTests.test🎉Emoji() [FUNC, EXT, LENGTH, NameNList, Merged, NList, Dwarf]\(" ")
+                        0x0160 (0x0010) /path/to/Emoji.swift:40
+                    0x0180 (0x0020) -[ЮникодTests testМетод] [FUNC, OBJC, LENGTH, NameNList, Merged, NList, Dwarf]\(" ")
+                        0x0180 (0x0010) /path/to/ObjC.m:50
+                    0x01C0 (0x0020) specialized MyTests.testПривет() [FUNC, LENGTH, NameNList, Merged, NList, Dwarf]\(" ")
+                        0x01C0 (0x0010) /путь/к/Файл.swift:14
+        """
+        let url = try makeFixture(body)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let map = try FileLocator.extractFunctions(url)
+
+        let cyrillic = try XCTUnwrap(map["MyTests.testПривет"])
+        XCTAssertEqual(cyrillic.file, "/путь/к/Файл.swift")
+        XCTAssertEqual(10, cyrillic.startLine)
+        XCTAssertEqual(14, cyrillic.endLine, "Continuation of a non-ASCII name must be merged")
+
+        XCTAssertEqual(20, try XCTUnwrap(map["MyTests.测试方法"]).startLine)
+        XCTAssertEqual(30, try XCTUnwrap(map["MyTests.`тест с пробелами`"]).startLine)
+        XCTAssertEqual(40, try XCTUnwrap(map["MyTests.test🎉Emoji"]).startLine)
+        // ObjC class/selector with Cyrillic letters — the `\w` class is Unicode-aware
+        XCTAssertEqual(50, try XCTUnwrap(map["ЮникодTests.testМетод"]).startLine)
+    }
+
+    func testStartLineIsRunningMinimum() throws {
+        // Chunks are not emitted in source order, so a later chunk may carry a lower line
+        // than the one that opened the range.
+        let body = """
+                    0x0100 (0x0020) MyModule.myFunc() [FUNC, EXT, LENGTH, NameNList, Merged, NList, Dwarf]\(" ")
+                        0x0100 (0x0010) /path/to/My.swift:20
+                        0x0110 (0x0010) /path/to/My.swift:25
+                    0x0120 (0x0020) specialized MyModule.myFunc() [FUNC, LENGTH, NameNList, Merged, NList, Dwarf]\(" ")
+                        0x0120 (0x0010) /path/to/My.swift:18
+                        0x0130 (0x0010) /path/to/My.swift:27
+        """
+        let url = try makeFixture(body)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let map = try FileLocator.extractFunctions(url)
+
+        let info = try XCTUnwrap(map["MyModule.myFunc"])
+        XCTAssertEqual(18, info.startLine, "startLine must fall to the lowest line seen")
+        XCTAssertEqual(27, info.endLine)
+    }
+
     func testSecondDeclarationOfSameNameReplacesRangeInsteadOfWidening() throws {
         // Generic functions can be emitted as several distinct EXT declarations at different
         // source lines. Each declaration must replace the recorded range rather than merge

--- a/Tests/DatadogSDKTesting/Utils/FileLocatorTests.swift
+++ b/Tests/DatadogSDKTesting/Utils/FileLocatorTests.swift
@@ -479,6 +479,52 @@ internal class FileLocatorEdgeCaseTests: XCTestCase {
         XCTAssertEqual(7, info.endLine)
     }
 
+    func testContinuationWithSyntheticSourcePathDoesNotEstablishLocation() throws {
+        // When the declaration chunk has no usable source line, a continuation chunk may
+        // establish the function's location — but only from real source. Compiler-generated
+        // and macro-expansion buffers must not be reported as the test's file, otherwise
+        // `test.source.file` points at a temporary buffer and codeowners resolution breaks.
+        let body = """
+                    0x0100 (0x0020) AsyncSuite.testFoo() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0100 (0x0020) /<compiler-generated>:0
+                    0x0120 (0x0020) closure #2 in AsyncSuite.testFoo() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0120 (0x0008) /var/folders/x/T/swift-generated-sources/@__swiftmacro_5Tests9testFooyyFMf_.swift:1
+                        0x0128 (0x0008) /<compiler-generated>:7
+                        0x0130 (0x0008) /path/to/AsyncSuite.swift:10
+                        0x0138 (0x0008) /path/to/AsyncSuite.swift:14
+        """
+        let url = try makeFixture(body)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let map = try FileLocator.extractFunctions(url)
+
+        let info = try XCTUnwrap(map["AsyncSuite.testFoo"])
+        XCTAssertEqual(info.file, "/path/to/AsyncSuite.swift",
+                       "Synthetic macro/compiler buffers must not become the test's source file")
+        XCTAssertEqual(10, info.startLine)
+        XCTAssertEqual(14, info.endLine)
+    }
+
+    func testSecondDeclarationOfSameNameReplacesRangeInsteadOfWidening() throws {
+        // Generic functions can be emitted as several distinct EXT declarations at different
+        // source lines. Each declaration must replace the recorded range rather than merge
+        // with the previous one, which would report a span covering both bodies.
+        let body = """
+                    0x0100 (0x0020) MyModule.withTest<A>(named:_:) [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0100 (0x0010) /path/to/My.swift:262
+                        0x0110 (0x0010) /path/to/My.swift:263
+                    0x0120 (0x0020) MyModule.withTest<A>(named:_:) [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0120 (0x0010) /path/to/My.swift:266
+                        0x0130 (0x0010) /path/to/My.swift:268
+        """
+        let url = try makeFixture(body)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let map = try FileLocator.extractFunctions(url)
+
+        let info = try XCTUnwrap(map["MyModule.withTest<A>(named:_:)"])
+        XCTAssertEqual(266, info.startLine, "Later declaration must replace the earlier range")
+        XCTAssertEqual(268, info.endLine)
+    }
+
     func testAsyncFunctionWithNoRecoverableSourceLinesOmittedWithoutCrash() throws {
         // If literally none of a function's chunks ever carry a real source line, it must
         // be silently omitted from the map rather than crashing or corrupting other entries.

--- a/Tests/DatadogSDKTesting/Utils/FileLocatorTests.swift
+++ b/Tests/DatadogSDKTesting/Utils/FileLocatorTests.swift
@@ -106,6 +106,45 @@ internal class FileLocatorFixtureTests: XCTestCase {
         let map = try FileLocator.extractFunctions(url)
         XCTAssertEqual(23, map.count)
     }
+
+    // MARK: symbols-async-thunk.log (SDTEST-3944 regression)
+
+    // Captured from a real `-O` build of an XCTestCase with sync/async/throwing test
+    // methods (`symbols -fullSourcePath -lazy` output). Under optimization, an async test
+    // method's own EXT-tagged DWARF entry can carry only `/<compiler-generated>:0` lines
+    // (no source info) — the real body lives in a `specialized` clone, which is untagged,
+    // named differently (`specialized Module.func()`), and lands far from the original
+    // entry with unrelated functions interleaved. Before the SDTEST-3944 fix this caused
+    // the async test methods to be dropped from the map entirely (`test.source.file` missing).
+
+    func testAsyncThunkFixtureRecoversAllAsyncTestMethods() throws {
+        let url = fixturesURL.appendingPathComponent("symbols-async-thunk.log")
+        let map = try FileLocator.extractFunctions(url)
+
+        let throwsInfo = try XCTUnwrap(map["AsyncRepro.testAsyncThrows"])
+        XCTAssertTrue(throwsInfo.file.hasSuffix("AsyncTests.swift"))
+        XCTAssertEqual(11, throwsInfo.startLine)
+        XCTAssertEqual(19, throwsInfo.endLine)
+
+        let plainInfo = try XCTUnwrap(map["AsyncRepro.testAsyncPlain"])
+        XCTAssertEqual(21, plainInfo.startLine)
+        XCTAssertEqual(28, plainInfo.endLine)
+
+        let manyAwaitsInfo = try XCTUnwrap(map["AsyncRepro.testAsyncManyAwaits"])
+        XCTAssertEqual(30, manyAwaitsInfo.startLine)
+        XCTAssertEqual(36, manyAwaitsInfo.endLine)
+
+        // The simple sync method in the same suite must still resolve as before.
+        let syncInfo = try XCTUnwrap(map["AsyncRepro.testSync"])
+        XCTAssertEqual(6, syncInfo.startLine)
+        XCTAssertEqual(8, syncInfo.endLine)
+
+        // A different suite's async method, whose first chunk already carries real lines,
+        // must also still resolve.
+        let otherInfo = try XCTUnwrap(map["AsyncRepro2.testOtherAsync"])
+        XCTAssertEqual(40, otherInfo.startLine)
+        XCTAssertEqual(43, otherInfo.endLine)
+    }
 }
 
 // MARK: - Edge case tests with synthetic fixtures
@@ -390,5 +429,68 @@ internal class FileLocatorEdgeCaseTests: XCTestCase {
         let info = try XCTUnwrap(map["MyModule.myFunc"])
         XCTAssertEqual(12, info.startLine)
         XCTAssertEqual(24, info.endLine)
+    }
+
+    // MARK: SDTEST-3944 regression — async thunk source-line recovery
+
+    func testAsyncFunctionSourceRecoveredFromNonAdjacentSpecializedClone() throws {
+        // The EXT-tagged entry and its immediate `@objc` thunk carry no real source line
+        // (compiler-generated bootstrap only). The real lines live in a `specialized` clone
+        // that is untagged and separated from the original by an unrelated function — it
+        // must still be matched back to the tracked function by name.
+        let body = """
+                    0x0100 (0x0020) AsyncSuite.testFoo() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0100 (0x0020) /<compiler-generated>:0
+                    0x0120 (0x0020) @objc AsyncSuite.testFoo() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0120 (0x0020) /<compiler-generated>:0
+                    0x0140 (0x0020) Other.unrelated() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0140 (0x0010) /path/to/Other.swift:1
+                    0x0160 (0x0020) specialized AsyncSuite.testFoo() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0160 (0x0010) /path/to/AsyncSuite.swift:10
+                        0x0170 (0x0010) /path/to/AsyncSuite.swift:12
+        """
+        let url = try makeFixture(body)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let map = try FileLocator.extractFunctions(url)
+
+        let info = try XCTUnwrap(map["AsyncSuite.testFoo"])
+        XCTAssertEqual(info.file, "/path/to/AsyncSuite.swift")
+        XCTAssertEqual(10, info.startLine)
+        XCTAssertEqual(12, info.endLine)
+        XCTAssertNotNil(map["Other.unrelated"])
+    }
+
+    func testObjcThunkContinuationMergedIntoTrackedFunction() throws {
+        // An immediately-adjacent `@objc` thunk that happens to carry real lines must be
+        // merged into the tracked function's range (previously never matched because the
+        // continuation regex could not span the space in "@objc Module.func()").
+        let body = """
+                    0x0100 (0x0020) AsyncSuite.testFoo() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0100 (0x0010) /path/to/AsyncSuite.swift:5
+                    0x0120 (0x0020) @objc AsyncSuite.testFoo() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0120 (0x0010) /path/to/AsyncSuite.swift:7
+        """
+        let url = try makeFixture(body)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let map = try FileLocator.extractFunctions(url)
+
+        let info = try XCTUnwrap(map["AsyncSuite.testFoo"])
+        XCTAssertEqual(5, info.startLine)
+        XCTAssertEqual(7, info.endLine)
+    }
+
+    func testAsyncFunctionWithNoRecoverableSourceLinesOmittedWithoutCrash() throws {
+        // If literally none of a function's chunks ever carry a real source line, it must
+        // be silently omitted from the map rather than crashing or corrupting other entries.
+        let body = """
+                    0x0100 (0x0020) AsyncSuite.testNoLines() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0100 (0x0020) /<compiler-generated>:0
+                    0x0120 (0x0020) @objc AsyncSuite.testNoLines() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf]\(" ")
+                        0x0120 (0x0020) /<compiler-generated>:0
+        """
+        let url = try makeFixture(body)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let map = try FileLocator.extractFunctions(url)
+        XCTAssertNil(map["AsyncSuite.testNoLines"])
     }
 }

--- a/Tests/fixtures/symbols-async-thunk.log
+++ b/Tests/fixtures/symbols-async-thunk.log
@@ -1,0 +1,462 @@
+.build/arm64-apple-macosx/release/ReproPackageTests.xctest/Contents/MacOS/ReproPackageTests.dSYM/Contents/Resources/DWARF/ReproPackageTests [arm64, 0.000431 seconds]:
+    54504C48-37D5-3ECA-A740-A769183AA9A5 /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.xctest/Contents/MacOS/ReproPackageTests.dSYM/Contents/Resources/DWARF/ReproPackageTests [dSYM_v3, FaultedFromDisk, Found-dSYM]  
+        0x0000000000000000 (  0x8000) __TEXT SEGMENT
+            0x0000000000000000 (  0x1300) MACH_HEADER
+            0x0000000000001300 (  0x3a50) __TEXT __text
+                0x0000000000001300 (    0x9c) static Runner.main() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001300 (    0x1c) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:527
+                    0x000000000000131c (    0x44) /private/tmp/sdtest3944pkg/<stdin>:0
+                    0x0000000000001360 (    0x2c) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:527
+                    0x000000000000138c (    0x10) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:527
+                0x000000000000139c (   0x114) static Runner.main() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000139c (    0x40) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:527
+                    0x00000000000013dc (    0x24) /<compiler-generated>:0
+                    0x0000000000001400 (     0x4) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:530
+                    0x0000000000001404 (    0x20) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:0
+                    0x0000000000001424 (     0x4) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:530
+                    0x0000000000001428 (    0x28) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:0
+                    0x0000000000001450 (    0x2c) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x000000000000147c (    0x14) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x0000000000001490 (     0xc) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:546
+                    0x000000000000149c (    0x14) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:546
+                0x00000000000014b0 (    0x3c) static Runner.main() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000014b0 (    0x1c) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x00000000000014cc (    0x10) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x00000000000014dc (    0x10) /<compiler-generated>:0
+                0x00000000000014ec (    0x50) __swift_instantiateConcreteTypeFromMangledNameV2 [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000014ec (    0x50) /<compiler-generated>:0
+                0x000000000000153c (    0x44) lazy protocol witness table accessor for type MainActor and conformance MainActor [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000153c (    0x44) /<compiler-generated>:0
+                0x0000000000001580 (    0xb0) static Runner.$main() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001580 (    0x70) /<compiler-generated>:0
+                    0x00000000000015f0 (    0x30) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:527
+                    0x0000000000001620 (    0x10) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:527
+                0x0000000000001630 (   0x12c) static Runner.$main() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001630 (    0x64) /<compiler-generated>:0
+                    0x0000000000001694 (     0x4) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:530
+                    0x0000000000001698 (    0x20) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:0
+                    0x00000000000016b8 (     0x4) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:530
+                    0x00000000000016bc (    0x28) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:0
+                    0x00000000000016e4 (    0x2c) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x0000000000001710 (    0x14) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x0000000000001724 (    0x24) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:506
+                    0x0000000000001748 (    0x14) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:506
+                0x000000000000175c (    0x3c) static Runner.$main() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000175c (    0x1c) /<compiler-generated>:0
+                    0x0000000000001778 (    0x10) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x0000000000001788 (    0x10) /<compiler-generated>:0
+                0x0000000000001798 (    0x44) static Runner.$main() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001798 (    0x44) /<compiler-generated>:0
+                0x00000000000017dc (     0x4) Runner.init() [FUNC, OMIT-FP, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000017dc (     0x4) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:0
+                0x00000000000017e0 (    0xb0) async_Main [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000017e0 (    0x70) /<compiler-generated>:0
+                    0x0000000000001850 (    0x30) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:527
+                    0x0000000000001880 (    0x10) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:527
+                0x0000000000001890 (   0x12c) async_MainTY0_ [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001890 (    0x64) /<compiler-generated>:0
+                    0x00000000000018f4 (     0x4) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:530
+                    0x00000000000018f8 (    0x20) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:0
+                    0x0000000000001918 (     0x4) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:530
+                    0x000000000000191c (    0x28) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:0
+                    0x0000000000001944 (    0x2c) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x0000000000001970 (    0x14) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:536
+                    0x0000000000001984 (    0x24) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:506
+                    0x00000000000019a8 (    0x14) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:506
+                0x00000000000019bc (    0x2c) async_MainTY2_ [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000019bc (    0x2c) /<compiler-generated>:0
+                0x00000000000019e8 (    0x58) main [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000019e8 (    0x58) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:0
+                0x0000000000001a40 (    0x4c) specialized thunk for @escaping @convention(thin) @async () -> () [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001a40 (    0x4c) /<compiler-generated>:0
+                0x0000000000001a8c (    0x48) specialized thunk for @escaping @convention(thin) @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001a8c (    0x48) /<compiler-generated>:0
+                0x0000000000001ad4 (    0xfc) specialized static Runner.testingLibrary() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001ad4 (    0x18) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:510
+                    0x0000000000001aec (     0x8) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:511
+                    0x0000000000001af4 (    0x6c) /<compiler-generated>:0
+                    0x0000000000001b60 (     0xc) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:513
+                    0x0000000000001b6c (    0x10) /<compiler-generated>:0
+                    0x0000000000001b7c (     0xc) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:514
+                    0x0000000000001b88 (    0x2c) /<compiler-generated>:0
+                    0x0000000000001bb4 (    0x18) /private/tmp/sdtest3944pkg/.build/arm64-apple-macosx/release/ReproPackageTests.derived/runner.swift:520
+                    0x0000000000001bcc (     0x4) /<compiler-generated>:0
+                0x0000000000001bd0 (    0x10) type metadata accessor for Runner [FUNC, OMIT-FP, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001bd0 (    0x10) /<compiler-generated>:0
+                0x0000000000001be0 (     0x4) async_MainTQ1_ [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000001be4 (     0x8) static RepoErr.__derived_enum_equals(_:_:) [FUNC, OMIT-FP, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001be4 (     0x8) /<compiler-generated>:0
+                0x0000000000001bec (    0x24) RepoErr.hash(into:) [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001bec (    0x24) /<compiler-generated>:0
+                0x0000000000001c10 (    0x40) RepoErr.hashValue.getter [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001c10 (    0x40) /<compiler-generated>:0
+                0x0000000000001c50 (     0x8) protocol witness for static Equatable.== infix(_:_:) in conformance RepoErr [FUNC, OMIT-FP, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001c50 (     0x8) /<compiler-generated>:0
+                0x0000000000001c58 (    0x40) protocol witness for Hashable.hashValue.getter in conformance RepoErr [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001c58 (    0x40) /<compiler-generated>:0
+                0x0000000000001c98 (    0x24) protocol witness for Hashable.hash(into:) in conformance RepoErr [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001c98 (    0x24) /<compiler-generated>:0
+                0x0000000000001cbc (    0x3c) protocol witness for Hashable._rawHashValue(seed:) in conformance RepoErr [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001cbc (    0x3c) /<compiler-generated>:0
+                0x0000000000001cf8 (     0x4) protocol witness for Error._domain.getter in conformance RepoErr [FUNC, OMIT-FP, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001cf8 (     0x4) /<compiler-generated>:0
+                0x0000000000001cfc (     0x4) protocol witness for Error._code.getter in conformance RepoErr [FUNC, OMIT-FP, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001cfc (     0x4) /<compiler-generated>:0
+                0x0000000000001d00 (     0x4) protocol witness for Error._userInfo.getter in conformance RepoErr [FUNC, OMIT-FP, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001d00 (     0x4) /<compiler-generated>:0
+                0x0000000000001d04 (     0x4) protocol witness for Error._getEmbeddedNSError() in conformance RepoErr [FUNC, OMIT-FP, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001d04 (     0x4) /<compiler-generated>:0
+                0x0000000000001d08 (    0x74) AsyncRepro.testSync() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001d08 (     0xc) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:6
+                    0x0000000000001d14 (    0x44) /<compiler-generated>:0
+                    0x0000000000001d58 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:8
+                    0x0000000000001d6c (    0x10) /<compiler-generated>:0
+                0x0000000000001d7c (    0x74) @objc AsyncRepro.testSync() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001d7c (    0x50) /<compiler-generated>:0
+                    0x0000000000001dcc (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:8
+                    0x0000000000001de0 (    0x10) /<compiler-generated>:0
+                0x0000000000001df0 (    0x58) AsyncRepro.testAsyncThrows() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001df0 (    0x58) /<compiler-generated>:0
+                0x0000000000001e48 (   0x12c) @objc AsyncRepro.testAsyncThrows() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001e48 (   0x12c) /<compiler-generated>:0
+                0x0000000000001f74 (    0x5c) @objc closure #1 in AsyncRepro.testAsyncThrows() [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001f74 (    0x5c) /<compiler-generated>:0
+                0x0000000000001fd0 (    0x58) AsyncRepro.testAsyncPlain() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000001fd0 (    0x58) /<compiler-generated>:0
+                0x0000000000002028 (    0x3c) AsyncRepro.testAsyncPlain() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002028 (    0x3c) /<compiler-generated>:0
+                0x0000000000002064 (   0x12c) @objc AsyncRepro.testAsyncPlain() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002064 (   0x12c) /<compiler-generated>:0
+                0x0000000000002190 (    0x5c) @objc closure #1 in AsyncRepro.testAsyncPlain() [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002190 (    0x5c) /<compiler-generated>:0
+                0x00000000000021ec (    0x48) @objc closure #1 in AsyncRepro.testAsyncPlain() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000021ec (    0x48) /<compiler-generated>:0
+                0x0000000000002234 (    0x58) AsyncRepro.testAsyncManyAwaits() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002234 (    0x58) /<compiler-generated>:0
+                0x000000000000228c (    0x3c) AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000228c (    0x3c) /<compiler-generated>:0
+                0x00000000000022c8 (   0x12c) @objc AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000022c8 (   0x12c) /<compiler-generated>:0
+                0x00000000000023f4 (    0x5c) @objc closure #1 in AsyncRepro.testAsyncManyAwaits() [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000023f4 (    0x5c) /<compiler-generated>:0
+                0x0000000000002450 (    0x8c) @objc closure #1 in AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002450 (    0x8c) /<compiler-generated>:0
+                0x00000000000024dc (    0x3c) AsyncRepro.__allocating_init(invocation:) [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000024dc (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:5
+                    0x00000000000024ec (    0x2c) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:0
+                0x0000000000002518 (     0x4) AsyncRepro.init(invocation:) [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x000000000000251c (     0xc) @objc AsyncRepro.init(invocation:) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000002528 (    0x28) AsyncRepro.__allocating_init(selector:) [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002528 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:5
+                    0x0000000000002538 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:0
+                0x0000000000002550 (     0x4) AsyncRepro.init(selector:) [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000002554 (     0xc) @objc AsyncRepro.init(selector:) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000002560 (    0x18) AsyncRepro.__allocating_init() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002560 (     0xc) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:5
+                    0x000000000000256c (     0xc) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:0
+                0x0000000000002578 (     0x4) AsyncRepro.init() [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x000000000000257c (     0x4) @objc AsyncRepro.init() [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000002580 (     0x4) AsyncRepro.__deallocating_deinit [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000002584 (    0x4c) AsyncRepro2.testOtherAsync() [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002584 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:40
+                    0x0000000000002598 (    0x28) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x00000000000025c0 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                0x00000000000025d0 (    0x60) AsyncRepro2.testOtherAsync() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000025d0 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x00000000000025e4 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x00000000000025fc (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x0000000000002600 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x0000000000002610 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x0000000000002620 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                0x0000000000002630 (    0x98) AsyncRepro2.testOtherAsync() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002630 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:42
+                    0x0000000000002644 (    0x2c) /<compiler-generated>:0
+                    0x0000000000002670 (     0x8) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:42
+                    0x0000000000002678 (     0x4) /<compiler-generated>:0
+                    0x000000000000267c (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:42
+                    0x0000000000002694 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:42
+                    0x00000000000026a8 (     0x8) /<compiler-generated>:0
+                    0x00000000000026b0 (     0x8) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:43
+                    0x00000000000026b8 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:43
+                0x00000000000026c8 (   0x12c) @objc AsyncRepro2.testOtherAsync() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000026c8 (   0x12c) /<compiler-generated>:0
+                0x00000000000027f4 (    0x50) @objc closure #1 in AsyncRepro2.testOtherAsync() [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000027f4 (    0x14) /<compiler-generated>:0
+                    0x0000000000002808 (    0x2c) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x0000000000002834 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                0x0000000000002844 (    0x9c) @objc closure #1 in AsyncRepro2.testOtherAsync() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002844 (    0x18) /<compiler-generated>:0
+                    0x000000000000285c (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x0000000000002874 (    0x48) /<compiler-generated>:0
+                    0x00000000000028bc (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                    0x00000000000028cc (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:41
+                0x00000000000028e0 (    0xa8) @objc closure #1 in AsyncRepro2.testOtherAsync() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000028e0 (    0x44) /<compiler-generated>:0
+                    0x0000000000002924 (     0x8) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:42
+                    0x000000000000292c (     0x4) /<compiler-generated>:0
+                    0x0000000000002930 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:42
+                    0x0000000000002948 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:42
+                    0x000000000000295c (    0x2c) /<compiler-generated>:0
+                0x0000000000002988 (    0x54) AsyncRepro.init(invocation:) [FUNC, NameNList, MangledNameNList, NList] 
+                0x00000000000029dc (    0x44) AsyncRepro.init(selector:) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000002a20 (    0x4c) @objc AsyncRepro.init(invocation:) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000002a6c (    0x34) AsyncRepro.init() [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000002aa0 (    0x3c) @objc AsyncRepro.init() [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000002adc (    0x34) AsyncRepro.__deallocating_deinit [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000002b10 (    0x54) thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002b10 (    0x54) /<compiler-generated>:0
+                0x0000000000002b64 (    0x54) thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002b64 (    0x54) /<compiler-generated>:0
+                0x0000000000002bb8 (   0x258) specialized Task<>.init(name:priority:operation:) [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002bb8 (   0x258) /<compiler-generated>:0
+                0x0000000000002e10 (    0x64) specialized thunk for @escaping @isolated(any) @callee_guaranteed @async () -> (@out A) [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002e10 (    0x64) /<compiler-generated>:0
+                0x0000000000002e74 (    0x40) specialized thunk for @escaping @isolated(any) @callee_guaranteed @async () -> (@out A) [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002e74 (    0x40) /<compiler-generated>:0
+                0x0000000000002eb4 (    0x50) specialized AsyncRepro.testAsyncThrows() [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002eb4 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:11
+                    0x0000000000002ec8 (    0x2c) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:12
+                    0x0000000000002ef4 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:12
+                0x0000000000002f04 (    0x60) specialized AsyncRepro.testAsyncThrows() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002f04 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:12
+                    0x0000000000002f18 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:12
+                    0x0000000000002f30 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:19
+                    0x0000000000002f34 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:19
+                    0x0000000000002f44 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:12
+                    0x0000000000002f54 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:12
+                0x0000000000002f64 (    0xb4) specialized AsyncRepro.testAsyncThrows() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000002f64 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:13
+                    0x0000000000002f7c (    0x14) /<compiler-generated>:0
+                    0x0000000000002f90 (     0x8) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:13
+                    0x0000000000002f98 (    0x20) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:0
+                    0x0000000000002fb8 (     0x8) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:14
+                    0x0000000000002fc0 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:19
+                    0x0000000000002fc4 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:19
+                    0x0000000000002fd8 (    0x2c) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:16
+                    0x0000000000003004 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:16
+                0x0000000000003018 (    0x60) specialized AsyncRepro.testAsyncThrows() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003018 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:16
+                    0x000000000000302c (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:16
+                    0x0000000000003044 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:19
+                    0x0000000000003048 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:19
+                    0x0000000000003058 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:16
+                    0x0000000000003068 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:16
+                0x0000000000003078 (    0x8c) specialized AsyncRepro.testAsyncThrows() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003078 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:18
+                    0x000000000000308c (    0x44) /<compiler-generated>:0
+                    0x00000000000030d0 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:18
+                    0x00000000000030e4 (     0x8) /<compiler-generated>:0
+                    0x00000000000030ec (     0x8) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:19
+                    0x00000000000030f4 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:19
+                0x0000000000003104 (    0x48) specialized AsyncRepro.testAsyncPlain() [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003104 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:21
+                    0x0000000000003118 (    0x24) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:22
+                    0x000000000000313c (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:22
+                0x000000000000314c (    0x48) specialized AsyncRepro.testAsyncPlain() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000314c (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:22
+                    0x0000000000003160 (    0x24) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:22
+                    0x0000000000003184 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:22
+                0x0000000000003194 (    0xd8) specialized AsyncRepro.testAsyncPlain() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003194 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:23
+                    0x00000000000031a8 (    0x14) /<compiler-generated>:0
+                    0x00000000000031bc (     0x8) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:23
+                    0x00000000000031c4 (    0x24) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:24
+                    0x00000000000031e8 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:24
+                    0x00000000000031f8 (    0x44) /<compiler-generated>:0
+                    0x000000000000323c (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:27
+                    0x0000000000003250 (     0x8) /<compiler-generated>:0
+                    0x0000000000003258 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:28
+                    0x000000000000325c (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:28
+                0x000000000000326c (    0x48) specialized AsyncRepro.testAsyncPlain() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000326c (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:24
+                    0x0000000000003280 (    0x24) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:24
+                    0x00000000000032a4 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:24
+                0x00000000000032b4 (    0x88) specialized AsyncRepro.testAsyncPlain() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000032b4 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:25
+                    0x00000000000032c8 (    0x44) /<compiler-generated>:0
+                    0x000000000000330c (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:27
+                    0x0000000000003320 (     0x8) /<compiler-generated>:0
+                    0x0000000000003328 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:28
+                    0x000000000000332c (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:28
+                0x000000000000333c (    0x14) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, OMIT-FP, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000333c (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:30
+                0x0000000000003350 (    0x4c) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003350 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003364 (    0x28) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x000000000000338c (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                0x000000000000339c (    0x60) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000339c (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x00000000000033b0 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x00000000000033c8 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x00000000000033cc (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x00000000000033dc (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x00000000000033ec (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                0x00000000000033fc (    0x4c) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000033fc (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003410 (    0x28) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003438 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                0x0000000000003448 (    0x60) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003448 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x000000000000345c (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003474 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x0000000000003478 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x0000000000003488 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003498 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                0x00000000000034a8 (    0x4c) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000034a8 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x00000000000034bc (    0x28) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x00000000000034e4 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                0x00000000000034f4 (    0x60) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000034f4 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003508 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003520 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x0000000000003524 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x0000000000003534 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003544 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                0x0000000000003554 (    0x4c) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003554 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003568 (    0x28) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x0000000000003590 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                0x00000000000035a0 (    0x60) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000035a0 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x00000000000035b4 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x00000000000035cc (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x00000000000035d0 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x00000000000035e0 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                    0x00000000000035f0 (    0x10) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:32
+                0x0000000000003600 (    0x58) specialized AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003600 (    0x18) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:33
+                    0x0000000000003618 (    0x20) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:0
+                    0x0000000000003638 (     0x8) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:33
+                    0x0000000000003640 (     0x4) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                    0x0000000000003644 (    0x14) /private/tmp/sdtest3944pkg/Tests/ReproTests/AsyncTests.swift:36
+                0x0000000000003658 (     0x4) base witness table accessor for Equatable in RepoErr [FUNC, OMIT-FP, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003658 (     0x4) /<compiler-generated>:0
+                0x000000000000365c (    0x40) lazy protocol witness table accessor for type RepoErr and conformance RepoErr [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000365c (    0x40) /<compiler-generated>:0
+                0x000000000000369c (     0x4) __swift_memcpy0_1 [FUNC, OMIT-FP, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000369c (     0x4) /<compiler-generated>:0
+                0x00000000000036a0 (     0x4) __swift_noop_void_return [FUNC, OMIT-FP, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000036a0 (     0x4) /<compiler-generated>:0
+                0x00000000000036a4 (    0x50) getEnumTagSinglePayload for RepoErr [FUNC, OMIT-FP, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000036a4 (    0x50) /<compiler-generated>:0
+                0x00000000000036f4 (    0x7c) storeEnumTagSinglePayload for RepoErr [FUNC, OMIT-FP, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000036f4 (    0x7c) /<compiler-generated>:0
+                0x0000000000003770 (     0x8) getEnumTag for RepoErr [FUNC, OMIT-FP, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003770 (     0x8) /<compiler-generated>:0
+                0x0000000000003778 (     0x4) destructiveProjectEnumData for RepoErr [FUNC, OMIT-FP, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003778 (     0x4) /<compiler-generated>:0
+                0x000000000000377c (     0x4) destructiveInjectEnumTag for RepoErr [FUNC, OMIT-FP, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000377c (     0x4) /<compiler-generated>:0
+                0x0000000000003780 (    0x10) type metadata accessor for RepoErr [FUNC, OMIT-FP, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003780 (    0x10) /<compiler-generated>:0
+                0x0000000000003790 (    0x20) type metadata accessor for AsyncRepro [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003790 (    0x20) /<compiler-generated>:0
+                0x00000000000037b0 (    0x20) type metadata accessor for AsyncRepro2 [FUNC, EXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000037b0 (    0x20) /<compiler-generated>:0
+                0x00000000000037d4 (    0x64) partial apply for @objc closure #1 in AsyncRepro2.testOtherAsync() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000037d4 (    0x64) /<compiler-generated>:0
+                0x000000000000383c (    0x78) partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x000000000000383c (    0x78) /<compiler-generated>:0
+                0x00000000000038b4 (    0x84) partial apply for thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000038b4 (    0x84) /<compiler-generated>:0
+                0x0000000000003938 (    0x50) outlined init with copy of TaskPriority? [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003938 (    0x50) /<compiler-generated>:0
+                0x0000000000003988 (    0x48) outlined destroy of TaskPriority? [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003988 (    0x48) /<compiler-generated>:0
+                0x00000000000039f4 (    0x70) partial apply for specialized thunk for @escaping @isolated(any) @callee_guaranteed @async () -> (@out A) [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x00000000000039f4 (    0x70) /<compiler-generated>:0
+                0x0000000000003a64 (    0x70) partial apply for specialized thunk for @escaping @isolated(any) @callee_guaranteed @async () -> (@out A) [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003a64 (    0x70) /<compiler-generated>:0
+                0x0000000000003ad4 (    0x3c) partial apply for specialized thunk for @escaping @isolated(any) @callee_guaranteed @async () -> (@out A) [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003ad4 (    0x3c) /<compiler-generated>:0
+                0x0000000000003b10 (    0x64) partial apply for @objc closure #1 in AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003b10 (    0x64) /<compiler-generated>:0
+                0x0000000000003b74 (    0x3c) partial apply for @objc closure #1 in AsyncRepro.testAsyncManyAwaits() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003b74 (    0x3c) /<compiler-generated>:0
+                0x0000000000003bb0 (    0x78) partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003bb0 (    0x78) /<compiler-generated>:0
+                0x0000000000003c28 (    0x84) partial apply for thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003c28 (    0x84) /<compiler-generated>:0
+                0x0000000000003cac (    0x64) partial apply for @objc closure #1 in AsyncRepro.testAsyncPlain() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003cac (    0x64) /<compiler-generated>:0
+                0x0000000000003d10 (    0x78) partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003d10 (    0x78) /<compiler-generated>:0
+                0x0000000000003d88 (    0x84) partial apply for thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003d88 (    0x84) /<compiler-generated>:0
+                0x0000000000003e0c (    0x2c) objectdestroyTm [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000003e38 (    0x64) partial apply for @objc closure #1 in AsyncRepro.testAsyncThrows() [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003e38 (    0x64) /<compiler-generated>:0
+                0x0000000000003e9c (    0x78) partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003e9c (    0x78) /<compiler-generated>:0
+                0x0000000000003f14 (    0x2c) objectdestroy.10Tm [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000003f40 (    0x84) partial apply for thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003f40 (    0x84) /<compiler-generated>:0
+                0x0000000000003fc4 (    0x40) lazy protocol witness table accessor for type RepoErr and conformance RepoErr [FUNC, PEXT, LENGTH, NameNList, MangledNameNList, Merged, NList, Dwarf] 
+                    0x0000000000003fc4 (    0x40) /<compiler-generated>:0
+                0x0000000000004008 (     0x4) AsyncRepro.testAsyncThrows() [FUNC, NameNList, MangledNameNList, NList] 
+                0x000000000000400c (     0x4) AsyncRepro2.__allocating_init(selector:) [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004010 (     0x4) AsyncRepro2.init(invocation:) [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004014 (     0x4) AsyncRepro2.init(selector:) [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004018 (     0x4) @objc AsyncRepro2.init() [FUNC, NameNList, MangledNameNList, NList] 
+                0x000000000000401c (     0x4) @objc AsyncRepro2.init(invocation:) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004020 (     0x4) @objc AsyncRepro2.init(selector:) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004024 (     0x4) AsyncRepro2.__allocating_init() [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004028 (     0x4) partial apply for specialized thunk for @escaping @isolated(any) @callee_guaranteed @async () -> (@out A) [FUNC, NameNList, MangledNameNList, NList] 
+                0x000000000000402c (     0x4) thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004030 (     0x4) thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004034 (     0x4) partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004038 (     0x4) partial apply for thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x000000000000403c (     0x4) partial apply for @objc closure #1 in AsyncRepro2.testOtherAsync() [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004040 (     0x4) partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004044 (     0x4) partial apply for thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004048 (     0x4) partial apply for @objc closure #1 in AsyncRepro.testAsyncPlain() [FUNC, NameNList, MangledNameNList, NList] 
+                0x000000000000404c (     0x4) partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004050 (     0x4) partial apply for thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004054 (     0x4) partial apply for @objc closure #1 in AsyncRepro.testAsyncThrows() [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004058 (     0x4) partial apply for thunk for @escaping @callee_guaranteed @Sendable @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x000000000000405c (     0x4) partial apply for thunk for @escaping @isolated(any) @callee_guaranteed @async () -> () [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004060 (     0x4) AsyncRepro2.init() [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004064 (    0x2c) AsyncRepro2.__deallocating_deinit [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004090 (     0x4) AsyncRepro2.__allocating_init(invocation:) [FUNC, EXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004094 (     0x4) @objc closure #1 in AsyncRepro.testAsyncThrows() [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004098 (   0x1ec) swift::AsyncTask::waitFuture(swift::AsyncTask*, swift::AsyncContext*, void (swift::AsyncContext* swift_async_context) swiftasynccall*, swift::AsyncContext*, swift::OpaqueValue*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004284 (    0xe8) swift::swift56override_swift_task_future_wait(swift::OpaqueValue*, swift::AsyncContext*, swift::AsyncTask*, void (swift::AsyncContext* swift_async_context) swiftasynccall*, swift::AsyncContext*, void (swift::OpaqueValue*, swift::AsyncContext* swift_async_context, swift::AsyncTask*, void (swift::AsyncContext* swift_async_context), swift::AsyncContext*) swiftasynccall*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x000000000000436c (     0x8) task_future_wait_resume_adapter(swift::AsyncContext*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004374 (   0x110) swift::swift56override_swift_task_future_wait_throwing(swift::OpaqueValue*, swift::AsyncContext*, swift::AsyncTask*, void (swift::AsyncContext* swift_async_context, void* swift_context) swiftasynccall*, swift::AsyncContext*, void (swift::OpaqueValue*, swift::AsyncContext* swift_async_context, swift::AsyncTask*, void* swift_context, swift::AsyncContext*) swiftasynccall*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004484 (    0x10) task_wait_throwing_resume_adapter(swift::AsyncContext*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004494 (    0x10) swift::swift56override_swift_task_create_common(unsigned long, swift::TaskOptionRecord*, swift::TargetMetadata<swift::InProcess> const*, void (swift::AsyncContext* swift_async_context) swiftasynccall*, void*, unsigned long, swift::AsyncTaskAndContext (unsigned long, swift::TaskOptionRecord*, swift::TargetMetadata<swift::InProcess> const*, void (swift::AsyncContext* swift_async_context), void (swift::AsyncContext* swift_async_context) swiftasynccall, unsigned long) swiftcall*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x00000000000044a4 (   0x130) swift::AsyncTask::flagAsRunning_slow() [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x00000000000045d4 (   0x130) swift::AsyncTask::flagAsSuspended_slow() [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004704 (    0x50) swift::swift_task_escalateBackdeploy56(swift::AsyncTask*, swift::JobPriority) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004754 (    0x30) swift::swift_task_escalateBackdeploy56(swift::AsyncTask*, swift::JobPriority)::$_0::operator()() const::'lambda'(void*)::__invoke(void*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004784 (    0xd0) swift::waitForStatusRecordUnlock(swift::AsyncTask*, swift::ActiveTaskStatus&) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004854 (    0x18) swift::swift_task_escalateBackdeploy56(swift::AsyncTask*, swift::JobPriority) (.cold.1) [FUNC, NameNList, MangledNameNList, NList] 
+                0x000000000000486c (     0x8) swift::swift_task_getCurrent() [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004874 (    0x34) swift::_swift_task_clearCurrent() [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x00000000000048a8 (    0x2c) swift::adoptTaskVoucher(swift::AsyncTask*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x00000000000048d4 (    0xb0) swift::restoreTaskVoucher(swift::AsyncTask*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004984 (    0x38) _initializeVouchersDisabled(void*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x00000000000049bc (    0xc4) swift::VoucherManager::swapToJob(swift::Job*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004a80 (    0x30) swift_voucher_needs_adopt(voucher_s*)::'lambda'()::operator()() const::'lambda'(void*)::__invoke(void*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004ab0 (    0x18) OUTLINED_FUNCTION_0 [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004ac8 (     0x4) swift::restoreTaskVoucher(swift::AsyncTask*) (.cold.1) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004acc (     0x4) swift::VoucherManager::swapToJob(swift::Job*) (.cold.1) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004ad0 (    0x48) swift::_swift_tsan_acquire(void*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004b18 (    0x48) swift::_swift_tsan_release(void*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004b60 (    0x30) swift::_swift_tsan_acquire(void*)::$_0::operator()() const::'lambda'(void*)::__invoke(void*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004b90 (    0x30) swift::_swift_tsan_release(void*)::$_0::operator()() const::'lambda'(void*)::__invoke(void*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004bc0 (    0x18) swift::_swift_tsan_acquire(void*) (.cold.1) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004bd8 (    0x18) swift::_swift_tsan_release(void*) (.cold.1) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004bf0 (     0x8) swift::MutexPlatformHelper::init(os_unfair_lock_s&, bool) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004bf8 (     0x4) swift::MutexPlatformHelper::destroy(os_unfair_lock_s&) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004bfc (    0x14) swift::MutexPlatformHelper::lock(os_unfair_lock_s&) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004c10 (    0x14) swift::MutexPlatformHelper::unlock(os_unfair_lock_s&) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004c24 (    0x48) swift::swift_task_enterThreadLocalContextBackdeploy56(char*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004c6c (    0x48) swift::swift_task_exitThreadLocalContextBackdeploy56(char*) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+                0x0000000000004cb4 (    0x30) swift::swift_task_enterThreadLocalContextBackdeploy56(char*)::$_0::operator()() const::'lambda'(void*)::__invoke(void*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004ce4 (    0x30) swift::swift_task_exitThreadLocalContextBackdeploy56(char*)::$_0::operator()() const::'lambda'(void*)::__invoke(void*) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004d14 (    0x18) swift::swift_task_enterThreadLocalContextBackdeploy56(char*) (.cold.1) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004d2c (    0x18) swift::swift_task_exitThreadLocalContextBackdeploy56(char*) (.cold.1) [FUNC, NameNList, MangledNameNList, NList] 
+                0x0000000000004d44 (     0xc) swift::swift_Concurrency_fatalError(unsigned int, char const*, ...) [FUNC, PEXT, NameNList, MangledNameNList, NList] 
+            0x0000000000004d50 (   0x30c) __TEXT __stubs


### PR DESCRIPTION
## Summary

Fixes [SDTEST-3944](https://datadoghq.atlassian.net/browse/SDTEST-3944): async/`async throws` XCTest methods were inconsistently missing `@test.source.file` (and therefore `@test.codeowners`), while sync methods in the same suite worked fine.

**Root cause**: `FileLocator` resolves `test.source.file`/`test.source.start`/`test.source.end` by parsing the text output of `symbols -fullSourcePath -lazy` once per test bundle. Under `-O`, an async test method's own `EXT`-tagged DWARF entry can contain only `/<compiler-generated>:0` lines (no real source info) — the real body lives in a differently-named, differently-tagged (or untagged) chunk, such as a `specialized` generic clone, which can land far from the original entry with unrelated functions interleaved. The old adjacency-based state machine (`.skipping/.started/.parsing/.continuing`) silently dropped such functions from the map instead of merging their lines in, so the test simply lost `test.source.file` — non-deterministically, depending on per-function codegen.

**Fix**: `FileLocator` now tracks the set of known test-function keys across the whole file (not just the immediately-preceding entry), and attributes source lines from *any* later chunk that resolves to the same name — after stripping known compiler-added wrapper prefixes (`@objc `, `specialized `, `closure #N in `, `partial apply for `) — regardless of where in the binary it landed.

## Test plan
- [x] Added `Tests/fixtures/symbols-async-thunk.log`, a real `symbols` dump captured from a `-O` build of an XCTestCase with sync/async/throwing test methods, reproducing the exact bug pattern
- [x] `FileLocatorFixtureTests.testAsyncThunkFixtureRecoversAllAsyncTestMethods` verifies all async test methods now resolve correctly against that fixture
- [x] `FileLocatorEdgeCaseTests.testAsyncFunctionSourceRecoveredFromNonAdjacentSpecializedClone` / `testObjcThunkContinuationMergedIntoTrackedFunction` / `testAsyncFunctionWithNoRecoverableSourceLinesOmittedWithoutCrash` cover the mechanism with small synthetic fixtures
- [x] Full `DatadogSDKTestingTests` target passes via `xcodebuild test`, including the pre-existing exact-count assertions on the large real fixtures (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDTEST-3944]: https://datadoghq.atlassian.net/browse/SDTEST-3944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ