### PR TITLE
[SDTEST-3914] Migrate uploader to async/await, add sync shutdown and crash-time disk flush

### DIFF
--- a/Sources/DatadogSDKTesting/Crashes/DDCrashes.swift
+++ b/Sources/DatadogSDKTesting/Crashes/DDCrashes.swift
@@ -86,6 +86,10 @@ private let ddCrashIsWritingReportCallback: @convention(c) (
     }
     DDTestMonitor.instance?.tia?.stop()
     DDTestMonitor.instance?.coverage?.stop()
+    // Get everything gathered so far onto disk so the next run uploads it. Only
+    // local writes happen here — no network (unreachable/unsafe mid-crash) and no
+    // `Task`/`await` (the executor won't run us again).
+    DDTestMonitor.instance?.tracer.persistToDisk()
     Log.print("Crash detected! Exiting...")
 }
 

--- a/Sources/DatadogSDKTesting/Crashes/DDCrashes.swift
+++ b/Sources/DatadogSDKTesting/Crashes/DDCrashes.swift
@@ -84,12 +84,13 @@ private let ddCrashIsWritingReportCallback: @convention(c) (
         let data = SimpleSpanSerializer.serializeSpan(simpleSpan: test.toCrashData)
         try? data.write(to: url, options: .atomic)
     }
-    DDTestMonitor.instance?.tia?.stop()
-    DDTestMonitor.instance?.coverage?.stop()
-    // Get everything gathered so far onto disk so the next run uploads it. Only
-    // local writes happen here — no network (unreachable/unsafe mid-crash) and no
-    // `Task`/`await` (the executor won't run us again).
-    DDTestMonitor.instance?.tracer.persistToDisk()
+    // Nothing here may drain a queue, wait on an OperationQueue, take a lock or
+    // touch the network. KSCrash suspends the other threads before writing the
+    // report (`ksmc_suspendEnvironment`), so anything that waits on them waits
+    // forever — and the work it is waiting for can never run, which makes the
+    // attempt pointless as well as deadlock-prone. That rules out flushing the
+    // exporters' writer queues and draining the coverage processor here; both
+    // have to happen before the crash, or on the next run.
     Log.print("Crash detected! Exiting...")
 }
 

