### PR TITLE
Wait for the app to reach the foreground in the UI environment test

### DIFF
--- a/IntegrationTests/UITests/AppUITests.swift
+++ b/IntegrationTests/UITests/AppUITests.swift
@@ -9,6 +9,13 @@ import XCTest
 final class UIEnvironmentPassed: XCTestCase {
     private static let envKeys = ["DD_ENV", "DD_SERVICE", "DD_API_KEY", "DD_TEST_RUNNER"]
 
+    /// Launching the app takes 60–90s on the visionOS simulator in CI, and the
+    /// harness reports `Unable to monitor event loop` while it comes up. These
+    /// timeouts are sized for that worst case; they cost nothing on faster
+    /// platforms, where both waits return as soon as the app is ready.
+    private static let launchTimeout: TimeInterval = 180
+    private static let elementTimeout: TimeInterval = 30
+
     override func setUpWithError() throws {
         continueAfterFailure = false
     }
@@ -17,12 +24,19 @@ final class UIEnvironmentPassed: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         defer { app.terminate() }
-        
+
+        // `launch()` returning does not mean the UI exists yet. Without this the
+        // element queries below start against an app that is still launching, and
+        // a slow simulator turns that into a spurious "not visible" failure.
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: Self.launchTimeout),
+                      "App did not reach the foreground within \(Self.launchTimeout)s (state: \(app.state.rawValue))")
+
         let env = ProcessInfo.processInfo.environment
         for key in Self.envKeys {
             guard let expected = env[key] else { continue }
             let element = app.staticTexts[key]
-            XCTAssertTrue(element.waitForExistence(timeout: 5), "\(key) should be visible in app")
+            XCTAssertTrue(element.waitForExistence(timeout: Self.elementTimeout),
+                          "\(key) should be visible in app")
             XCTAssertEqual(element._textValue, expected, "\(key) value mismatch")
         }
     }


### PR DESCRIPTION
## What

Makes `UIEnvironmentPassed/testEnvironmentPassed` wait for the app under test to actually reach the foreground before querying UI elements, and raises the element timeout from 5s to 30s.

## Why

The nightly **Integration Tests** workflow has failed on **visionOSsim** every run since Aug 10 (Aug 10, 11, 12, 13, 14), on both Xcode 26.2 and 26.4. Every other platform passes.

```
AppUITests.swift:25: error: XCTAssertTrue failed - DD_ENV should be visible in app
```

**This is not a regression.** The failing runs are on commit `881ed24`, unchanged since Jul 29 — the same commit that passed Aug 3–7 — with the same runner image (`macos-26-arm64/20260728.0273`) and the same `xrOS 26.5.simruntime`.

What actually happens is that launching the app takes **57–90 seconds** on the visionOS simulator in CI, and `app.launch()` returning does not mean the UI exists yet — the harness logs `Unable to monitor event loop` while it comes up, then spends 20s "Checking for crash reports corresponding to unexpected termination". The test gave the first element **5 seconds**, so it was querying an app that was still launching.

Comparing the last green run with the failures:

| Run | App launch | Result |
|---|---|---|
| Aug 7 (green) | 57.1s | `DD_ENV` found after 1.6s → pass |
| Aug 10 (red) | 87.5s | never found → fail |
| Aug 14 (red) | 63.8s | never found → fail |

Green was already marginal. The runners got slower and it tipped over.

## Change

```swift
app.launch()
XCTAssertTrue(app.wait(for: .runningForeground, timeout: 180), ...)
// then, per element:
element.waitForExistence(timeout: 30)   // was 5
```

Both waits return as soon as the app is ready, so **nothing gets slower on the platforms that were already passing** — this only covers the worst case. The 180s launch bound is sized against the observed 87s worst case.

## Test plan

- `xcodebuild build-for-testing -scheme IntegrationTests-UITests` succeeds.
- Real verification is the nightly Integration Tests run (or a manual `workflow_dispatch`), since the failure only reproduces on the visionOS simulator under CI load. Worth dispatching this workflow on the branch before merging rather than waiting for the 02:00 UTC cron.

## Note

If visionOS launch stays this pathological, the follow-up worth considering is quarantining this one UI test on visionOS — it verifies env-var propagation, which the other four platforms already cover — rather than continuing to raise timeouts. This PR deliberately does the smaller thing first.
