### PR TITLE
Extract semaphore/lock wait helpers, simplify upload slot acquisition

### DIFF
--- a/Sources/EventsExporter/Upload/DataUploadWorker.swift
+++ b/Sources/EventsExporter/Upload/DataUploadWorker.swift
@@ -133,7 +133,7 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     private func uploadNextBatch() async {
         // Skip this tick if a flush holds the slot — it is draining everything
         // anyway, and the loop must not read a batch out from under it.
-        guard uploadSlot.wait(timeout: .now()) == .success else { return }
+        guard uploadSlot.tryAcquire() else { return }
         defer { uploadSlot.signal() }
 
         guard let batch = nextBatch() else {
@@ -300,8 +300,7 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
     /// Deliberately ignores `isStopped`: `stop()` is followed by a final `flush()`
     /// on the shutdown path, and that flush still has to drain everything.
     private func acquireUploadSlot(until deadline: Date) -> Bool {
-        let remaining = max(0, deadline.timeIntervalSinceNow)
-        guard uploadSlot.wait(timeout: .now() + remaining) == .success else {
+        guard uploadSlot.wait(until: deadline) else {
             log.print("[\(featureName)] flush timed out waiting for an in-flight upload; leaving batches on disk")
             return false
         }
@@ -310,12 +309,9 @@ internal final class DataUploadWorker: DataUploadWorkerType, @unchecked Sendable
 
     /// Suspending counterpart: polls rather than blocking a cooperative thread.
     private func acquireUploadSlot(until deadline: Date) async -> Bool {
-        while uploadSlot.wait(timeout: .now()) != .success {
-            guard deadline.timeIntervalSinceNow > 0 else {
-                log.print("[\(featureName)] flush timed out waiting for an in-flight upload; leaving batches on disk")
-                return false
-            }
-            try? await Task.sleep(nanoseconds: 10_000_000)
+        guard await uploadSlot.wait(until: deadline) else {
+            log.print("[\(featureName)] flush timed out waiting for an in-flight upload; leaving batches on disk")
+            return false
         }
         return true
     }

--- a/Sources/EventsExporter/Utils/Async.swift
+++ b/Sources/EventsExporter/Utils/Async.swift
@@ -25,3 +25,24 @@ public func waitForAsync<V, E: Error>(_ function: @Sendable @escaping () async t
     waiter.wait()
     return try result!.get()
 }
+
+public extension DispatchSemaphore {
+    func tryAcquire() -> Bool {
+        wait(timeout: .now()) == .success
+    }
+    
+    func wait(until deadline: Date) -> Bool {
+        let remaining = max(0, deadline.timeIntervalSinceNow)
+        return wait(timeout: .now() + remaining) == .success
+    }
+    
+    func wait(until deadline: Date = .distantFuture, sleep: UInt64 = 10_000_000) async -> Bool {
+        while !tryAcquire() {
+            guard deadline.timeIntervalSinceNow > 0 else {
+                return false
+            }
+            try? await Task.sleep(nanoseconds: sleep)
+        }
+        return true
+    }
+}

--- a/Sources/EventsExporter/Utils/Async.swift
+++ b/Sources/EventsExporter/Utils/Async.swift
@@ -36,13 +36,15 @@ public extension DispatchSemaphore {
         return wait(timeout: .now() + remaining) == .success
     }
     
-    func wait(until deadline: Date = .distantFuture, sleep nanoseconds: UInt64 = 10_000_000) async -> Bool {
+    func wait(until deadline: Date = .distantFuture, sleep seconds: TimeInterval = 0.01) async -> Bool {
         while !tryAcquire() {
-            guard deadline.timeIntervalSinceNow > 0 else {
+            let deadlineInterval = deadline.timeIntervalSinceNow
+            guard deadlineInterval > 0 else {
                 return false
             }
+            let sleepNS = UInt64(min(seconds, deadlineInterval) * 1_000_000_000)
             do {
-                try await Task.sleep(nanoseconds: nanoseconds)
+                try await Task.sleep(nanoseconds: sleepNS)
             } catch {
                 return false
             }

--- a/Sources/EventsExporter/Utils/Async.swift
+++ b/Sources/EventsExporter/Utils/Async.swift
@@ -36,12 +36,16 @@ public extension DispatchSemaphore {
         return wait(timeout: .now() + remaining) == .success
     }
     
-    func wait(until deadline: Date = .distantFuture, sleep: UInt64 = 10_000_000) async -> Bool {
+    func wait(until deadline: Date = .distantFuture, sleep nanoseconds: UInt64 = 10_000_000) async -> Bool {
         while !tryAcquire() {
             guard deadline.timeIntervalSinceNow > 0 else {
                 return false
             }
-            try? await Task.sleep(nanoseconds: sleep)
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds)
+            } catch {
+                return false
+            }
         }
         return true
     }

--- a/Sources/EventsExporter/Utils/Synced.swift
+++ b/Sources/EventsExporter/Utils/Synced.swift
@@ -26,6 +26,10 @@ public final class UnfairLock: Sendable {
     public func unlock() {
         os_unfair_lock_unlock(_lock)
     }
+    
+    public func tryLock() -> Bool {
+        os_unfair_lock_trylock(_lock)
+    }
 
     public func whileLocked<T>(_ action: () throws -> T) rethrows -> T {
         os_unfair_lock_lock(_lock)


### PR DESCRIPTION
## Summary
- Add `DispatchSemaphore.tryAcquire()` and `DispatchSemaphore.wait(until:)` (sync and async) helpers to `Async.swift`
- Add `UnfairLock.tryLock()` helper to `Synced.swift`
- Use the new helpers in `DataUploadWorker` to remove duplicated deadline/polling logic in `uploadNextBatch()` and `acquireUploadSlot(until:)`

## Test plan
- [x] Existing EventsExporter upload/flush unit tests pass
- [x] CI green