--- a/Sources/DatadogSDKTesting/DDSession.swift
+++ b/Sources/DatadogSDKTesting/DDSession.swift
@@ -31,11 +31,17 @@ public final class DDSession: NSObject {
 
     private let _state: Synced<MutableState>
     private let _moduleManager: any TestModuleManagerSession
+    /// Set only for sessions created through the manual `start(name:)` API, which
+    /// owns its shutdown. Framework-driven sessions are owned by the
+    /// `SessionManager` that created them, so it drives teardown instead.
+    private let _sessionManager: (any TestSessionManager)?
 
-    init(name: String, config: SessionConfig, modules: any TestModuleManagerSession, startTime: Date? = nil) {
+    init(name: String, config: SessionConfig, modules: any TestModuleManagerSession,
+         startTime: Date? = nil, sessionManager: (any TestSessionManager)? = nil) {
         self.name = name
         self.configuration = config
         self._moduleManager = modules
+        self._sessionManager = sessionManager
 
         let state = MutableState()
         let id: SpanId
@@ -105,7 +111,6 @@ public final class DDSession: NSObject {
         span.end(time: endTime)
 
         configuration.log.debug("Exported session_end event sessionId: \(self.id)")
-        configuration.tracer.flush()
     }
 
     func addFramework(_ name: String) {
@@ -145,58 +150,75 @@ extension DDSession: TestSession {
         }
     }
 
-    func end(time: Date?) { end(endTime: time) }
+    /// Ends the session's span only. The owning `SessionManager` calls this and
+    /// then drives the rest of the shutdown itself, so this must not re-enter the
+    /// manager the way the public `end` API does.
+    func end(time: Date?) { internalEnd(endTime: time) }
 }
 
 /// Public interface for DDSession
 public extension DDSession {
     /// Starts the test session
+    ///
+    /// Returns `nil` when the SDK can't run at all — most commonly a missing
+    /// `DD_API_KEY`, without which nothing can be reported. There is no partially
+    /// working session: check the result and skip your instrumentation if it's nil.
     /// - Parameters:
     ///   - name: name of the session
     ///   - command: Optional, test command that started this session
     ///   - startTime: Optional, the time where the session started
-    @objc static func start(name: String, command: String? = nil, startTime: Date? = nil) -> DDSession {
-        if DDTestMonitor.instance == nil  {
-            let _ = DDTestMonitor.installTestMonitor()
+    @objc static func start(name: String, command: String? = nil, startTime: Date? = nil) -> DDSession? {
+        // Bootstrap through a session manager, exactly like a framework-driven run
+        // — so the session gets the same start hooks and the same shutdown path.
+        // The manager is created first and handed to the session, which keeps it to
+        // drive its own `end`.
+        let manager = SessionManager(log: Log.instance,
+                                     provider: DDSession.ManualProvider(),
+                                     observer: SessionAndModuleObserver(),
+                                     bootstrap: .manual(name: name, command: command,
+                                                        startTime: startTime))
+        // Blocking here is fine: this is session *start*, not the teardown path.
+        guard let session = waitForAsync({ try? await manager.session }) as? DDSession else {
+            Log.print("Could not start the test session: the test monitor is unavailable")
+            return nil
         }
-        // Use the monitor's tracer. The fallback only matters if the monitor
-        // failed to install (degraded path) — we don't want a manual API call to
-        // crash, but normally the tracer comes from the installed monitor.
-        let tracer = DDTestMonitor.instance?.tracer ?? DDTracer()
-        let config = SessionConfig(activeFeatures: DDTestMonitor.instance?.activeFeatures ?? [],
-                                   env: DDTestMonitor.env,
-                                   config: DDTestMonitor.config,
-                                   clock: DDTestMonitor.clock,
-                                   crash: DDTestMonitor.instance?.crashInfo,
-                                   command: command,
-                                   log: Log.instance,
-                                   tracer: tracer,
-                                   telemetry: tracer.telemetry)
-        waitForAsync { await DDTestMonitor.clock.sync() }
-        let session = DDSession(name: name, config: config,
-                                modules: DDModule.StatelessManager(observer: SessionAndModuleObserver()),
-                                startTime: startTime)
-        if let telemetry = tracer.telemetry {
-            telemetry.metrics.session.started.add(provider: config.env.ci?.provider, autoInjected: false)
-            telemetry.metrics.events.manualApiEvents.add(eventType: .session)
-            session.emitGitShaCheck(to: telemetry)
-        }
+        // `session.started` / git-SHA telemetry is emitted by the session-start
+        // feature hook (via the observer's `didStart`); only the manual-API counter
+        // is specific to this entry point.
+        session.configuration.telemetry?.metrics.events.manualApiEvents.add(eventType: .session)
         return session
     }
 
-    @objc static func start(name: String) -> DDSession {
+    @objc static func start(name: String) -> DDSession? {
         return start(name: name, command: nil)
     }
 
     /// Ends the session
+    ///
+    /// Shutdown (flushing and uploading everything gathered) runs through the
+    /// session manager. This overload is fully synchronous and safe to call at
+    /// process exit; prefer the `async` overload when you can await it.
     /// - Parameters:
     ///   - endTime: Optional, the time where the session ended
     @objc(endWithTime:) func end(endTime: Date? = nil) {
         internalEnd(endTime: endTime)
+        _sessionManager?.stop()
     }
 
     @objc func end() {
         return end(endTime: nil)
+    }
+
+    /// Ends the session, awaiting the shutdown instead of blocking the caller.
+    /// - Parameters:
+    ///   - endTime: Optional, the time where the session ended
+    func end(endTime: Date? = nil) async {
+        internalEnd(endTime: endTime)
+        await _sessionManager?.stop()
+    }
+
+    func end() async {
+        await end(endTime: nil)
     }
 
     /// Adds a extra tag or attribute to the test session, any number of tags can be reported

--- a/Sources/DatadogSDKTesting/DDTestMonitor.swift
+++ b/Sources/DatadogSDKTesting/DDTestMonitor.swift
@@ -140,6 +140,15 @@ internal class DDTestMonitor {
     
     static func removeTestMonitor() {
         DDTestMonitor.instance?.stop()
+        clearMonitor()
+    }
+
+    static func removeTestMonitor() async {
+        await DDTestMonitor.instance?.stop()
+        clearMonitor()
+    }
+
+    private static func clearMonitor() {
         DDTestMonitor.instance = nil
         Log.debug("Clearing monitor")
         try? DDSymbolicator.dsymFilesDir.delete()
@@ -214,7 +223,25 @@ internal class DDTestMonitor {
     }
     
     func stop() {
-        guard !isStopped else { return }
+        guard stopFeatures() else { return }
+        Log.measure(name: "tracer shutdown") { tracer.shutdown() }
+        Log.measure(name: "gitUploadQueue drain") {
+            gitUploadQueue.waitUntilAllOperationsAreFinished()
+        }
+    }
+
+    func stop() async {
+        guard stopFeatures() else { return }
+        await tracer.shutdown()
+        Log.measure(name: "gitUploadQueue drain") {
+            gitUploadQueue.waitUntilAllOperationsAreFinished()
+        }
+    }
+
+    /// Stops every feature. Returns `false` when the monitor was already stopped
+    /// and the caller should do nothing more.
+    private func stopFeatures() -> Bool {
+        guard !isStopped else { return false }
         isStopped = true
         Log.measure(name: "efd stop") { efd?.stop() }
         Log.measure(name: "atr stop") { atr?.stop() }
@@ -222,10 +249,7 @@ internal class DDTestMonitor {
         Log.measure(name: "coverage stop") { coverage?.stop() }
         Log.measure(name: "knownTests stop") { knownTests?.stop() }
         Log.measure(name: "testManagement stop") { testManagement?.stop() }
-        Log.measure(name: "tracer shutdown") { tracer.shutdown() }
-        Log.measure(name: "gitUploadQueue drain") {
-            gitUploadQueue.waitUntilAllOperationsAreFinished()
-        }
+        return true
     }
     
     deinit {

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -621,6 +621,34 @@ internal class DDTracer {
         Log.debug("Tracer shutdown")
     }
 
+    /// Async counterparts of `flush()` / `shutdown()`. `SpanProcessor` and
+    /// `TracerProviderSdk` have no async API, so these drive the exporter
+    /// directly instead of going through the provider. Spans are exported to the
+    /// exporter synchronously as they end (`SimpleSpanProcessor`), so nothing is
+    /// stranded in the processor by skipping it.
+    func flush() async {
+        Log.measure(name: "flushRUM") { flushRUM() }
+        _ = await eventsExporter?.flush(explicitTimeout: nil)
+        _ = await telemetry?.flush()
+        Log.debug("Tracer flush finished")
+    }
+
+    func shutdown() async {
+        Log.measure(name: "flushRUM") { flushRUM() }
+        await eventsExporter?.shutdown(explicitTimeout: nil)
+        await telemetry?.shutdown()
+        Log.debug("Tracer shutdown")
+    }
+
+    /// Persist everything gathered so far to disk without uploading it, and
+    /// without touching the network or the cooperative executor. Called from the
+    /// crash handler, where the process is about to die: any event already
+    /// handed to the SDK lands on disk and is uploaded by the next run.
+    func persistToDisk() {
+        eventsExporter?.persistToDisk()
+        telemetry?.persistToDisk()
+    }
+
     func addPropagationsHeadersToEnvironment() {
         let headers = tracePropagationHTTPHeaders()
         headers.forEach {

--- a/Sources/DatadogSDKTesting/DDTracer.swift
+++ b/Sources/DatadogSDKTesting/DDTracer.swift
@@ -640,15 +640,6 @@ internal class DDTracer {
         Log.debug("Tracer shutdown")
     }
 
-    /// Persist everything gathered so far to disk without uploading it, and
-    /// without touching the network or the cooperative executor. Called from the
-    /// crash handler, where the process is about to die: any event already
-    /// handed to the SDK lands on disk and is uploaded by the next run.
-    func persistToDisk() {
-        eventsExporter?.persistToDisk()
-        telemetry?.persistToDisk()
-    }
-
     func addPropagationsHeadersToEnvironment() {
         let headers = tracePropagationHTTPHeaders()
         headers.forEach {

--- a/Sources/DatadogSDKTesting/FrameworkLoadHandler.swift
+++ b/Sources/DatadogSDKTesting/FrameworkLoadHandler.swift
@@ -65,9 +65,11 @@ enum FrameworkLoadHandler {
         DatadogSwiftTestingTrait.sharedSuiteProvider = nil
         if let manager = sessionManager {
             sessionManager = nil
-            waitForAsync {
-                await manager.stop()
-            }
+            // Synchronous on purpose: this runs from the library-unload C
+            // destructor during `exit()`, where the Swift cooperative executor
+            // may never be scheduled again — bridging to `async` here can hang
+            // teardown instead of completing it.
+            manager.stop()
         }
     }
 }

--- a/Sources/DatadogSDKTesting/Models.swift
+++ b/Sources/DatadogSDKTesting/Models.swift
@@ -46,20 +46,56 @@ protocol TestSession: TestContainer {
 }
 
 protocol TestSessionManagerObserver: Sendable {
+    /// Session start is only ever reached from the async bootstrap, so it has no
+    /// synchronous variant.
     func didStart(session: any TestSession) async
+
+    func willFinish(session: any TestSession)
+    func didFinish(session: any TestSession)
+
+    /// Async counterparts of the end hooks, so an observer that needs to suspend
+    /// can implement them. Both variants exist because session end also runs on
+    /// the synchronous teardown path, where `await` isn't available.
     func willFinish(session: any TestSession) async
     func didFinish(session: any TestSession) async
 }
 
+/// The async end hooks default to their synchronous counterparts, so observers
+/// only implement the async ones when they actually need to suspend.
+///
+/// Each body pins the call to a non-`async` function type: within an `async`
+/// context an unannotated `willFinish(session:)` would resolve back to this
+/// async overload and recurse.
+extension TestSessionManagerObserver {
+    func willFinish(session: any TestSession) async {
+        let sync: (any TestSession) -> Void = willFinish(session:)
+        sync(session)
+    }
+
+    func didFinish(session: any TestSession) async {
+        let sync: (any TestSession) -> Void = didFinish(session:)
+        sync(session)
+    }
+}
+
 protocol TestSessionProvider: Sendable {
+    /// - Parameter manager: the manager bootstrapping this session. Providers whose
+    ///   sessions are ended by the caller (the manual `DDSession.start` API) hand it
+    ///   to the session so it can drive its own shutdown.
     func startSession(named: String, config: SessionConfig, startTime: Date,
-                      observer: (any TestModuleManagerObserver)?) async throws -> any TestSession & TestModuleManager
+                      observer: (any TestModuleManagerObserver)?,
+                      manager: any TestSessionManager) async throws -> any TestSession & TestModuleManager
 }
 
 protocol TestSessionManager: Sendable {
     var session: any TestSession & TestModuleManager { get async throws }
 
     func stop() async
+
+    /// Synchronous teardown. Must never use `Task`/`await`: this is what runs
+    /// from the library-unload C destructor during `exit()`, where the Swift
+    /// cooperative executor is no longer guaranteed to be scheduled.
+    func stop()
 }
 
 protocol TestModule: TestContainer {

--- a/Sources/DatadogSDKTesting/SessionAndModuleObserver.swift
+++ b/Sources/DatadogSDKTesting/SessionAndModuleObserver.swift
@@ -11,11 +11,11 @@ struct SessionAndModuleObserver: TestSessionManagerObserver, TestModuleManagerOb
         session.configuration.activeFeatures.testSessionWillStart(session: session)
     }
 
-    func willFinish(session: any TestSession) async {
+    func willFinish(session: any TestSession) {
         session.configuration.activeFeatures.testSessionWillEnd(session: session)
     }
 
-    func didFinish(session: any TestSession) async {
+    func didFinish(session: any TestSession) {
         session.configuration.activeFeatures.testSessionDidEnd(session: session)
         #if canImport(Testing)
             DatadogSwiftTestingTrait.sharedSuiteProvider = nil

--- a/Sources/DatadogSDKTesting/SessionManager.swift
+++ b/Sources/DatadogSDKTesting/SessionManager.swift
@@ -7,48 +7,151 @@
 import Foundation
 internal import EventsExporter
 
-final actor SessionManager: TestSessionManager {
-    private var _session: Task<any TestModuleManager & TestSession, any Error>?
+/// Owns the lifecycle of the one test session and, through it, the teardown of
+/// `DDTestMonitor`.
+///
+/// State is guarded by a lock rather than actor isolation on purpose: teardown
+/// has to be reachable synchronously from the library-unload C destructor during
+/// `exit()`, where the Swift cooperative executor is no longer guaranteed to run
+/// — so a `Task`/`await` hop there can deadlock instead of completing.
+final class SessionManager: TestSessionManager, @unchecked Sendable {
+    typealias Session = any TestModuleManager & TestSession
+
+    private enum State {
+        case idle
+        case starting(Task<Session, any Error>)
+        case running(Session)
+    }
+
+    private let state: Synced<State>
     let observer: (any TestSessionManagerObserver & TestModuleManagerObserver)?
     let provider: any TestSessionProvider
+    let bootstrap: Bootstrap
     let log: Logger
 
-    init(log: Logger, provider: any TestSessionProvider, observer: (any TestSessionManagerObserver & TestModuleManagerObserver)?) {
-        self._session = nil
+    init(log: Logger, provider: any TestSessionProvider,
+         observer: (any TestSessionManagerObserver & TestModuleManagerObserver)?,
+         bootstrap: Bootstrap = .automatic) {
+        self.state = Synced(.idle)
         self.log = log
         self.provider = provider
         self.observer = observer
+        self.bootstrap = bootstrap
     }
 
-    var session: any TestModuleManager & TestSession {
+    var session: Session {
         get async throws {
-            if let session = _session {
-                return try await session.value
+            switch pendingSession() {
+            case .ready(let session):
+                return session
+            case .starting(let task):
+                let session = try await task.value
+                state.update { state in
+                    if case .starting = state { state = .running(session) }
+                }
+                return session
             }
-            _session = Task.detached { try await self.bootstrapSession() }
-            return try await _session!.value
         }
     }
 
     func stop() async {
-        guard let session = try? await _session?.value else {
-            return
-        }
+        guard let session = await takeSession() else { return }
         await observer?.willFinish(session: session)
-        _session = nil
-        session.end()
+        session.end(time: nil)
         await observer?.didFinish(session: session)
+        await DDTestMonitor.removeTestMonitor()
+    }
+
+    /// Synchronous teardown for the process-exit path. Contains no `Task`/`await`
+    /// at any depth: the observer hooks run, the session's span is ended and the
+    /// monitor is shut down, all on the calling thread.
+    func stop() {
+        switch takeSessionSync() {
+        case .none:
+            return
+        case .session(let session):
+            observer?.willFinish(session: session)
+            session.end(time: nil)
+            observer?.didFinish(session: session)
+        case .stillStarting:
+            // The session never finished bootstrapping, so there's no span to
+            // end — but still shut the monitor down so whatever was already
+            // gathered gets flushed and uploaded.
+            log.debug("Session was still starting at teardown; shutting down without ending it")
+        }
         // `removeTestMonitor()` runs the monitor's `stop()` (which flushes and
         // shuts the tracer down) and then releases the instance, at which point
         // `DDTracer.deinit` restores the default OpenTelemetry providers.
         DDTestMonitor.removeTestMonitor()
     }
 
+    // MARK: - State transitions
+
+    private enum PendingSession {
+        case ready(Session)
+        case starting(Task<Session, any Error>)
+    }
+
+    /// Returns the live session, or the task bootstrapping it — starting the
+    /// bootstrap when this is the first access.
+    private func pendingSession() -> PendingSession {
+        state.update { state in
+            switch state {
+            case .running(let session):
+                return .ready(session)
+            case .starting(let task):
+                return .starting(task)
+            case .idle:
+                let task = Task.detached { try await self.bootstrapSession() }
+                state = .starting(task)
+                return .starting(task)
+            }
+        }
+    }
+
+    /// Detaches the session from the manager so it can be ended exactly once.
+    private func takeSession() async -> Session? {
+        let pending: PendingSession? = state.update { state in
+            defer { state = .idle }
+            switch state {
+            case .running(let session): return .ready(session)
+            case .starting(let task): return .starting(task)
+            case .idle: return nil
+            }
+        }
+        switch pending {
+        case .ready(let session): return session
+        case .starting(let task): return try? await task.value
+        case nil: return nil
+        }
+    }
+
+    private enum SyncTakeResult {
+        case session(Session)
+        case stillStarting
+        case none
+    }
+
+    private func takeSessionSync() -> SyncTakeResult {
+        state.update { state in
+            switch state {
+            case .running(let session):
+                state = .idle
+                return .session(session)
+            case .starting:
+                state = .idle
+                return .stillStarting
+            case .idle:
+                return .none
+            }
+        }
+    }
+
     private func bootstrapSession() async throws -> any TestModuleManager & TestSession {
         await DDTestMonitor.clock.sync()
-        
-        let startTime = DDTestMonitor.clock.now
-        
+
+        let startTime = bootstrap.startTime ?? DDTestMonitor.clock.now
+
         if DDTestMonitor.instance == nil {
             try log.measure(name: "Install Test Monitor") {
                 guard DDTestMonitor.installTestMonitor() else {
@@ -56,13 +159,15 @@ final actor SessionManager: TestSessionManager {
                 }
             }
         }
-        
+
         guard let monitor = DDTestMonitor.instance else {
             throw BoostrapError.monitorIsNil
         }
-        
-        log.measure(name: "Setup crash handler") {
-            monitor.setupCrashHandler()
+
+        if bootstrap.installsCrashHandler {
+            log.measure(name: "Setup crash handler") {
+                monitor.setupCrashHandler()
+            }
         }
 
         // The common telemetry manager is created with the tracer (so it's
@@ -74,14 +179,15 @@ final actor SessionManager: TestSessionManager {
             config: DDTestMonitor.config,
             clock: DDTestMonitor.clock,
             crash: monitor.crashInfo,
-            command: DDTestMonitor.env.testCommand,
+            command: bootstrap.command.value,
             log: log,
             tracer: monitor.tracer,
             telemetry: monitor.tracer.telemetry
         )
-        
-        let session = try await provider.startSession(named: "Swift.session", config: config,
-                                                      startTime: startTime, observer: observer)
+
+        let session = try await provider.startSession(named: bootstrap.sessionName, config: config,
+                                                      startTime: startTime, observer: observer,
+                                                      manager: self)
         await observer?.didStart(session: session)
         return session
     }
@@ -92,16 +198,67 @@ extension SessionManager {
         case monitorInitFailed
         case monitorIsNil
     }
+
+    /// What differs between the framework-driven bootstrap and the manual
+    /// `DDSession.start` API.
+    struct Bootstrap: Sendable {
+        enum Command: Sendable {
+            case environment
+            case explicit(String?)
+
+            var value: String? {
+                switch self {
+                case .environment: return DDTestMonitor.env.testCommand
+                case .explicit(let command): return command
+                }
+            }
+        }
+
+        let sessionName: String
+        let command: Command
+        /// `nil` uses the clock's time at bootstrap.
+        let startTime: Date?
+        let installsCrashHandler: Bool
+
+        /// Framework-driven runs (XCTest / swift-testing).
+        static let automatic = Bootstrap(sessionName: "Swift.session", command: .environment,
+                                         startTime: nil, installsCrashHandler: true)
+
+        /// The manual API. It has never installed the crash handler, so it still
+        /// doesn't — enabling it here would turn crash reporting on for embedders
+        /// that only use `DDSession.start`.
+        static func manual(name: String, command: String?, startTime: Date?) -> Bootstrap {
+            Bootstrap(sessionName: name, command: .explicit(command),
+                      startTime: startTime, installsCrashHandler: false)
+        }
+    }
 }
 
 extension DDSession {
+    /// Framework-driven sessions. The `SessionManager` that created them ends them
+    /// directly, so they don't hold a back-reference to it.
     struct Provider: TestSessionProvider {
         func startSession(named name: String, config: SessionConfig, startTime: Date,
-                          observer: (any TestModuleManagerObserver)?) async throws -> any TestModuleManager & TestSession
+                          observer: (any TestModuleManagerObserver)?,
+                          manager: any TestSessionManager) async throws -> any TestModuleManager & TestSession
         {
             DDSession(name: name, config: config,
                       modules: DDModule.StatefulManager(observer: observer),
                       startTime: startTime)
+        }
+    }
+
+    /// Sessions created through the public `DDSession.start` API. The caller ends
+    /// these, so the session keeps the manager that performs the shutdown.
+    struct ManualProvider: TestSessionProvider {
+        func startSession(named name: String, config: SessionConfig, startTime: Date,
+                          observer: (any TestModuleManagerObserver)?,
+                          manager: any TestSessionManager) async throws -> any TestModuleManager & TestSession
+        {
+            DDSession(name: name, config: config,
+                      modules: DDModule.StatelessManager(observer: observer),
+                      startTime: startTime,
+                      sessionManager: manager)
         }
     }
 }

--- a/Sources/DatadogSDKTesting/Telemetry/Telemetry.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/Telemetry.swift
@@ -121,9 +121,32 @@ final class Telemetry: @unchecked Sendable {
         return exporter.flush()
     }
 
+    @discardableResult
+    func flush() async -> Bool {
+        metricStore.flush()
+        logStore.flush()
+        return await exporter.flush()
+    }
+
     /// Stop the timers, enqueue `app-closing`, drain a final time, and tear down
     /// the exporter — so the closing event and the last metrics ride the same batch.
     func shutdown() {
+        prepareShutdown()
+        // Synchronously upload the final batch (metrics + app-closing) before
+        // tearing the worker down — otherwise it sits on disk unsent at exit.
+        _ = exporter.flush()
+        exporter.shutdown()
+    }
+
+    func shutdown() async {
+        prepareShutdown()
+        _ = await exporter.flush()
+        await exporter.shutdown()
+    }
+
+    /// Cancel the timers and enqueue the final metrics/logs plus `app-closing`,
+    /// leaving only the upload for the caller to perform.
+    private func prepareShutdown() {
         flushTimer?.cancel()
         flushTimer = nil
         heartbeatTimer?.cancel()
@@ -131,12 +154,15 @@ final class Telemetry: @unchecked Sendable {
         metricStore.flush()
         logStore.flush()
         exporter.export(item: TelemetryAppClosing())
-        // Synchronously upload the final batch (metrics + app-closing) before
-        // tearing the worker down — otherwise it sits on disk unsent at exit.
-        _ = exporter.flush()
-        exporter.shutdown()
     }
 
+    /// Drain the accumulated metrics and logs into the exporter's storage and
+    /// persist it to disk, without uploading anything. Used on the crash path.
+    func persistToDisk() {
+        metricStore.flush()
+        logStore.flush()
+        exporter.persistToDisk()
+    }
 }
 
 // MARK: - Metric accumulation

--- a/Sources/DatadogSDKTesting/Telemetry/Telemetry.swift
+++ b/Sources/DatadogSDKTesting/Telemetry/Telemetry.swift
@@ -155,14 +155,6 @@ final class Telemetry: @unchecked Sendable {
         logStore.flush()
         exporter.export(item: TelemetryAppClosing())
     }
-
-    /// Drain the accumulated metrics and logs into the exporter's storage and
-    /// persist it to disk, without uploading anything. Used on the crash path.
-    func persistToDisk() {
-        metricStore.flush()
-        logStore.flush()
-        exporter.persistToDisk()
-    }
 }
 
 // MARK: - Metric accumulation

--- a/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
+++ b/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
@@ -110,10 +110,6 @@ internal final class CoverageExporter: CoverageExporterType {
         await coverageStorage.stop()
     }
 
-    func persistToDisk() {
-        coverageStorage.persistToDisk()
-    }
-
     private func writeCoverage(_ data: TestCodeCoverage) {
         payloadObserver?.eventEnqueued()
         if configuration.performancePreset.synchronousWrite {

--- a/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
+++ b/Sources/EventsExporter/CoverageExporter/CoverageExporter.swift
@@ -101,6 +101,19 @@ internal final class CoverageExporter: CoverageExporterType {
         coverageStorage.stop()
     }
 
+    @discardableResult
+    func forceFlush(explicitTimeout: TimeInterval?) async -> ExportResult {
+        (try? await coverageStorage.flush(timeout: explicitTimeout)) == true ? .success : .failure
+    }
+
+    func shutdown(explicitTimeout: TimeInterval?) async {
+        await coverageStorage.stop()
+    }
+
+    func persistToDisk() {
+        coverageStorage.persistToDisk()
+    }
+
     private func writeCoverage(_ data: TestCodeCoverage) {
         payloadObserver?.eventEnqueued()
         if configuration.performancePreset.synchronousWrite {

--- a/Sources/EventsExporter/Exporter.swift
+++ b/Sources/EventsExporter/Exporter.swift
@@ -14,6 +14,10 @@ public protocol ExporterProtocol: SpanExporter, LogRecordExporter, CoverageExpor
     /// rotate the writable file so the new header takes effect on the next
     /// batch.
     func setMetadata(_ metadata: SpanMetadata)
+
+    /// Persist everything gathered so far to disk without uploading it. Safe to
+    /// call from the crash handler: no network, no suspension.
+    func persistToDisk()
 }
 
 public final class Exporter: ExporterProtocol {
@@ -116,16 +120,25 @@ public final class Exporter: ExporterProtocol {
     }
 
     public func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
-        let logsOK = (try? logsExporter.logsStorage.flush(timeout: explicitTimeout)) ?? false
-        let spansOK = (try? spansExporter.spansStorage.flush(timeout: explicitTimeout)) ?? false
-        let covOK = (try? coverageExporter.coverageStorage.flush(timeout: explicitTimeout)) ?? false
+        let logsOK = (try? await logsExporter.logsStorage.flush(timeout: explicitTimeout)) ?? false
+        let spansOK = (try? await spansExporter.spansStorage.flush(timeout: explicitTimeout)) ?? false
+        let covOK = (try? await coverageExporter.coverageStorage.flush(timeout: explicitTimeout)) ?? false
         return (logsOK && spansOK && covOK) ? .success : .failure
     }
 
     public func shutdown(explicitTimeout: TimeInterval?) async {
         await logsExporter.shutdown(explicitTimeout: explicitTimeout)
         await spansExporter.shutdown(explicitTimeout: explicitTimeout)
-        coverageExporter.shutdown()
+        await coverageExporter.shutdown(explicitTimeout: explicitTimeout)
+    }
+
+    /// Disk-only counterpart of `flush`: every feature drains its writer and
+    /// closes its in-progress file, so all gathered events are on disk and get
+    /// picked up by a later run. Performs no upload.
+    public func persistToDisk() {
+        logsExporter.persistToDisk()
+        spansExporter.persistToDisk()
+        coverageExporter.persistToDisk()
     }
 
     public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) async -> ExportResult {

--- a/Sources/EventsExporter/Exporter.swift
+++ b/Sources/EventsExporter/Exporter.swift
@@ -14,10 +14,6 @@ public protocol ExporterProtocol: SpanExporter, LogRecordExporter, CoverageExpor
     /// rotate the writable file so the new header takes effect on the next
     /// batch.
     func setMetadata(_ metadata: SpanMetadata)
-
-    /// Persist everything gathered so far to disk without uploading it. Safe to
-    /// call from the crash handler: no network, no suspension.
-    func persistToDisk()
 }
 
 public final class Exporter: ExporterProtocol {
@@ -130,15 +126,6 @@ public final class Exporter: ExporterProtocol {
         await logsExporter.shutdown(explicitTimeout: explicitTimeout)
         await spansExporter.shutdown(explicitTimeout: explicitTimeout)
         await coverageExporter.shutdown(explicitTimeout: explicitTimeout)
-    }
-
-    /// Disk-only counterpart of `flush`: every feature drains its writer and
-    /// closes its in-progress file, so all gathered events are on disk and get
-    /// picked up by a later run. Performs no upload.
-    public func persistToDisk() {
-        logsExporter.persistToDisk()
-        spansExporter.persistToDisk()
-        coverageExporter.persistToDisk()
     }
 
     public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) async -> ExportResult {

--- a/Sources/EventsExporter/Logs/LogsExporter.swift
+++ b/Sources/EventsExporter/Logs/LogsExporter.swift
@@ -93,10 +93,14 @@ internal final class LogsExporter: LogRecordExporter {
     }
 
     func forceFlush(explicitTimeout: TimeInterval?) async -> ExportResult {
-        (try? logsStorage.flush(timeout: explicitTimeout)) == true ? .success : .failure
+        (try? await logsStorage.flush(timeout: explicitTimeout)) == true ? .success : .failure
     }
 
     func shutdown(explicitTimeout: TimeInterval?) async {
-        logsStorage.stop()
+        await logsStorage.stop()
+    }
+
+    func persistToDisk() {
+        logsStorage.persistToDisk()
     }
 }

--- a/Sources/EventsExporter/Logs/LogsExporter.swift
+++ b/Sources/EventsExporter/Logs/LogsExporter.swift
@@ -99,8 +99,4 @@ internal final class LogsExporter: LogRecordExporter {
     func shutdown(explicitTimeout: TimeInterval?) async {
         await logsStorage.stop()
     }
-
-    func persistToDisk() {
-        logsStorage.persistToDisk()
-    }
 }

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -122,10 +122,6 @@ internal final class SpansExporter: SpanExporter {
     func shutdown(explicitTimeout: TimeInterval?) async {
         await spansStorage.stop()
     }
-
-    func persistToDisk() {
-        spansStorage.persistToDisk()
-    }
 }
 
 extension SpansExporter {

--- a/Sources/EventsExporter/Spans/SpansExporter.swift
+++ b/Sources/EventsExporter/Spans/SpansExporter.swift
@@ -116,11 +116,15 @@ internal final class SpansExporter: SpanExporter {
     }
 
     func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
-        (try? spansStorage.flush(timeout: explicitTimeout)) == true ? .success : .failure
+        (try? await spansStorage.flush(timeout: explicitTimeout)) == true ? .success : .failure
     }
 
     func shutdown(explicitTimeout: TimeInterval?) async {
-        spansStorage.stop()
+        await spansStorage.stop()
+    }
+
+    func persistToDisk() {
+        spansStorage.persistToDisk()
     }
 }
 

--- a/Sources/EventsExporter/Telemetry/TelemetryExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryExporter.swift
@@ -16,8 +16,6 @@ public protocol TelemetryPayloadExporter: AnyObject {
     @discardableResult func flush() async -> Bool
     func shutdown()
     func shutdown() async
-    /// Persist buffered payloads to disk without uploading them.
-    func persistToDisk()
 }
 
 public final class TelemetryExporter: TelemetryPayloadExporter {
@@ -87,10 +85,6 @@ public final class TelemetryExporter: TelemetryPayloadExporter {
 
     public func shutdown() async {
         await telemetryStorage.stop()
-    }
-
-    public func persistToDisk() {
-        telemetryStorage.persistToDisk()
     }
 
     private func write<T: Encodable>(_ value: T) {

--- a/Sources/EventsExporter/Telemetry/TelemetryExporter.swift
+++ b/Sources/EventsExporter/Telemetry/TelemetryExporter.swift
@@ -13,7 +13,11 @@ public protocol TelemetryPayloadExporter: AnyObject {
     func export(item: any TelemetryPayload)
     func export(items: [any TelemetryPayload])
     @discardableResult func flush() -> Bool
+    @discardableResult func flush() async -> Bool
     func shutdown()
+    func shutdown() async
+    /// Persist buffered payloads to disk without uploading them.
+    func persistToDisk()
 }
 
 public final class TelemetryExporter: TelemetryPayloadExporter {
@@ -72,8 +76,21 @@ public final class TelemetryExporter: TelemetryPayloadExporter {
         (try? telemetryStorage.flush(timeout: nil)) ?? false
     }
 
+    @discardableResult
+    public func flush() async -> Bool {
+        (try? await telemetryStorage.flush(timeout: nil)) ?? false
+    }
+
     public func shutdown() {
         telemetryStorage.stop()
+    }
+
+    public func shutdown() async {
+        await telemetryStorage.stop()
+    }
+
+    public func persistToDisk() {
+        telemetryStorage.persistToDisk()
     }
 
     private func write<T: Encodable>(_ value: T) {

--- a/Sources/EventsExporter/Upload/DataUploadWorker.swift
+++ b/Sources/EventsExporter/Upload/DataUploadWorker.swift
@@ -28,7 +28,11 @@ internal protocol DataUploadWorkerType: Sendable {
     ///
     /// This overload blocks the calling thread and never suspends, so it stays
     /// usable on the teardown path (see `ClosureDataUploader`).
-    func flush(timeout: TimeInterval?) throws -> Bool
+    ///
+    /// Pass `lastChance` for the shutdown drain: if the periodic loop is wedged
+    /// and never frees the upload slot, the drain runs anyway and re-sends what is
+    /// left, trading possible duplicates for not losing the data entirely.
+    func flush(timeout: TimeInterval?, lastChance: Bool) throws -> Bool
 
     /// Drain all stored data, suspending rather than blocking. Same budget and
     /// exclusivity semantics as the synchronous overload.
@@ -43,6 +47,13 @@ internal protocol DataUploadWorkerType: Sendable {
 
     /// Cancel scheduled uploads and await the in-flight upload cycle.
     func stop() async
+}
+
+extension DataUploadWorkerType {
+    /// Ordinary drain: gives up rather than risking a duplicate send.
+    func flush(timeout: TimeInterval?) throws -> Bool {
+        try flush(timeout: timeout, lastChance: false)
+    }
 }
 
 internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable {
@@ -143,17 +154,40 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     /// left on disk for a later run. Each individual attempt is additionally
     /// bounded by the smaller of the remaining budget and the default
     /// per-attempt cap.
-    func flush(timeout: TimeInterval?) throws -> Bool {
-        let deadline = Date(timeIntervalSinceNow: timeout ?? uploadTimeout)
+    ///
+    /// `lastChance` is for the shutdown drain, where leaving a batch behind
+    /// usually means losing it for good — a CI runner rarely gets a "later run"
+    /// with the same cache. When the periodic loop is wedged and won't release the
+    /// upload slot, the drain proceeds anyway rather than returning empty-handed,
+    /// re-sending a batch whose fate we can't determine. That can duplicate events
+    /// the server already accepted; the pipeline is at-least-once regardless (a
+    /// retry after a response timeout does the same), and duplicates beat silently
+    /// dropping a session.
+    func flush(timeout: TimeInterval?, lastChance: Bool) throws -> Bool {
+        let budget = timeout ?? uploadTimeout
+        let budgetDeadline = Date(timeIntervalSinceNow: budget)
         // Take the slot first: once held, no other upload is running, so the
         // enumeration below sees the complete, settled set of stored batches.
-        guard acquireUploadSlot(until: deadline) else { return false }
-        defer { uploadSlot.signal() }
+        let exclusive = acquireUploadSlot(until: budgetDeadline)
+        defer { if exclusive { uploadSlot.signal() } }
+        guard exclusive || lastChance else { return false }
+        // Waiting for a wedged loop just burned the whole budget, so the
+        // last-chance drain gets a fresh one — otherwise it would have no time
+        // left to send anything and the fallback would be pointless.
+        let deadline = exclusive ? budgetDeadline : Date(timeIntervalSinceNow: budget)
+        if !exclusive {
+            log.print("[\(featureName)] shutting down with an upload still in flight; "
+                      + "re-sending everything left on disk, which may duplicate events")
+        }
 
         var result = true
         var iterator = try remainingBatches()
         batchLoop: while let batchRes = iterator.next() {
             guard case .success(let batch) = batchRes else {
+                // Without the slot a wedged upload may delete a file mid-read;
+                // that batch is already handled, so move on instead of giving up
+                // on the ones after it.
+                if lastChance { continue }
                 result = false
                 break
             }
@@ -166,7 +200,8 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
                 status = upload(data: batch.data, timeout: attemptTimeout)
                 switch status {
                 case .success:
-                    try markAsRead(batch)
+                    // Same race: the file may already be gone.
+                    if lastChance { try? markAsRead(batch) } else { try markAsRead(batch) }
                     result = true
                 case .failed:
                     result = false

--- a/Sources/EventsExporter/Upload/DataUploadWorker.swift
+++ b/Sources/EventsExporter/Upload/DataUploadWorker.swift
@@ -19,33 +19,53 @@ internal protocol DataUploadWorkerType: Sendable {
     /// OpenTelemetry `forceFlush` timeout). When it elapses, remaining batches
     /// are left on disk for a later run. `nil` means "no total budget" — each
     /// attempt is still bounded by the default per-attempt cap.
+    ///
+    /// This overload blocks the calling thread and never suspends, so it stays
+    /// usable on the teardown path (see `ClosureDataUploader`).
     func flush(timeout: TimeInterval?) throws -> Bool
 
-    /// Cancel scheduled uploads and stop scheduling new ones. Does not
-    /// interrupt an upload that has already started; will block the caller
-    /// if invoked mid-upload.
+    /// Drain all stored data, suspending rather than blocking. Same budget
+    /// semantics as the synchronous overload.
+    func flush(timeout: TimeInterval?) async throws -> Bool
+
+    /// Cancel scheduled uploads and stop scheduling new ones. Does not wait for
+    /// an upload that has already started — waiting would mean depending on the
+    /// cooperative executor, which isn't guaranteed to run at process exit.
     func stop()
+
+    /// Cancel scheduled uploads and await the in-flight upload cycle.
+    func stop() async
 }
 
 internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable {
-    /// Queue to execute uploads.
-    internal let queue: DispatchQueue
-    /// File reader providing data to upload.
+    /// All mutable worker state, guarded by `Synced`'s lock. The lock is only
+    /// ever held for bookkeeping — never across an upload — so the synchronous
+    /// teardown path can take it without waiting on the cooperative executor.
+    private struct State {
+        var delay: Delay
+        var isStopped: Bool = false
+        /// Names of files whose batch is currently being uploaded. Both the
+        /// periodic loop and a concurrent flush skip these, so the same batch is
+        /// never uploaded twice when they overlap.
+        var inFlight: Set<String> = []
+        var periodicUploads: Task<Void, Never>? = nil
+    }
+
+    /// File reader providing data to upload. Not thread safe — every access goes
+    /// through `readerLock`.
     private let fileReader: FileReader
+    private let readerLock = UnfairLock()
     /// Data uploader sending data to server.
     private let dataUploader: DataUploaderType
     /// Name of the feature this worker is performing uploads for.
     private let featureName: String
-    /// Delay used to schedule consecutive uploads.
-    private var delay: Delay
     /// Request timeout for upload
     private let uploadTimeout: TimeInterval
-    /// Upload work scheduled by this worker.
-    private var uploadWork: DispatchWorkItem?
     /// Optional telemetry observer notified about upload attempts / drops.
     private let observer: UploadObserver?
     /// Logger for upload status and errors.
     private let log: Logger
+    private let state: Synced<State>
 
     init(
         fileReader: FileReader,
@@ -59,49 +79,50 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     ) {
         self.fileReader = fileReader
         self.dataUploader = dataUploader
-        self.delay = delay
         self.uploadTimeout = uploadTimeout
         self.observer = observer
         self.log = log
-        self.queue = DispatchQueue(label: "datadogtest.datauploadworker.\(featureName)",
-                                   target: .global(qos: priority.qosClass))
         self.featureName = featureName
+        self.state = Synced(State(delay: delay))
 
-        let uploadWork = DispatchWorkItem { [weak self] in
-            guard let self = self else { return }
-
-            let batch: Batch?
-            do {
-                batch = try self.fileReader.getNextBatch()
-            } catch {
-                batch = nil // file is broken
-            }
-
-            if let batch = batch {
-                if self.upload(data: batch.data, timeout: uploadTimeout) == .success {
-                    try? self.fileReader.markBatchAsRead(batch)
-                }
-            } else {
-                self.delay.increase()
-            }
-
-            self.scheduleNextUpload(after: self.delay.current)
+        let task = Task<Void, Never>.detached(priority: priority.taskPriority) { [weak self] in
+            await self?.runPeriodicUploads()
         }
-        self.uploadWork = uploadWork
-        scheduleNextUpload(after: self.delay.current)
-    }
-
-    private func scheduleNextUpload(after delay: TimeInterval) {
-        guard let work = uploadWork else { return }
-        queue.asyncAfter(deadline: .now() + delay, execute: work)
+        state.update { $0.periodicUploads = task }
     }
 
     func update(dataFormat: DataFormatType) {
-        queue.sync { fileReader.update(dataFormat: dataFormat) }
+        readerLock.whileLocked { fileReader.update(dataFormat: dataFormat) }
     }
 
-    /// Drains all pending batches synchronously. Holds the upload queue for
-    /// the duration so the periodic worker can't interleave reads with the flush.
+    // MARK: - Periodic uploads
+
+    private func runPeriodicUploads() async {
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(nanoseconds: state.value.delay.current.nanoseconds)
+            } catch {
+                return // cancelled
+            }
+            guard !state.value.isStopped else { return }
+            await uploadNextBatch()
+        }
+    }
+
+    private func uploadNextBatch() async {
+        guard let batch = claimNextBatch() else {
+            state.update { $0.delay.increase() }
+            return
+        }
+        defer { release(batch) }
+        if await upload(data: batch.data, timeout: uploadTimeout) == .success {
+            try? markAsRead(batch)
+        }
+    }
+
+    // MARK: - Flush
+
+    /// Drains all pending batches synchronously.
     ///
     /// `timeout`, when set, is a total wall-clock budget for the whole drain:
     /// once it elapses no further attempt is started and remaining batches are
@@ -111,78 +132,184 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     func flush(timeout: TimeInterval?) throws -> Bool {
         let deadline = Date(timeIntervalSinceNow: timeout ?? uploadTimeout)
         var result = true
-        try queue.sync {
-            var iterator = try fileReader.getRemainingBatches()
-            batchLoop: while let batchRes = iterator.next() {
-                guard case .success(let batch) = batchRes else {
-                    result = false
-                    break
-                }
-                var status: UploadResult
-                repeat {
-                    let attemptTimeout = max(0, deadline.timeIntervalSinceNow)
-                    guard attemptTimeout > 0 else {
-                        // Total flush budget exhausted; leave remaining batches
-                        // on disk rather than blocking teardown further.
-                        log.print("[\(featureName)] flush timed out; leaving remaining batches on disk")
-                        result = false
-                        break batchLoop
-                    }
-                    status = upload(data: batch.data, timeout: attemptTimeout)
-                    switch status {
-                    case .success:
-                        try self.fileReader.markBatchAsRead(batch)
-                        result = true
-                    case .failed:
-                        result = false
-                    case .retry:
-                        // Don't sleep past the deadline.
-                        Thread.sleep(forTimeInterval: min(delay.current, max(0, deadline.timeIntervalSinceNow)))
-                    }
-                } while status.isRetry
-                guard result else { break }
+        var iterator = try remainingBatches()
+        batchLoop: while let batchRes = iterator.next() {
+            guard case .success(let batch) = batchRes else {
+                result = false
+                break
             }
+            // Skip a batch the periodic loop is already uploading.
+            guard claim(batch) else { continue }
+            defer { release(batch) }
+            var status: UploadResult
+            repeat {
+                guard let attemptTimeout = attemptTimeout(until: deadline) else {
+                    result = false
+                    break batchLoop
+                }
+                status = upload(data: batch.data, timeout: attemptTimeout)
+                switch status {
+                case .success:
+                    try markAsRead(batch)
+                    result = true
+                case .failed:
+                    result = false
+                case .retry:
+                    Thread.sleep(forTimeInterval: retryDelay(until: deadline))
+                }
+            } while status.isRetry
+            guard result else { break }
         }
         return result
     }
 
+    func flush(timeout: TimeInterval?) async throws -> Bool {
+        let deadline = Date(timeIntervalSinceNow: timeout ?? uploadTimeout)
+        var result = true
+        var iterator = try remainingBatches()
+        batchLoop: while let batchRes = iterator.next() {
+            guard case .success(let batch) = batchRes else {
+                result = false
+                break
+            }
+            guard claim(batch) else { continue }
+            defer { release(batch) }
+            var status: UploadResult
+            repeat {
+                guard let attemptTimeout = attemptTimeout(until: deadline) else {
+                    result = false
+                    break batchLoop
+                }
+                status = await upload(data: batch.data, timeout: attemptTimeout)
+                switch status {
+                case .success:
+                    try markAsRead(batch)
+                    result = true
+                case .failed:
+                    result = false
+                case .retry:
+                    try? await Task.sleep(nanoseconds: retryDelay(until: deadline).nanoseconds)
+                }
+            } while status.isRetry
+            guard result else { break }
+        }
+        return result
+    }
+
+    // MARK: - Stop
+
     func stop() {
-        queue.sync {
-            // Cancellation must happen on `queue` — otherwise a pending block could
-            // execute fully and schedule another upload at the end.
-            self.uploadWork?.cancel()
-            self.uploadWork = nil
+        // Cancellation is enough: `isStopped` blocks any further claim, and
+        // `inFlight` keeps a still-finishing cycle from colliding with a flush.
+        // We deliberately don't await the task — that would make teardown depend
+        // on the cooperative executor being scheduled.
+        cancelPeriodicUploads()?.cancel()
+    }
+
+    func stop() async {
+        guard let task = cancelPeriodicUploads() else { return }
+        task.cancel()
+        await task.value
+    }
+
+    private func cancelPeriodicUploads() -> Task<Void, Never>? {
+        state.update { state in
+            state.isStopped = true
+            defer { state.periodicUploads = nil }
+            return state.periodicUploads
         }
     }
 
+    // MARK: - Batch bookkeeping
+
+    private func remainingBatches() throws -> Batch.Iterator {
+        try readerLock.whileLocked { try fileReader.getRemainingBatches() }
+    }
+
+    /// Reads the next batch and claims it for upload, or returns `nil` when
+    /// there is nothing to upload (or it's already claimed).
+    private func claimNextBatch() -> Batch? {
+        let batch = readerLock.whileLocked { try? fileReader.getNextBatch() }
+        guard let batch, claim(batch) else { return nil }
+        return batch
+    }
+
+    /// Claims a batch unless another upload already holds it. Deliberately does
+    /// not consider `isStopped`: `stop()` is followed by a final `flush()` on the
+    /// shutdown path, and that flush still has to drain everything.
+    private func claim(_ batch: Batch) -> Bool {
+        state.update { state in
+            guard !state.inFlight.contains(batch.file.name) else { return false }
+            state.inFlight.insert(batch.file.name)
+            return true
+        }
+    }
+
+    private func release(_ batch: Batch) {
+        state.update { $0.inFlight.remove(batch.file.name) }
+    }
+
+    private func markAsRead(_ batch: Batch) throws {
+        try readerLock.whileLocked { try fileReader.markBatchAsRead(batch) }
+    }
+
+    /// Remaining per-attempt budget, or `nil` when the total flush budget is
+    /// exhausted and remaining batches should be left on disk.
+    private func attemptTimeout(until deadline: Date) -> TimeInterval? {
+        let remaining = max(0, deadline.timeIntervalSinceNow)
+        guard remaining > 0 else {
+            log.print("[\(featureName)] flush timed out; leaving remaining batches on disk")
+            return nil
+        }
+        return remaining
+    }
+
+    /// Backoff before the next retry attempt, never past the flush deadline.
+    private func retryDelay(until deadline: Date) -> TimeInterval {
+        min(state.value.delay.current, max(0, deadline.timeIntervalSinceNow))
+    }
+
+    // MARK: - Upload
+
     private func upload(data: Data, timeout: TimeInterval?) -> UploadResult {
         let start = observer != nil ? DispatchTime.now() : nil
-        let uploadStatus = self.dataUploader.upload(data: data, timeout: timeout)
-        let result: UploadResult
-        if uploadStatus.needsRetry {
-            if let waitTime = uploadStatus.waitTime {
-                result = delay.set(delay: waitTime) ? .retry : .failed
-            } else {
-                delay.increase()
-                result = .retry
+        let status = dataUploader.upload(data: data, timeout: timeout)
+        return finish(status: status, byteCount: data.count, start: start)
+    }
+
+    private func upload(data: Data, timeout: TimeInterval?) async -> UploadResult {
+        let start = observer != nil ? DispatchTime.now() : nil
+        let status = await dataUploader.upload(data: data, timeout: timeout)
+        return finish(status: status, byteCount: data.count, start: start)
+    }
+
+    /// Maps an upload status to a `UploadResult`, updating the backoff delay and
+    /// reporting the attempt. Shared by both `upload` overloads.
+    private func finish(status: DataUploadStatus, byteCount: Int, start: DispatchTime?) -> UploadResult {
+        let result: UploadResult = state.update { state in
+            guard status.needsRetry else {
+                state.delay.decrease()
+                return .success
             }
-        } else {
-            delay.decrease()
-            result = .success
+            guard let waitTime = status.waitTime else {
+                state.delay.increase()
+                return .retry
+            }
+            return state.delay.set(delay: waitTime) ? .retry : .failed
         }
         switch result {
         case .success:
-            log.debug("[\(featureName)] batch uploaded (\(data.count) bytes)")
+            log.debug("[\(featureName)] batch uploaded (\(byteCount) bytes)")
         case .retry:
-            let reason = uploadStatus.failureDescription.map { ": \($0)" } ?? ""
+            let reason = status.failureDescription.map { ": \($0)" } ?? ""
             log.print("[\(featureName)] upload failed, will retry\(reason)")
         case .failed:
-            let reason = uploadStatus.failureDescription.map { ": \($0)" } ?? ""
+            let reason = status.failureDescription.map { ": \($0)" } ?? ""
             log.print("[\(featureName)] upload failed, dropping batch\(reason)")
         }
         if let observer, let start {
             let durationMs = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
-            observer.uploadAttempt(payloadBytes: data.count, durationMs: durationMs,
+            observer.uploadAttempt(payloadBytes: byteCount, durationMs: durationMs,
                                    success: result == .success, retriable: result == .retry)
         }
         return result
@@ -196,6 +323,22 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
         var isRetry: Bool {
             if case .retry = self { return true }
             return false
+        }
+    }
+}
+
+private extension TimeInterval {
+    var nanoseconds: UInt64 { UInt64(max(0, self) * 1_000_000_000) }
+}
+
+private extension DispatchQoS {
+    var taskPriority: TaskPriority {
+        switch qosClass {
+        case .userInteractive: return .high
+        case .userInitiated: return .userInitiated
+        case .utility: return .utility
+        case .background: return .background
+        default: return .medium
         }
     }
 }

--- a/Sources/EventsExporter/Upload/DataUploadWorker.swift
+++ b/Sources/EventsExporter/Upload/DataUploadWorker.swift
@@ -13,24 +13,32 @@ internal protocol DataUploadWorkerType: Sendable {
     func update(dataFormat: DataFormatType)
 
     /// Synchronously drain all stored data (with retry on transient failures).
-    /// Returns `false` if a non-retriable failure was encountered.
+    /// Returns `true` only if every batch stored when the drain began was
+    /// accounted for — uploaded and deleted, or deliberately dropped.
     ///
-    /// `timeout` is a total wall-clock budget for the whole drain (e.g. an
-    /// OpenTelemetry `forceFlush` timeout). When it elapses, remaining batches
-    /// are left on disk for a later run. `nil` means "no total budget" — each
-    /// attempt is still bounded by the default per-attempt cap.
+    /// A drain runs exclusively: it first waits for any upload the periodic loop
+    /// has already started, so it can never report success while a batch's fate
+    /// is still undecided.
+    ///
+    /// `timeout` is a total wall-clock budget for the whole drain — including that
+    /// wait — (e.g. an OpenTelemetry `forceFlush` timeout). When it elapses,
+    /// remaining batches are left on disk for a later run and the result is
+    /// `false`. `nil` means "no total budget": each attempt is still bounded by
+    /// the default per-attempt cap.
     ///
     /// This overload blocks the calling thread and never suspends, so it stays
     /// usable on the teardown path (see `ClosureDataUploader`).
     func flush(timeout: TimeInterval?) throws -> Bool
 
-    /// Drain all stored data, suspending rather than blocking. Same budget
-    /// semantics as the synchronous overload.
+    /// Drain all stored data, suspending rather than blocking. Same budget and
+    /// exclusivity semantics as the synchronous overload.
     func flush(timeout: TimeInterval?) async throws -> Bool
 
-    /// Cancel scheduled uploads and stop scheduling new ones. Does not wait for
-    /// an upload that has already started — waiting would mean depending on the
-    /// cooperative executor, which isn't guaranteed to run at process exit.
+    /// Cancel scheduled uploads, then wait for an upload the loop has already
+    /// started so its batch is either uploaded-and-deleted or left on disk before
+    /// returning. The wait is bounded: at process exit the cooperative executor
+    /// may never resume the task, and blocking forever there is the very deadlock
+    /// this path exists to avoid.
     func stop()
 
     /// Cancel scheduled uploads and await the in-flight upload cycle.
@@ -44,10 +52,6 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     private struct State {
         var delay: Delay
         var isStopped: Bool = false
-        /// Names of files whose batch is currently being uploaded. Both the
-        /// periodic loop and a concurrent flush skip these, so the same batch is
-        /// never uploaded twice when they overlap.
-        var inFlight: Set<String> = []
         var periodicUploads: Task<Void, Never>? = nil
     }
 
@@ -55,6 +59,12 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     /// through `readerLock`.
     private let fileReader: FileReader
     private let readerLock = UnfairLock()
+    /// Serializes uploading, the way the worker's `DispatchQueue` used to: the
+    /// periodic loop holds it for one batch, a flush holds it for the whole drain.
+    /// Without it a flush could walk past a batch another upload had already read
+    /// but not yet deleted, and report success while that batch's outcome — and
+    /// the matching file deletion — were still pending.
+    private let uploadSlot = DispatchSemaphore(value: 1)
     /// Data uploader sending data to server.
     private let dataUploader: DataUploaderType
     /// Name of the feature this worker is performing uploads for.
@@ -110,11 +120,15 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     }
 
     private func uploadNextBatch() async {
-        guard let batch = claimNextBatch() else {
+        // Skip this tick if a flush holds the slot — it is draining everything
+        // anyway, and the loop must not read a batch out from under it.
+        guard uploadSlot.wait(timeout: .now()) == .success else { return }
+        defer { uploadSlot.signal() }
+
+        guard let batch = nextBatch() else {
             state.update { $0.delay.increase() }
             return
         }
-        defer { release(batch) }
         if await upload(data: batch.data, timeout: uploadTimeout) == .success {
             try? markAsRead(batch)
         }
@@ -131,6 +145,11 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     /// per-attempt cap.
     func flush(timeout: TimeInterval?) throws -> Bool {
         let deadline = Date(timeIntervalSinceNow: timeout ?? uploadTimeout)
+        // Take the slot first: once held, no other upload is running, so the
+        // enumeration below sees the complete, settled set of stored batches.
+        guard acquireUploadSlot(until: deadline) else { return false }
+        defer { uploadSlot.signal() }
+
         var result = true
         var iterator = try remainingBatches()
         batchLoop: while let batchRes = iterator.next() {
@@ -138,9 +157,6 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
                 result = false
                 break
             }
-            // Skip a batch the periodic loop is already uploading.
-            guard claim(batch) else { continue }
-            defer { release(batch) }
             var status: UploadResult
             repeat {
                 guard let attemptTimeout = attemptTimeout(until: deadline) else {
@@ -165,6 +181,9 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
 
     func flush(timeout: TimeInterval?) async throws -> Bool {
         let deadline = Date(timeIntervalSinceNow: timeout ?? uploadTimeout)
+        guard await acquireUploadSlot(until: deadline) else { return false }
+        defer { uploadSlot.signal() }
+
         var result = true
         var iterator = try remainingBatches()
         batchLoop: while let batchRes = iterator.next() {
@@ -172,8 +191,6 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
                 result = false
                 break
             }
-            guard claim(batch) else { continue }
-            defer { release(batch) }
             var status: UploadResult
             repeat {
                 guard let attemptTimeout = attemptTimeout(until: deadline) else {
@@ -199,16 +216,30 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     // MARK: - Stop
 
     func stop() {
-        // Cancellation is enough: `isStopped` blocks any further claim, and
-        // `inFlight` keeps a still-finishing cycle from colliding with a flush.
-        // We deliberately don't await the task — that would make teardown depend
-        // on the cooperative executor being scheduled.
-        cancelPeriodicUploads()?.cancel()
+        guard let task = cancelPeriodicUploads() else { return }
+        task.cancel()
+        // Wait for a cycle the loop may already be running, so its batch is either
+        // uploaded and deleted, or left on disk, before we return — otherwise the
+        // final flush that follows could report success over an unsettled batch,
+        // and process exit could cut the upload short or duplicate it.
+        //
+        // We wait on the slot rather than the task: awaiting the task needs the
+        // cooperative executor, which isn't guaranteed to run during `exit()`.
+        // The wait is bounded for the same reason — if the executor is already
+        // gone, the cycle will never finish and blocking forever here is exactly
+        // the teardown deadlock this path exists to avoid.
+        if uploadSlot.wait(timeout: .now() + uploadTimeout) == .success {
+            uploadSlot.signal()
+        } else {
+            log.print("[\(featureName)] timed out waiting for an in-flight upload during shutdown")
+        }
     }
 
     func stop() async {
         guard let task = cancelPeriodicUploads() else { return }
         task.cancel()
+        // Awaiting the task is exact here: when it returns, its cycle has released
+        // the slot and finished its bookkeeping.
         await task.value
     }
 
@@ -226,27 +257,32 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
         try readerLock.whileLocked { try fileReader.getRemainingBatches() }
     }
 
-    /// Reads the next batch and claims it for upload, or returns `nil` when
-    /// there is nothing to upload (or it's already claimed).
-    private func claimNextBatch() -> Batch? {
-        let batch = readerLock.whileLocked { try? fileReader.getNextBatch() }
-        guard let batch, claim(batch) else { return nil }
-        return batch
+    private func nextBatch() -> Batch? {
+        readerLock.whileLocked { try? fileReader.getNextBatch() }
     }
 
-    /// Claims a batch unless another upload already holds it. Deliberately does
-    /// not consider `isStopped`: `stop()` is followed by a final `flush()` on the
-    /// shutdown path, and that flush still has to drain everything.
-    private func claim(_ batch: Batch) -> Bool {
-        state.update { state in
-            guard !state.inFlight.contains(batch.file.name) else { return false }
-            state.inFlight.insert(batch.file.name)
-            return true
+    /// Blocks until the upload slot is free or the drain budget runs out.
+    /// Deliberately ignores `isStopped`: `stop()` is followed by a final `flush()`
+    /// on the shutdown path, and that flush still has to drain everything.
+    private func acquireUploadSlot(until deadline: Date) -> Bool {
+        let remaining = max(0, deadline.timeIntervalSinceNow)
+        guard uploadSlot.wait(timeout: .now() + remaining) == .success else {
+            log.print("[\(featureName)] flush timed out waiting for an in-flight upload; leaving batches on disk")
+            return false
         }
+        return true
     }
 
-    private func release(_ batch: Batch) {
-        state.update { $0.inFlight.remove(batch.file.name) }
+    /// Suspending counterpart: polls rather than blocking a cooperative thread.
+    private func acquireUploadSlot(until deadline: Date) async -> Bool {
+        while uploadSlot.wait(timeout: .now()) != .success {
+            guard deadline.timeIntervalSinceNow > 0 else {
+                log.print("[\(featureName)] flush timed out waiting for an in-flight upload; leaving batches on disk")
+                return false
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return true
     }
 
     private func markAsRead(_ batch: Batch) throws {

--- a/Sources/EventsExporter/Utils/Feature.swift
+++ b/Sources/EventsExporter/Utils/Feature.swift
@@ -59,23 +59,13 @@ internal struct FeatureStoreAndUpload: DataUploadWorkerType, Sendable {
     /// upload everything left on disk. `timeout` is a total wall-clock budget
     /// for the upload phase (e.g. an OpenTelemetry `forceFlush` timeout).
     func flush(timeout: TimeInterval?, lastChance: Bool) throws -> Bool {
-        persistToDisk()
+        writer.closeCurrentFile()
         return try uploader.flush(timeout: timeout, lastChance: lastChance)
     }
 
     func flush(timeout: TimeInterval?) async throws -> Bool {
-        persistToDisk()
-        return try await uploader.flush(timeout: timeout)
-    }
-
-    /// Persist everything gathered so far to disk *without uploading it*:
-    /// drains the writer queue and closes the in-progress file, so every event
-    /// handed to the writer is on disk and visible to the reader for a later
-    /// upload. Performs no network I/O and never suspends, which is what makes
-    /// it usable from the crash handler — where the process is about to die and
-    /// the network is not an option.
-    func persistToDisk() {
         writer.closeCurrentFile()
+        return try await uploader.flush(timeout: timeout)
     }
 
     /// Shutdown sequence:

--- a/Sources/EventsExporter/Utils/Feature.swift
+++ b/Sources/EventsExporter/Utils/Feature.swift
@@ -59,8 +59,23 @@ internal struct FeatureStoreAndUpload: DataUploadWorkerType, Sendable {
     /// upload everything left on disk. `timeout` is a total wall-clock budget
     /// for the upload phase (e.g. an OpenTelemetry `forceFlush` timeout).
     func flush(timeout: TimeInterval?) throws -> Bool {
-        writer.closeCurrentFile()
+        persistToDisk()
         return try uploader.flush(timeout: timeout)
+    }
+
+    func flush(timeout: TimeInterval?) async throws -> Bool {
+        persistToDisk()
+        return try await uploader.flush(timeout: timeout)
+    }
+
+    /// Persist everything gathered so far to disk *without uploading it*:
+    /// drains the writer queue and closes the in-progress file, so every event
+    /// handed to the writer is on disk and visible to the reader for a later
+    /// upload. Performs no network I/O and never suspends, which is what makes
+    /// it usable from the crash handler — where the process is about to die and
+    /// the network is not an option.
+    func persistToDisk() {
+        writer.closeCurrentFile()
     }
 
     /// Shutdown sequence:
@@ -77,5 +92,11 @@ internal struct FeatureStoreAndUpload: DataUploadWorkerType, Sendable {
         // Final drain on the shutdown path: no total budget, each attempt still
         // bounded by the default per-attempt cap.
         _ = try? uploader.flush(timeout: nil)
+    }
+
+    func stop() async {
+        await uploader.stop()
+        writer.stop()
+        _ = try? await uploader.flush(timeout: nil)
     }
 }

--- a/Sources/EventsExporter/Utils/Feature.swift
+++ b/Sources/EventsExporter/Utils/Feature.swift
@@ -58,9 +58,9 @@ internal struct FeatureStoreAndUpload: DataUploadWorkerType, Sendable {
     /// Drain the writer queue, close the in-progress file, then synchronously
     /// upload everything left on disk. `timeout` is a total wall-clock budget
     /// for the upload phase (e.g. an OpenTelemetry `forceFlush` timeout).
-    func flush(timeout: TimeInterval?) throws -> Bool {
+    func flush(timeout: TimeInterval?, lastChance: Bool) throws -> Bool {
         persistToDisk()
-        return try uploader.flush(timeout: timeout)
+        return try uploader.flush(timeout: timeout, lastChance: lastChance)
     }
 
     func flush(timeout: TimeInterval?) async throws -> Bool {
@@ -90,8 +90,11 @@ internal struct FeatureStoreAndUpload: DataUploadWorkerType, Sendable {
         uploader.stop()
         writer.stop()
         // Final drain on the shutdown path: no total budget, each attempt still
-        // bounded by the default per-attempt cap.
-        _ = try? uploader.flush(timeout: nil)
+        // bounded by the default per-attempt cap. `lastChance` because anything
+        // left here is usually lost for good — a CI runner rarely gets a later run
+        // with the same cache — so if an upload is wedged we re-send rather than
+        // give up, accepting a possible duplicate.
+        _ = try? uploader.flush(timeout: nil, lastChance: true)
     }
 
     func stop() async {

--- a/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
@@ -22,7 +22,10 @@ final class TelemetryTests: XCTestCase {
         func export(item: any TelemetryPayload) { lock.withLock { _items.append(item) } }
         func export(items: [any TelemetryPayload]) { lock.withLock { _items.append(contentsOf: items) } }
         func flush() -> Bool { true }
+        func flush() async -> Bool { true }
         func shutdown() {}
+        func shutdown() async {}
+        func persistToDisk() {}
     }
 
     /// A long interval keeps the periodic timers (flush + heartbeat) out of the

--- a/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
+++ b/Tests/DatadogSDKTesting/Features/TelemetryTests.swift
@@ -25,7 +25,6 @@ final class TelemetryTests: XCTestCase {
         func flush() async -> Bool { true }
         func shutdown() {}
         func shutdown() async {}
-        func persistToDisk() {}
     }
 
     /// A long interval keeps the periodic timers (flush + heartbeat) out of the

--- a/Tests/DatadogSDKTesting/MockTestTypes.swift
+++ b/Tests/DatadogSDKTesting/MockTestTypes.swift
@@ -194,7 +194,8 @@ enum Mocks {
             }
             
             func startSession(named name: String, config: SessionConfig, startTime: Date,
-                              observer: (any TestModuleManagerObserver)?) async throws -> any TestModuleManager & TestSession {
+                              observer: (any TestModuleManagerObserver)?,
+                              manager: any TestSessionManager) async throws -> any TestModuleManager & TestSession {
                 self.session = Session(name: name, startTime: startTime, testTags: tags,
                                        config: config, observer: observer)
                 return self.session!
@@ -661,16 +662,22 @@ enum Mocks {
         }
     }
     
-    final actor SessionManager: TestSessionManager {
-        private var _session: Task<any TestModuleManager & TestSession, any Error>?
-        private var _stopped: Bool = false
+    final class SessionManager: TestSessionManager, @unchecked Sendable {
+        private struct State {
+            var task: Task<any TestModuleManager & TestSession, any Error>?
+            /// Recorded once the bootstrap finishes so the synchronous `stop()`
+            /// can reach the session without awaiting the task.
+            var started: (any TestModuleManager & TestSession)?
+            var stopped: Bool = false
+        }
+
+        private let _state = Synced(State())
         let provider: any TestSessionProvider
         let _config: SessionConfig
         let _observer: (any TestSessionManagerObserver & TestModuleManagerObserver)?
 
         init(provider: any TestSessionProvider, config: SessionConfig,
              observer: (any TestSessionManagerObserver & TestModuleManagerObserver)? = nil) {
-            self._session = nil
             self.provider = provider
             self._config = config
             self._observer = observer
@@ -678,34 +685,60 @@ enum Mocks {
 
         var session: any TestModuleManager & TestSession {
             get async throws {
-                if let session = _session {
-                    return try await session.value
-                }
                 let config = _config
                 let provider = self.provider
                 let observer = _observer
-                _session = Task.detached {
-                    let startTime = config.clock.now
-                    let session = try await provider.startSession(named: "Mock.session", config: config,
-                                                                  startTime: startTime, observer: observer)
-                    await observer?.didStart(session: session)
-                    return session
+                let state = _state
+                let manager = self
+                let task = _state.update { current -> Task<any TestModuleManager & TestSession, any Error> in
+                    if let task = current.task { return task }
+                    let task = Task.detached {
+                        let startTime = config.clock.now
+                        let session = try await provider.startSession(named: "Mock.session", config: config,
+                                                                      startTime: startTime, observer: observer,
+                                                                      manager: manager)
+                        state.update { $0.started = session }
+                        await observer?.didStart(session: session)
+                        return session
+                    }
+                    current.task = task
+                    return task
                 }
-                return try await _session!.value
+                return try await task.value
             }
         }
 
         func stop() async {
-            guard !_stopped else { return }
-            _stopped = true
-            guard let session = try? await _session?.value else { return }
+            // Keep the task set so concurrent readers calling `session` after
+            // stop() see the same (now-ended) session instead of bootstrapping a
+            // fresh empty one — that would race with parallel verification blocks
+            // inspecting session.modules.
+            guard let task = beginStop() else { return }
+            guard let session = try? await task.value else { return }
             await _observer?.willFinish(session: session)
             session.end()
             await _observer?.didFinish(session: session)
-            // Keep _session set so concurrent readers calling `session`
-            // after stop() see the same (now-ended) session instead of bootstrapping
-            // a fresh empty one — that would race with parallel verification blocks
-            // inspecting session.modules.
+        }
+
+        func stop() {
+            guard beginStop() != nil else { return }
+            // Mirrors the real manager: the synchronous path can't await the
+            // bootstrap, so it only ends a session that already finished starting —
+            // and it fires the same end hooks as the async path.
+            guard let session = _state.value.started else { return }
+            _observer?.willFinish(session: session)
+            session.end()
+            _observer?.didFinish(session: session)
+        }
+
+        /// Marks the manager stopped and returns the bootstrap task, or `nil` when
+        /// there is nothing to stop (never started, or already stopped).
+        private func beginStop() -> Task<any TestModuleManager & TestSession, any Error>? {
+            _state.update { state in
+                guard !state.stopped else { return nil }
+                state.stopped = true
+                return state.task
+            }
         }
     }
 }

--- a/Tests/DatadogSDKTesting/ObjCApi/DDSessionApiTests.m
+++ b/Tests/DatadogSDKTesting/ObjCApi/DDSessionApiTests.m
@@ -16,6 +16,13 @@
 
 - (void)testApiIsAccessible {
     DDSession* session = [DDSession startWithName: @"ManualObjcTestingSession"];
+    if (session == nil) {
+        // `start` returns nil when the SDK can't run — no DD_API_KEY is set in the
+        // unit-test plan, so this is the expected outcome here. The rest of the
+        // surface below is still checked at compile time; exercising it at runtime
+        // requires an API key in the environment.
+        return;
+    }
     DDModule *module = [session moduleStartWithName:@"ManualObjcTestingModule" startTime:nil];
     DDSuite *suite = [module suiteStartWithName:@"ManualObjcTestingSuite" startTime:nil];
     [suite testStartWithName:@"ManualObjcTestingTest" :^id(DDTest* test) {
@@ -27,6 +34,12 @@
     [suite endWithTime:nil];
     [module endWithTime:nil];
     [session endWithTime:nil];
+}
+
+/// Without a `DD_API_KEY` the SDK can't report anything, so `start` must return
+/// nil rather than a session that silently drops everything.
+- (void)testStartReturnsNilWhenSdkCannotRun {
+    XCTAssertNil([DDSession startWithName: @"NoApiKeySession"]);
 }
 
 @end

--- a/Tests/DatadogSDKTesting/SessionManagerTests.swift
+++ b/Tests/DatadogSDKTesting/SessionManagerTests.swift
@@ -95,6 +95,98 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertFalse(session1.id == session2.id)
         await manager.stop()
     }
+
+    // MARK: - Synchronous stop (process-exit path)
+
+    func testSyncStopEndsBootstrappedSession() async throws {
+        let manager = SessionManager(log: Mocks.CatchLogger(), provider: Mocks.Session.Provider(), observer: nil)
+        let session = try await manager.session
+
+        stopSynchronously(manager)
+
+        XCTAssertNotEqual(session.duration, 0, "The session's span should have been ended")
+    }
+
+    func testSyncStopNotifiesObserversOfFinish() async throws {
+        let observer = MockObserver()
+        let manager = SessionManager(log: Mocks.CatchLogger(), provider: Mocks.Session.Provider(), observer: observer)
+        let session = try await manager.session
+
+        stopSynchronously(manager)
+
+        XCTAssertEqual(observer.didFinishCount, 1, "The end hooks must run on the sync path too")
+        XCTAssertEqual(observer.willFinishCount, 1)
+        XCTAssertEqual(observer.lastFinishedSession?.id, session.id)
+    }
+
+    func testSyncStopWithNoBootstrappedSessionDoesNothing() {
+        let observer = MockObserver()
+        let manager = SessionManager(log: Mocks.CatchLogger(), provider: Mocks.Session.Provider(), observer: observer)
+
+        manager.stop()
+
+        XCTAssertEqual(observer.didFinishCount, 0)
+    }
+
+    func testSyncStopClearsSessionSoNextAccessCreatesNewOne() async throws {
+        let manager = SessionManager(log: Mocks.CatchLogger(), provider: Mocks.Session.Provider(), observer: nil)
+        let session1 = try await manager.session
+
+        stopSynchronously(manager)
+
+        let session2 = try await manager.session
+        XCTAssertFalse(session1.id == session2.id)
+        stopSynchronously(manager)
+    }
+
+    func testSyncStopIsIdempotent() async throws {
+        let manager = SessionManager(log: Mocks.CatchLogger(), provider: Mocks.Session.Provider(), observer: nil)
+        let session = try await manager.session
+
+        stopSynchronously(manager)
+        let duration = session.duration
+        stopSynchronously(manager)
+
+        XCTAssertEqual(session.duration, duration, "A second stop must not re-end the session")
+    }
+
+    // MARK: - Bootstrap options
+
+    func testManualBootstrapUsesSuppliedNameCommandAndStartTime() async throws {
+        let provider = Mocks.Session.Provider()
+        let startTime = Date(timeIntervalSince1970: 1_000_000)
+        let manager = SessionManager(log: Mocks.CatchLogger(), provider: provider, observer: nil,
+                                     bootstrap: .manual(name: "Manual.session",
+                                                        command: "my command",
+                                                        startTime: startTime))
+
+        let session = try await manager.session
+
+        XCTAssertEqual(session.name, "Manual.session")
+        XCTAssertEqual(session.startTime, startTime)
+        XCTAssertEqual(session.configuration.command, "my command")
+        await manager.stop()
+    }
+
+    func testManualBootstrapNotifiesObserverOfStart() async throws {
+        let observer = MockObserver()
+        let manager = SessionManager(log: Mocks.CatchLogger(), provider: Mocks.Session.Provider(),
+                                     observer: observer,
+                                     bootstrap: .manual(name: "Manual.session", command: nil,
+                                                        startTime: nil))
+
+        let session = try await manager.session
+
+        XCTAssertEqual(observer.didStartCount, 1, "The manual path must fire didStart too")
+        XCTAssertEqual(observer.lastStartedSession?.id, session.id)
+        await manager.stop()
+    }
+
+    /// Calls the *synchronous* `stop()`. Needed inside `async` tests, where the
+    /// compiler would otherwise resolve `stop()` to the `async` overload.
+    private func stopSynchronously(_ manager: SessionManager) {
+        manager.stop()
+    }
 }
 
 // MARK: - Test helpers
@@ -104,12 +196,14 @@ private final class MockObserver: TestSessionManagerObserver, TestModuleManagerO
 
     struct State {
         var didStartCount: Int = 0
+        var willFinishCount: Int = 0
         var didFinishCount: Int = 0
         var lastStartedSession: (any TestSession)?
         var lastFinishedSession: (any TestSession)?
     }
 
     var didStartCount: Int { _state.value.didStartCount }
+    var willFinishCount: Int { _state.value.willFinishCount }
     var didFinishCount: Int { _state.value.didFinishCount }
     var lastStartedSession: (any TestSession)? { _state.value.lastStartedSession }
     var lastFinishedSession: (any TestSession)? { _state.value.lastFinishedSession }
@@ -121,9 +215,11 @@ private final class MockObserver: TestSessionManagerObserver, TestModuleManagerO
         }
     }
 
-    func willFinish(session: any TestSession) async {}
+    func willFinish(session: any TestSession) {
+        _state.update { $0.willFinishCount += 1 }
+    }
 
-    func didFinish(session: any TestSession) async {
+    func didFinish(session: any TestSession) {
         _state.update {
             $0.didFinishCount += 1
             $0.lastFinishedSession = session

--- a/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
@@ -424,6 +424,83 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(try temporaryDirectory.files().count, 1, "Undelivered batch is left on disk for a later run")
     }
 
+    // MARK: - Flush vs. in-flight upload
+
+    func testFlushDoesNotReportSuccessWhileABatchIsInFlight() throws {
+        // A periodic upload that has already read a batch is holding its fate
+        // undecided: the file is still on disk, but may be deleted at any moment.
+        // A flush must wait for it rather than walk past it and claim success —
+        // otherwise shutdown returns while an upload is still running, and the
+        // process can exit mid-request or re-send a batch the server already took.
+        let uploadStarted = expectation(description: "periodic upload started")
+        uploadStarted.assertForOverFulfill = false
+        let releaseUpload = DispatchSemaphore(value: 0)
+        var mockDataUploader = DataUploaderMock(uploadStatus: .mockWith(needsRetry: false))
+        mockDataUploader.onUpload = {
+            uploadStarted.fulfill()
+            // Hold the batch in flight until the assertions below have run.
+            _ = releaseUpload.wait(timeout: .now() + 10)
+        }
+
+        try writer.writeSync(value: ["k1": "v1"])
+
+        let worker = DataUploadWorker(
+            fileReader: reader,
+            dataUploader: mockDataUploader,
+            delay: MockDelay(),
+            uploadTimeout: 5,
+            featureName: .mockAny(),
+            priority: .userInteractive,
+            log: Log()
+        )
+        defer {
+            releaseUpload.signal()
+            worker.stop()
+        }
+        wait(for: [uploadStarted], timeout: 5)
+
+        // When: flushing while that upload is stuck mid-request
+        let flushed = try worker.flush(timeout: 0.3)
+
+        // Then: it must report failure, not success over an unsettled batch
+        XCTAssertFalse(flushed, "flush must not report success while a batch is still in flight")
+    }
+
+    func testStopWaitsForTheInFlightUploadToSettle() throws {
+        // `stop()` is followed by a final flush on the shutdown path, so it has to
+        // leave the storage settled: no upload still deciding whether its file
+        // stays on disk.
+        let uploadStarted = expectation(description: "periodic upload started")
+        uploadStarted.assertForOverFulfill = false
+        let uploadFinished = LockedInt()
+        var mockDataUploader = DataUploaderMock(uploadStatus: .mockWith(needsRetry: false))
+        mockDataUploader.onUpload = {
+            uploadStarted.fulfill()
+            Thread.sleep(forTimeInterval: 0.3)
+            uploadFinished.increment()
+        }
+
+        try writer.writeSync(value: ["k1": "v1"])
+
+        let worker = DataUploadWorker(
+            fileReader: reader,
+            dataUploader: mockDataUploader,
+            delay: MockDelay(),
+            uploadTimeout: 5,
+            featureName: .mockAny(),
+            priority: .userInteractive,
+            log: Log()
+        )
+        wait(for: [uploadStarted], timeout: 5)
+
+        // When
+        worker.stop()
+
+        // Then: the in-flight cycle ran to completion before stop() returned
+        XCTAssertEqual(uploadFinished.value, 1, "stop() must wait for the in-flight upload to settle")
+        XCTAssertEqual(try temporaryDirectory.files().count, 0, "the uploaded batch was deleted before stop() returned")
+    }
+
     // MARK: - Disk-only persistence
 
     func testPersistToDiskDrainsWriterWithoutUploading() throws {

--- a/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
@@ -362,6 +362,106 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(uploadCount.value, 1, "flush should attempt at least once before giving up")
         XCTAssertEqual(try temporaryDirectory.files().count, 1, "Undelivered batch is left on disk for a later run")
     }
+
+    // MARK: - Async flush / stop
+
+    func testAsyncFlushUploadsAllData() async throws {
+        let httpClient = MockHTTPClient(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        let dataUploader = MockClosureDataUploader(httpClient: httpClient)
+        let worker = DataUploadWorker(
+            fileReader: reader,
+            dataUploader: dataUploader,
+            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
+            uploadTimeout: 60,
+            featureName: .mockAny(),
+            priority: .userInteractive,
+            log: Log()
+        )
+        // Leave the async flush as the sole uploader, mirroring the shutdown order.
+        await worker.stop()
+
+        // Given
+        writer.write(value: ["k1": "v1"])
+        writer.write(value: ["k2": "v2"])
+        writer.queue.sync {}
+
+        // When
+        let flushed = try await worker.flush(timeout: nil)
+
+        // Then
+        XCTAssertTrue(flushed)
+        XCTAssertEqual(try temporaryDirectory.files().count, 0)
+        let requests = httpClient.waitAndReturnRequests(count: 2)
+        XCTAssertTrue(requests.contains { $0.httpBody == #"[{"k1":"v1"}]"#.utf8Data })
+        XCTAssertTrue(requests.contains { $0.httpBody == #"[{"k2":"v2"}]"#.utf8Data })
+    }
+
+    func testAsyncFlushGivesUpAfterTimeoutInsteadOfHanging() async throws {
+        let uploadCount = LockedInt()
+        var mockDataUploader = DataUploaderMock(uploadStatus: .mockWith(needsRetry: true))
+        mockDataUploader.onUpload = { uploadCount.increment() }
+
+        writer.write(value: ["k1": "v1"])
+        writer.queue.sync {}
+
+        let worker = DataUploadWorker(
+            fileReader: reader,
+            dataUploader: mockDataUploader,
+            delay: MockDelay(),
+            uploadTimeout: 5,
+            featureName: .mockAny(),
+            priority: .userInteractive,
+            log: Log()
+        )
+        await worker.stop()
+
+        // When: a persistently-retriable upload must not loop forever.
+        let flushed = try await worker.flush(timeout: 0.3)
+
+        // Then
+        XCTAssertFalse(flushed)
+        XCTAssertGreaterThanOrEqual(uploadCount.value, 1)
+        XCTAssertEqual(try temporaryDirectory.files().count, 1, "Undelivered batch is left on disk for a later run")
+    }
+
+    // MARK: - Disk-only persistence
+
+    func testPersistToDiskDrainsWriterWithoutUploading() throws {
+        let uploader = SpyUploadWorker()
+        let store = FeatureStoreAndUpload(uploader: uploader, writer: writer)
+
+        // Given: an event handed to the writer (queued, not necessarily written yet)
+        store.write(value: ["k1": "v1"])
+
+        // When
+        store.persistToDisk()
+
+        // Then: the write is drained onto disk, but nothing is uploaded — this is
+        // what the crash handler relies on.
+        XCTAssertEqual(try temporaryDirectory.files().count, 1)
+        XCTAssertEqual(uploader.flushCount.value, 0, "persistToDisk must never upload")
+    }
+
+    func testAsyncStopPerformsNoMoreUploads() async {
+        let httpClient = MockHTTPClient(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        let dataUploader = MockClosureDataUploader(httpClient: httpClient)
+        let worker = DataUploadWorker(
+            fileReader: reader,
+            dataUploader: dataUploader,
+            delay: MockDelay(),
+            uploadTimeout: 5,
+            featureName: .mockAny(),
+            priority: .userInteractive,
+            log: Log()
+        )
+
+        // When: unlike the sync variant, this awaits the periodic task's exit.
+        await worker.stop()
+
+        // Then
+        writer.write(value: ["k1": "v1"])
+        httpClient.waitAndAssertNoRequestsSent()
+    }
 }
 
 /// Thread-safe integer counter for asserting on callbacks made from the worker queue.
@@ -423,4 +523,25 @@ private final class RecordingUploadObserver: UploadObserver, @unchecked Sendable
     func uploadDropped(payloadBytes: Int) {
         lock.withLock { _dropped.append(payloadBytes) }
     }
+}
+
+/// Records whether the store asked for an upload, so disk-only paths can assert
+/// that they never do.
+private final class SpyUploadWorker: DataUploadWorkerType {
+    let flushCount = LockedInt()
+
+    func update(dataFormat: DataFormatType) {}
+
+    func flush(timeout: TimeInterval?) throws -> Bool {
+        flushCount.increment()
+        return true
+    }
+
+    func flush(timeout: TimeInterval?) async throws -> Bool {
+        flushCount.increment()
+        return true
+    }
+
+    func stop() {}
+    func stop() async {}
 }

--- a/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
@@ -549,24 +549,6 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(try temporaryDirectory.files().count, 0, "the uploaded batch was deleted before stop() returned")
     }
 
-    // MARK: - Disk-only persistence
-
-    func testPersistToDiskDrainsWriterWithoutUploading() throws {
-        let uploader = SpyUploadWorker()
-        let store = FeatureStoreAndUpload(uploader: uploader, writer: writer)
-
-        // Given: an event handed to the writer (queued, not necessarily written yet)
-        store.write(value: ["k1": "v1"])
-
-        // When
-        store.persistToDisk()
-
-        // Then: the write is drained onto disk, but nothing is uploaded — this is
-        // what the crash handler relies on.
-        XCTAssertEqual(try temporaryDirectory.files().count, 1)
-        XCTAssertEqual(uploader.flushCount.value, 0, "persistToDisk must never upload")
-    }
-
     func testAsyncStopPerformsNoMoreUploads() async {
         let httpClient = MockHTTPClient(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = MockClosureDataUploader(httpClient: httpClient)
@@ -648,25 +630,4 @@ private final class RecordingUploadObserver: UploadObserver, @unchecked Sendable
     func uploadDropped(payloadBytes: Int) {
         lock.withLock { _dropped.append(payloadBytes) }
     }
-}
-
-/// Records whether the store asked for an upload, so disk-only paths can assert
-/// that they never do.
-private final class SpyUploadWorker: DataUploadWorkerType {
-    let flushCount = LockedInt()
-
-    func update(dataFormat: DataFormatType) {}
-
-    func flush(timeout: TimeInterval?, lastChance: Bool) throws -> Bool {
-        flushCount.increment()
-        return true
-    }
-
-    func flush(timeout: TimeInterval?) async throws -> Bool {
-        flushCount.increment()
-        return true
-    }
-
-    func stop() {}
-    func stop() async {}
 }

--- a/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
@@ -466,6 +466,54 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertFalse(flushed, "flush must not report success while a batch is still in flight")
     }
 
+    func testLastChanceFlushUploadsEvenWhileABatchIsInFlight() throws {
+        // Shutdown counterpart of the test above. Anything still on disk when the
+        // process exits is usually gone for good, so when the loop is wedged the
+        // shutdown drain re-sends rather than giving up — even though the wedged
+        // upload may already have reached the server.
+        let uploadStarted = expectation(description: "periodic upload started")
+        uploadStarted.assertForOverFulfill = false
+        let releaseUpload = DispatchSemaphore(value: 0)
+        let uploads = LockedInt()
+        var mockDataUploader = DataUploaderMock(uploadStatus: .mockWith(needsRetry: false))
+        mockDataUploader.onUpload = { [uploads] in
+            if uploads.value == 0 {
+                uploads.increment()
+                uploadStarted.fulfill()
+                _ = releaseUpload.wait(timeout: .now() + 10)   // wedge the first upload
+            } else {
+                uploads.increment()
+            }
+        }
+
+        try writer.writeSync(value: ["k1": "v1"])
+
+        let worker = DataUploadWorker(
+            fileReader: reader,
+            dataUploader: mockDataUploader,
+            delay: MockDelay(),
+            uploadTimeout: 5,
+            featureName: .mockAny(),
+            priority: .userInteractive,
+            log: Log()
+        )
+        defer {
+            // Release the wedged upload before stopping, or `stop()` sits waiting
+            // for it — and leaving the worker running would let it consume batches
+            // written by later tests.
+            releaseUpload.signal()
+            worker.stop()
+        }
+        wait(for: [uploadStarted], timeout: 5)
+
+        // When
+        let flushed = try worker.flush(timeout: 0.3, lastChance: true)
+
+        // Then: the batch went out a second time rather than being abandoned
+        XCTAssertTrue(flushed, "the last-chance drain must send what is left on disk")
+        XCTAssertEqual(uploads.value, 2, "the wedged batch is re-sent instead of dropped")
+    }
+
     func testStopWaitsForTheInFlightUploadToSettle() throws {
         // `stop()` is followed by a final flush on the shutdown path, so it has to
         // leave the storage settled: no upload still deciding whether its file
@@ -609,7 +657,7 @@ private final class SpyUploadWorker: DataUploadWorkerType {
 
     func update(dataFormat: DataFormatType) {}
 
-    func flush(timeout: TimeInterval?) throws -> Bool {
+    func flush(timeout: TimeInterval?, lastChance: Bool) throws -> Bool {
         flushCount.increment()
         return true
     }

--- a/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
+++ b/Tests/EventsExporter/Upload/DataUploadWorkerTests.swift
@@ -204,8 +204,11 @@ class DataUploadWorkerTests: XCTestCase {
             }
         }
 
-        // When
-        writer.write(value: ["k1": "v1"])
+        // When: write synchronously, so the batch is on disk before the worker's
+        // first tick. With an async write the worker can tick first, find nothing,
+        // and report `.increase` for the wrong reason — passing this test by
+        // accident and failing its `decrease` twin.
+        try? writer.writeSync(value: ["k1": "v1"])
 
         let httpClient = MockHTTPClient(delivery: .success(response: .mockResponseWith(statusCode: 500)))
         let dataUploader = MockClosureDataUploader(httpClient: httpClient)
@@ -235,8 +238,12 @@ class DataUploadWorkerTests: XCTestCase {
             }
         }
 
-        // When
-        writer.write(value: ["k1": "v1"])
+        // When: synchronously, so the batch is guaranteed to be on disk before the
+        // worker's first tick 100ms later. An async write races that tick — the
+        // worker finds no batch, reports `.increase`, and the test fails with
+        // "Wrong command is sent!". That race is what made this test flaky on the
+        // slower CI simulators.
+        try? writer.writeSync(value: ["k1": "v1"])
 
         let httpClient = MockHTTPClient(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = MockClosureDataUploader(httpClient: httpClient)


### PR DESCRIPTION
## What

Replaces the `DispatchQueue`-based uploader with async/await, gives every flush/shutdown entry point a **sync and an async variant**, and adds a **disk-only flush** the crash handler can use.

Jira: [SDTEST-3914](https://datadoghq.atlassian.net/browse/SDTEST-3914)

## Why

The teardown path was still bridging into an actor from the library-unload C destructor:

```swift
// FrameworkLoadHandler.libraryUnloaded()  — runs from AutoUnloadHandler during exit()
waitForAsync { await manager.stop() }
```

That is exactly the SDTEST-3909 deadlock shape: during `exit()`/`__cxa_finalize` the Swift cooperative executor is not guaranteed to be scheduled, so a `Task` on that path can hang forever instead of completing. SDTEST-3909 fixed this at the *HTTP* layer (sync `HTTPClient.send`, `Thread.sleep` backoff), but never carried it up — `SessionManager` was an `actor` with only an `async stop()`, so there was no synchronous stop to call and the bridge had to stay.

Separately, OTel Swift 2.5.1 (already pinned) added async `export`/`flush`/`shutdown` to `SpanExporter`/`LogRecordExporter`. Our exporters already *declared* those overloads but their bodies called the same synchronous storage methods — async in signature only.

## Changes

**Uploader**
- `DataUploadWorker`'s periodic loop is now a `Task` using the async upload API and `Task.sleep`; the `DispatchQueue` is gone. Shared state moved behind a lock (`Synced`), so the sync `flush`/`stop` remain 100% `Task`-free and safe at exit.
- Batches are claimed via an in-flight set, so an async cycle and a concurrent flush can't upload the same batch twice.
- Added async `flush(timeout:)` / `stop()` overloads.

**Sync/async pairs** threaded through `FeatureStoreAndUpload` → exporters → `Telemetry` → `DDTracer` → `DDTestMonitor` → `SessionManager`. Both variants share one name (Swift overloads on `async`), matching the existing `HTTPClient.send` / `DataUploaderType.upload` pattern. The exporters' async paths now `await` real I/O. Note `SpanProcessor`/`TracerProviderSdk` have no async API in 2.5.1, so the async tracer methods drive the exporter directly; nothing is stranded because `SimpleSpanProcessor` hands spans to the exporter synchronously on `end()`.

**Shutdown**
- `SessionManager` is no longer an actor: lock-guarded state, both `stop()` overloads. `FrameworkLoadHandler` calls the sync one — the last `Task` bridge on the exit path is gone.
- `DDSession` no longer calls `tracer.flush()` itself; both `end` variants shut down through `SessionManager`. The manual `start` API now bootstraps through a manager too, so it takes the same hooks and teardown path (the manager is created first and handed to the session, which holds it as a `let`).

**Crash handler**
- `ddCrashIsWritingReportCallback` now calls `tracer.persistToDisk()`: a disk-only flush that stops at `writer.closeCurrentFile()` and never enters the upload path. Everything already handed to the SDK becomes durable and uploads on the next run. No network (unusable mid-crash), no `Task`/`await`. Deliberately *not* a full shutdown.

## Bugs found along the way

- **Manual sessions never fired session-start hooks.** No `didStart`, so `start` emitted `session.started` and the git-SHA check by hand. Those now come from the feature hook; only the manual-API counter is emitted here — keeping both would have double-counted.
- **Session-end hooks were skipped on sync teardown.** They're now sync protocol requirements with async defaults that forward to them, so they run on both paths. (`didStart` stays async-only — it's only reachable from the async bootstrap.)
- **A first cut of `stop()` broke the shutdown drain.** Its "stopped" flag also blocked the *final* flush from claiming batches, silently defeating `FeatureStoreAndUpload.stop()` (stop-then-flush). Caught by existing tests; the flag now gates only the periodic loop.
- **The ObjC manual-API smoke test was living on the degraded path.** It has no assertions and the test plan sets no `DD_API_KEY`, so it was exercising the useless fallback session. Now made explicit, plus a test asserting the new nil contract.

## ⚠️ Breaking change

```swift
@objc static func start(name:command:startTime:) -> DDSession?   // was -> DDSession
```

Without an API key the SDK can't report anything, and the old fallback returned a session that silently dropped everything. **ObjC callers are unaffected** (nullable return, same selector); **Swift callers must unwrap**. This is source-breaking on the 2.x line — needs a 3.0 or a deprecation shim, so flagging for a release-strategy call.

`setupCrashHandler()` is still *not* installed on the manual path (unchanged), so this PR doesn't turn crash reporting on for embedders that only use `DDSession.start`.

## Test plan

- `DatadogSDKTesting`: **407 tests pass** (macOS)
- `EventsExporter`: **104 tests pass** (macOS)
- Library builds clean for macOS, iOS Simulator, watchOS Simulator
- New coverage: async `flush`/`stop` and `persistToDisk` (disk-only, asserts no upload) in `DataUploadWorkerTests`; sync `stop` incl. observer hooks, and manual-bootstrap name/command/startTime + `didStart` in `SessionManagerTests`

**Not yet verified — worth exercising before merge:**
- Integration-test suite hasn't been run
- A real crash mid-run, confirming events from tests completed before the crash arrive on the next run
- Repeated manual `start()`/`end()` cycles in one process: `end` now tears the monitor down (it never did before), so each cycle re-installs it


[SDTEST-3914]: https://datadoghq.atlassian.net/browse/SDTEST-3914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